### PR TITLE
feat: Adds client features endpoint

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ jobs:
         name: Checkout code
         with:
           token: ${{ secrets.GH_PUSH_TOKEN }}
+          fetch-depth: 0
       - name: setup git config
         run: |
           git config user.name "Github Release Bot"
@@ -27,7 +28,10 @@ jobs:
           rustup set auto-self-update disable
           rustup toolchain install stable --profile minimal
           rustup show
-      - uses: Swatinem/rust-cache@v2
+      - name: Use rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
       - name: Install cargo smart-release
         run: |
           cargo install cargo-smart-release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,7 +2076,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "unleash-types 0.4.0",
+ "unleash-types 0.4.1",
  "unleash-yggdrasil",
 ]
 
@@ -2093,9 +2093,9 @@ dependencies = [
 
 [[package]]
 name = "unleash-types"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0c6b0dea14d7fe9296f2217b8f0b1dc21b1616d158d5f3623caaa09ef86bf3"
+checksum = "cd02ee0e5dca295018290a6e4d7bdd53a961f58a08695ef3e9fc34180a581e0d"
 dependencies = [
  "chrono",
  "derive_builder",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -24,5 +24,5 @@ tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread", "tracing"
 tracing = { version = "0.1.37", features = ["log"] }
 tracing-opentelemetry = "0.18.0"
 tracing-subscriber = { version = "0.3.16", features = ["json", "env-filter"] }
-unleash-types = "0.4.0"
+unleash-types = "0.4.1"
 unleash-yggdrasil = "0.2.0"

--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -1,11 +1,12 @@
-use crate::offline_provider::OfflineProvider;
 use crate::types::{EdgeJsonResult, FeaturesProvider};
 use actix_web::get;
 use actix_web::web::{self, Json};
 use unleash_types::client_features::ClientFeatures;
 
 #[get("/client/features")]
-async fn features(features_source: web::Data<OfflineProvider>) -> EdgeJsonResult<ClientFeatures> {
+async fn features(
+    features_source: web::Data<dyn FeaturesProvider>,
+) -> EdgeJsonResult<ClientFeatures> {
     let client_features = features_source.get_client_features();
     Ok(Json(client_features))
 }

--- a/server/src/edge_api.rs
+++ b/server/src/edge_api.rs
@@ -1,0 +1,3 @@
+use actix_web::web;
+
+pub fn configure_edge_api(_cfg: &mut web::ServiceConfig) {}

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -5,7 +5,7 @@ use actix_web::{http::StatusCode, HttpResponseBuilder, ResponseError};
 
 #[derive(Debug)]
 pub enum EdgeError {
-    InvalidBackupFile(String),
+    InvalidBackupFile(String, String),
     NoFeaturesFile,
     TlsError,
 }
@@ -15,7 +15,11 @@ impl Error for EdgeError {}
 impl Display for EdgeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            EdgeError::InvalidBackupFile(msg) => write!(f, "{}", msg),
+            EdgeError::InvalidBackupFile(path, why_invalid) => write!(
+                f,
+                "file at path: {} was invalid due to {}",
+                path, why_invalid
+            ),
             EdgeError::TlsError => write!(f, "Could not configure TLS"),
             EdgeError::NoFeaturesFile => write!(f, "No features file located"),
         }
@@ -25,7 +29,7 @@ impl Display for EdgeError {
 impl ResponseError for EdgeError {
     fn status_code(&self) -> actix_web::http::StatusCode {
         match self {
-            EdgeError::InvalidBackupFile(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            EdgeError::InvalidBackupFile(_, _) => StatusCode::INTERNAL_SERVER_ERROR,
             EdgeError::TlsError => StatusCode::INTERNAL_SERVER_ERROR,
             EdgeError::NoFeaturesFile => StatusCode::INTERNAL_SERVER_ERROR,
         }

--- a/server/src/frontend_api.rs
+++ b/server/src/frontend_api.rs
@@ -1,0 +1,3 @@
+use actix_web::web;
+
+pub fn configure_frontend_api(_cfg: &mut web::ServiceConfig) {}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,13 +1,18 @@
+use std::sync::Arc;
+
 use crate::cli::EdgeMode;
 use crate::offline_provider::OfflineProvider;
 use actix_web::{middleware, web, App, HttpServer};
 use actix_web_opentelemetry::RequestTracing;
 use clap::Parser;
 use cli::CliArgs;
+use types::FeaturesProvider;
 
 mod cli;
 mod client_api;
+mod edge_api;
 mod error;
+mod frontend_api;
 mod internal_backstage;
 mod metrics;
 mod offline_provider;
@@ -24,19 +29,25 @@ async fn main() -> Result<(), anyhow::Error> {
     }
     .map_err(anyhow::Error::new)?;
     let server = HttpServer::new(move || {
+        let client_provider_arc: Arc<dyn FeaturesProvider> = Arc::new(client_provider.clone());
+        let client_provider_data = web::Data::from(client_provider_arc);
         App::new()
-            .app_data(web::Data::new(client_provider.clone()))
+            .app_data(client_provider_data)
             .wrap(RequestTracing::new())
             .wrap(request_metrics.clone())
             .wrap(middleware::Logger::default())
+            .service(web::scope("/internal-backstage").configure(|service_cfg| {
+                internal_backstage::configure_internal_backstage(
+                    service_cfg,
+                    metrics_handler.clone(),
+                )
+            }))
             .service(
-                web::scope("/internal-backstage")
-                    .configure(internal_backstage::configure_internal_backstage)
-                    .service(
-                        web::resource("/metrics").route(web::get().to(metrics_handler.clone())),
-                    ),
+                web::scope("/api")
+                    .configure(client_api::configure_client_api)
+                    .configure(frontend_api::configure_frontend_api),
             )
-            .service(web::scope("/api").configure(client_api::configure_client_api))
+            .service(web::scope("/edge").configure(edge_api::configure_edge_api))
     });
     let server = if args.http.tls.tls_enable {
         let config = tls::config(args.clone().http.tls)


### PR DESCRIPTION
This is worth a comment, since the way it was solved depends on which mode you're executing edge in. Currently edge only supports one mode, so we could've just explicitly passed in the provider for getting features.

However, we are aware that we want at least two more providers for features, so this lays the ground work for implementing more modes and providers, but still using the same actix handler for the `/api/client/features` endpoint.

Co-authored-by: Simon Hornby <liquidwicked64@gmail.com>