### PR TITLE
task: Build minimal docker container from scratch base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM alpine:3.17
+FROM scratch
 
-WORKDIR /app
-COPY target/aarch64-unknown-linux-musl/release/unleash-edge /app/
-ENTRYPOINT ["/app/unleash-edge"]
+COPY target/aarch64-unknown-linux-musl/release/unleash-edge /unleash-edge
+ENTRYPOINT ["/unleash-edge"]


### PR DESCRIPTION
## What
This PR updates our Dockerfile to take advantage of our musl build, and just use scratch as BASE, which means that the only thing that exists in the container is our executable. Smaller image, smaller attack surface. :)