### PR TITLE
feat: Add edge-token extractor to lock down access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,6 +1761,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-case"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d6cf5a7dffb3f9dceec8e6b8ca528d9bd71d36c9f074defb548ce161f598c0"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45b7bf6e19353ddd832745c8fcf77a17a93171df7151187f26623f2b75b5b26"
+dependencies = [
+ "cfg-if",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2072,6 +2094,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
+ "test-case",
  "tokio",
  "tracing",
  "tracing-opentelemetry",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -26,3 +26,6 @@ tracing-opentelemetry = "0.18.0"
 tracing-subscriber = { version = "0.3.16", features = ["json", "env-filter"] }
 unleash-types = "0.4.1"
 unleash-yggdrasil = "0.2.0"
+
+[dev-dependencies]
+test-case = "2.2.2"

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -17,6 +17,9 @@ pub struct CliArgs {
 
     #[clap(short, long, env)]
     pub bootstrap_file: Option<PathBuf>,
+
+    #[clap(short, long, env)]
+    pub client_keys: Vec<String>,
 }
 
 impl CliArgs {

--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -1,11 +1,12 @@
-use crate::types::{EdgeJsonResult, FeaturesProvider};
+use crate::types::{EdgeJsonResult, EdgeProvider, EdgeToken};
 use actix_web::get;
 use actix_web::web::{self, Json};
 use unleash_types::client_features::ClientFeatures;
 
 #[get("/client/features")]
 async fn features(
-    features_source: web::Data<dyn FeaturesProvider>,
+    _edge_token: EdgeToken,
+    features_source: web::Data<dyn EdgeProvider>,
 ) -> EdgeJsonResult<ClientFeatures> {
     let client_features = features_source.get_client_features();
     Ok(Json(client_features))

--- a/server/src/edge_api.rs
+++ b/server/src/edge_api.rs
@@ -1,3 +1,28 @@
-use actix_web::web;
+use actix_web::{
+    get,
+    web::{self, Json},
+};
 
-pub fn configure_edge_api(_cfg: &mut web::ServiceConfig) {}
+use crate::types::{EdgeJsonResult, EdgeToken, TokenProvider, TokenStrings, ValidatedTokens};
+
+#[get("/validate")]
+async fn validate(
+    _client_token: EdgeToken,
+    token_provider: web::Data<dyn TokenProvider>,
+    tokens: Json<TokenStrings>,
+) -> EdgeJsonResult<ValidatedTokens> {
+    let valid_tokens: Vec<EdgeToken> = tokens
+        .into_inner()
+        .tokens
+        .into_iter()
+        .filter(|t| token_provider.secret_is_valid(t))
+        .map(|t| token_provider.token_details(t).unwrap()) // Guaranteed because we just checked that the secret exists
+        .collect();
+    Ok(Json(ValidatedTokens {
+        tokens: valid_tokens,
+    }))
+}
+
+pub fn configure_edge_api(cfg: &mut web::ServiceConfig) {
+    cfg.service(validate);
+}

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -5,8 +5,11 @@ use actix_web::{http::StatusCode, HttpResponseBuilder, ResponseError};
 
 #[derive(Debug)]
 pub enum EdgeError {
+    AuthorizationDenied,
     InvalidBackupFile(String, String),
     NoFeaturesFile,
+    NoTokenProvider,
+    TokenParseError,
     TlsError,
 }
 
@@ -22,6 +25,9 @@ impl Display for EdgeError {
             ),
             EdgeError::TlsError => write!(f, "Could not configure TLS"),
             EdgeError::NoFeaturesFile => write!(f, "No features file located"),
+            EdgeError::AuthorizationDenied => write!(f, "Not allowed to access"),
+            EdgeError::NoTokenProvider => write!(f, "Could not get a TokenProvider"),
+            EdgeError::TokenParseError => write!(f, "Could not parse edge token"),
         }
     }
 }
@@ -32,6 +38,9 @@ impl ResponseError for EdgeError {
             EdgeError::InvalidBackupFile(_, _) => StatusCode::INTERNAL_SERVER_ERROR,
             EdgeError::TlsError => StatusCode::INTERNAL_SERVER_ERROR,
             EdgeError::NoFeaturesFile => StatusCode::INTERNAL_SERVER_ERROR,
+            EdgeError::AuthorizationDenied => StatusCode::FORBIDDEN,
+            EdgeError::NoTokenProvider => StatusCode::INTERNAL_SERVER_ERROR,
+            EdgeError::TokenParseError => StatusCode::UNAUTHORIZED,
         }
     }
 

