### PR TITLE
feat: add basic proxy endpoints and related test code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,6 +733,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,6 +953,12 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
@@ -2099,6 +2118,7 @@ dependencies = [
  "chrono",
  "clap 4.1.3",
  "dotenv",
+ "env_logger",
  "opentelemetry",
  "opentelemetry-prometheus",
  "prometheus",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -32,4 +32,5 @@ unleash-types = "0.5.1"
 unleash-yggdrasil = "0.4.0"
 
 [dev-dependencies]
+env_logger = "0.10.0"
 test-case = "2.2.2"

--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -5,10 +5,10 @@ use unleash_types::client_features::ClientFeatures;
 
 #[get("/client/features")]
 async fn features(
-    _edge_token: EdgeToken,
+    edge_token: EdgeToken,
     features_source: web::Data<dyn EdgeProvider>,
 ) -> EdgeJsonResult<ClientFeatures> {
-    let client_features = features_source.get_client_features();
+    let client_features = features_source.get_client_features(edge_token);
     Ok(Json(client_features))
 }
 

--- a/server/src/frontend_api.rs
+++ b/server/src/frontend_api.rs
@@ -1,3 +1,169 @@
-use actix_web::web;
+use actix_web::{
+    get,
+    web::{self, Json},
+};
+use unleash_types::{
+    client_features::{ClientFeatures, Payload},
+    frontend::{EvaluatedToggle, EvaluatedVariant, FrontendResult},
+};
+use unleash_yggdrasil::{Context, EngineState};
 
-pub fn configure_frontend_api(_cfg: &mut web::ServiceConfig) {}
+use crate::types::{EdgeJsonResult, EdgeProvider, EdgeToken};
+
+#[get("/proxy/all")]
+async fn get_frontend_features(
+    edge_token: EdgeToken,
+    features_source: web::Data<dyn EdgeProvider>,
+    context: web::Query<Context>,
+) -> EdgeJsonResult<FrontendResult> {
+    let client_features = features_source.get_client_features(edge_token);
+    let context = context.into_inner();
+
+    let evaluated_features = resolve_frontend_features(client_features, context);
+
+    Ok(Json(FrontendResult {
+        toggles: evaluated_features,
+    }))
+}
+
+#[actix_web::post("/proxy/all")]
+async fn post_frontend_features(
+    edge_token: EdgeToken,
+    features_source: web::Data<dyn EdgeProvider>,
+    context: web::Json<Context>,
+) -> EdgeJsonResult<FrontendResult> {
+    let client_features = features_source.get_client_features(edge_token);
+    let context = context.into_inner();
+
+    let evaluated_features = resolve_frontend_features(client_features, context);
+
+    Ok(Json(FrontendResult {
+        toggles: evaluated_features,
+    }))
+}
+
+fn resolve_frontend_features(
+    client_features: ClientFeatures,
+    context: Context,
+) -> Vec<EvaluatedToggle> {
+    let mut engine = EngineState::default();
+    engine.take_state(client_features.clone());
+
+    client_features
+        .features
+        .into_iter()
+        .map(|toggle| {
+            let variant = engine.get_variant(toggle.name.clone(), &context);
+            EvaluatedToggle {
+                name: toggle.name.clone(),
+                enabled: engine.is_enabled(toggle.name, &context),
+                variant: EvaluatedVariant {
+                    name: variant.name,
+                    enabled: variant.enabled,
+                    payload: variant.payload.map(|succ| Payload {
+                        payload_type: succ.payload_type,
+                        value: succ.value,
+                    }),
+                },
+                impression_data: false,
+            }
+        })
+        .collect()
+}
+
+pub fn configure_frontend_api(cfg: &mut web::ServiceConfig) {
+    cfg.service(get_frontend_features);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::types::{EdgeProvider, FeaturesProvider, TokenProvider};
+    use actix_web::{
+        http::header::ContentType,
+        test,
+        web::{self, Bytes},
+        App,
+    };
+    use serde_json::json;
+    use unleash_types::{
+        client_features::{ClientFeature, ClientFeatures, Variant},
+        frontend::{EvaluatedToggle, EvaluatedVariant, FrontendResult},
+    };
+
+    #[derive(Clone)]
+    struct MockDataSource {}
+
+    impl FeaturesProvider for MockDataSource {
+        fn get_client_features(&self, _token: crate::types::EdgeToken) -> ClientFeatures {
+            return ClientFeatures {
+                version: 1,
+                features: vec![ClientFeature {
+                    name: "test".into(),
+                    enabled: true,
+                    ..ClientFeature::default()
+                }],
+                segments: None,
+                query: None,
+            };
+        }
+    }
+
+    impl TokenProvider for MockDataSource {
+        fn get_known_tokens(&self) -> Vec<crate::types::EdgeToken> {
+            todo!()
+        }
+
+        fn secret_is_valid(&self, _secret: &str) -> bool {
+            true
+        }
+
+        fn token_details(&self, _secret: String) -> Option<crate::types::EdgeToken> {
+            todo!()
+        }
+    }
+
+    impl EdgeProvider for MockDataSource {}
+
+    #[actix_web::test]
+    async fn calling_post_requests_resolves_context_values_correctly() {
+        env_logger::init();
+        let mock_data = MockDataSource {};
+        let client_provider_arc: Arc<dyn EdgeProvider> = Arc::new(mock_data.clone());
+        let client_provider_data = web::Data::from(client_provider_arc);
+
+        let app = test::init_service(
+            App::new()
+                .app_data(client_provider_data)
+                .service(web::scope("/api").service(super::post_frontend_features)),
+        )
+        .await;
+        let req = test::TestRequest::post()
+            .uri("/api/proxy/all")
+            .insert_header(ContentType::json())
+            .insert_header((
+                "Authorization",
+                "*:development.03fa5f506428fe80ed5640c351c7232e38940814d2923b08f5c05fa7",
+            ))
+            .set_json(json!({}))
+            .to_request();
+
+        let result = test::call_and_read_body(&app, req).await;
+
+        let expected = FrontendResult {
+            toggles: vec![EvaluatedToggle {
+                name: "test".into(),
+                enabled: true,
+                variant: EvaluatedVariant {
+                    name: "disabled".into(),
+                    enabled: false,
+                    payload: None,
+                },
+                impression_data: false,
+            }],
+        };
+
+        assert_eq!(result, serde_json::to_vec(&expected).unwrap());
+    }
+}

--- a/server/src/frontend_api.rs
+++ b/server/src/frontend_api.rs
@@ -1,5 +1,5 @@
 use actix_web::{
-    get,
+    get, post,
     web::{self, Json},
 };
 use unleash_types::{
@@ -26,7 +26,7 @@ async fn get_frontend_features(
     }))
 }
 