--- a/server/src/offline_provider.rs
+++ b/server/src/offline_provider.rs
@@ -1,5 +1,5 @@
 use crate::error::EdgeError;
-use crate::types::FeaturesProvider;
+use crate::types::{EdgeProvider, EdgeToken, FeaturesProvider, TokenProvider};
 use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
@@ -8,6 +8,7 @@ use unleash_types::client_features::ClientFeatures;
 #[derive(Debug, Clone)]
 pub struct OfflineProvider {
     pub features: ClientFeatures,
+    pub valid_tokens: Vec<EdgeToken>,
 }
 
 impl FeaturesProvider for OfflineProvider {
@@ -16,9 +17,29 @@ impl FeaturesProvider for OfflineProvider {
     }
 }
 
+impl TokenProvider for OfflineProvider {
+    fn get_known_tokens(&self) -> Vec<EdgeToken> {
+        self.valid_tokens.clone()
+    }
+
+    fn secret_is_valid(&self, secret: &String) -> bool {
+        self.valid_tokens.iter().any(|t| &t.secret == secret)
+    }
+
+    fn token_details(&self, secret: String) -> Option<EdgeToken> {
+        self.valid_tokens
+            .clone()
+            .into_iter()
+            .find(|t| t.secret == secret)
+    }
+}
+
+impl EdgeProvider for OfflineProvider {}
+
 impl OfflineProvider {
     pub fn instantiate_provider(
         bootstrap_file: Option<PathBuf>,
+        valid_tokens: Vec<String>,
     ) -> Result<OfflineProvider, EdgeError> {
         if let Some(bootstrap) = bootstrap_file {
             let file = File::open(bootstrap.clone()).map_err(|_| EdgeError::NoFeaturesFile)?;
@@ -27,12 +48,20 @@ impl OfflineProvider {
                 let path = format!("{}", bootstrap.clone().display());
                 EdgeError::InvalidBackupFile(path, e.to_string())
             })?;
-            Ok(OfflineProvider::new(client_features))
+            Ok(OfflineProvider::new(client_features, valid_tokens))
         } else {
             Err(EdgeError::NoFeaturesFile)
         }
     }
-    pub fn new(features: ClientFeatures) -> Self {
-        OfflineProvider { features }
+    pub fn new(features: ClientFeatures, valid_tokens: Vec<String>) -> Self {
+        OfflineProvider {
+            features,
+            valid_tokens: valid_tokens
+                .into_iter()
+                .map(|t| EdgeToken::try_from(t))
+                .filter(|t| t.is_ok())
+                .map(|t| t.unwrap())
+                .collect(),
+        }
     }
 }

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -1,10 +1,194 @@
-use actix_web::web::Json;
+use std::{
+    future::{ready, Ready},
+    str::FromStr,
+};
+
+use actix_web::{
+    dev::Payload,
+    http::header::HeaderValue,
+    web::{Data, Json},
+    FromRequest, HttpRequest,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tracing::warn;
 use unleash_types::client_features::ClientFeatures;
 
 use crate::error::EdgeError;
 
 pub type EdgeJsonResult<T> = Result<Json<T>, EdgeError>;
+pub type EdgeResult<T> = Result<T, EdgeError>;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum TokenType {
+    Frontend,
+    Client,
+    Admin,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct EdgeToken {
+    pub secret: String,
+    #[serde(rename = "type")]
+    pub token_type: Option<TokenType>,
+    pub environment: Option<String>,
+    pub projects: Vec<String>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub seen_at: Option<DateTime<Utc>>,
+    pub alias: Option<String>,
+}
+
+impl EdgeToken {
+    pub fn no_project_or_environment(s: &str) -> Self {
+        EdgeToken {
+            secret: s.into(),
+            token_type: None,
+            environment: None,
+            projects: vec![],
+            expires_at: None,
+            seen_at: Some(Utc::now()),
+            alias: None,
+        }
+    }
+}
+
+impl FromRequest for EdgeToken {
+    type Error = EdgeError;
+    type Future = Ready<EdgeResult<Self>>;
+
+    fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
+        if let Some(token_provider) = req.app_data::<Data<dyn EdgeProvider>>() {
+            let value = req.headers().get("Authorization");
+            let key = match value {
+                Some(v) => EdgeToken::try_from(v.clone()),
+                None => Err(EdgeError::AuthorizationDenied),
+            }
+            .and_then(|client_token| {
+                if token_provider.secret_is_valid(&client_token.secret) {
+                    Ok(client_token)
+                } else {
+                    Err(EdgeError::AuthorizationDenied)
+                }
+            });
+            ready(key)
+        } else {
+            warn!("Could not find a token provider");
+            ready(Err(EdgeError::NoTokenProvider))
+        }
+    }
+}
+
+impl TryFrom<HeaderValue> for EdgeToken {
+    type Error = EdgeError;
+
+    fn try_from(value: HeaderValue) -> Result<Self, Self::Error> {
+        value
+            .to_str()
+            .map_err(|_| EdgeError::AuthorizationDenied)
+            .and_then(|t| EdgeToken::from_str(t))
+    }
+}
+
+impl TryFrom<String> for EdgeToken {
+    type Error = EdgeError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        EdgeToken::from_str(value.as_str())
+    }
+}
+
+impl FromStr for EdgeToken {
+    type Err = EdgeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.contains(':') && s.contains('.') {
+            let token_parts: Vec<String> = s
+                .clone()
+                .split(":")
+                .take(2)
+                .map(|s| s.to_string())
+                .collect();
+            let token_projects = if let Some(projects) = token_parts.get(0) {
+                if projects == "[]" {
+                    vec![]
+                } else {
+                    vec![projects.clone()]
+                }
+            } else {
+                return Err(EdgeError::TokenParseError);
+            };
+            if let Some(env_and_key) = token_parts.get(1) {
+                let e_a_k: Vec<String> = env_and_key
+                    .split(".")
+                    .take(2)
+                    .map(|s| s.to_string())
+                    .collect();
+                if e_a_k.len() != 2 {
+                    return Err(EdgeError::TokenParseError);
+                }
+                Ok(EdgeToken {
+                    environment: e_a_k.get(0).cloned(),
+                    projects: token_projects,
+                    token_type: None,
+                    secret: s.into(),
+                    expires_at: None,
+                    seen_at: Some(Utc::now()),
+                    alias: None,
+                })
+            } else {
+                return Err(EdgeError::TokenParseError);
+            }
+        } else {
+            Ok(EdgeToken::no_project_or_environment(s))
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TokenStrings {
+    pub tokens: Vec<String>,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ValidatedTokens {
+    pub tokens: Vec<EdgeToken>,
+}
 
 pub trait FeaturesProvider {
     fn get_client_features(&self) -> ClientFeatures;
+}
+
+pub trait TokenProvider {
+    fn get_known_tokens(&self) -> Vec<EdgeToken>;
+    fn secret_is_valid(&self, secret: &String) -> bool;
+    fn token_details(&self, secret: String) -> Option<EdgeToken>;
+}
+
+pub trait EdgeProvider: FeaturesProvider + TokenProvider {}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use test_case::test_case;
+    use tracing::warn;
+
+    use crate::types::EdgeToken;
+
+    #[test_case("943ca9171e2c884c545c5d82417a655fb77cec970cc3b78a8ff87f4406b495d0"; "old java client token")]
+    #[test_case("demo-app:production.614a75cf68bef8703aa1bd8304938a81ec871f86ea40c975468eabd6"; "demo token with project and environment")]
+    #[test_case("secret-123"; "old example proxy token")]
+    #[test_case("*:default.5fa5ac2580c7094abf0d87c68b1eeb54bdc485014aef40f9fcb0673b"; "demo token with access to all projects and default environment")]
+    fn edge_token_from_string(token: &str) {
+        let parsed_token = EdgeToken::from_str(token);
+        match parsed_token {
+            Ok(t) => {
+                assert_eq!(t.secret, token);
+            }
+            Err(e) => {
+                warn!("{}", e);
+                panic!("Could not parse token");
+            }
+        }
+    }
 }


### PR DESCRIPTION
## What
This adds EdgeToken as a type. It also adds a way to go from an HttpRequest to an EdgeToken by implementing Actix's trait FromRequest for an EdgeToken.

If you have an endpoint where you need authentication, you simply say that you want an EdgeToken and the type system will guarantee you either get an EdgeToken or you'll get a 403 error.

## Thoughts
We now have two traits, one for resolving features, and one for verifying tokens, or converting from an authorization header to a token. These are merged to a trait I've called EdgeProvider, and we now wire in an offline implementation of EdgeProvider (give bootstrap file, and a list of accepted tokens that will have read-access to the bootstrap file and it's results).

I tried to make our methods only require the traits they use, but the wiring in Actix from web::Data to method parameters wasn't able to see that something that implemented the Super trait would satisfy the Subtrait.

At least not the way I did it. Something to dig into next week.