-#[actix_web::post("/proxy/all")]
+#[post("/proxy/all")]
 async fn post_frontend_features(
     edge_token: EdgeToken,
     features_source: web::Data<dyn EdgeProvider>,
@@ -99,9 +99,9 @@ mod tests {
 
     impl MockDataSource {
         fn with(self, features: ClientFeatures) -> Self {
-            return MockDataSource {
+            MockDataSource {
                 features: Some(features),
-            };
+            }
         }
     }
 
@@ -133,8 +133,7 @@ mod tests {
     impl Into<Data<dyn EdgeProvider>> for MockDataSource {
         fn into(self) -> Data<dyn EdgeProvider> {
             let client_provider_arc: Arc<dyn EdgeProvider> = Arc::new(self.clone());
-            let provider = Data::from(client_provider_arc);
-            provider
+            Data::from(client_provider_arc)
         }
     }
 

--- a/server/src/offline_provider.rs
+++ b/server/src/offline_provider.rs
@@ -12,7 +12,7 @@ pub struct OfflineProvider {
 }
 
 impl FeaturesProvider for OfflineProvider {
-    fn get_client_features(&self) -> ClientFeatures {
+    fn get_client_features(&self, _: EdgeToken) -> ClientFeatures {
         self.features.clone()
     }
 }

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -150,7 +150,7 @@ pub struct ValidatedTokens {
 }
 
 pub trait FeaturesProvider {
-    fn get_client_features(&self) -> ClientFeatures;
+    fn get_client_features(&self, token: EdgeToken) -> ClientFeatures;
 }
 
 pub trait TokenProvider {


### PR DESCRIPTION
Adds a basic implementation of front end endpoints. The core purpose of this PR is to consume Yggdrasil and set a path forward for integration testing