### PR TITLE
task: Added prometheus metrics from shadow

### DIFF
--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -11,7 +11,7 @@ pub enum EdgeMode {
 pub struct OfflineArgs {
     #[clap(short, long, env)]
     pub bootstrap_file: Option<PathBuf>,
-    #[clap(short, long, env)]
+    #[clap(short, long, env, value_delimiter = ',')]
     pub client_keys: Vec<String>,
 }
 

--- a/server/src/metrics.rs
+++ b/server/src/metrics.rs
@@ -5,9 +5,11 @@ use opentelemetry::{
         export::metrics::aggregation,
         metrics::{controllers, processors, selectors},
     },
+    trace::FutureExt,
 };
 #[cfg(target_os = "linux")]
 use prometheus::process_collector::ProcessCollector;
+use tracing::instrument::WithSubscriber;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::{EnvFilter, Registry};
 
@@ -39,6 +41,11 @@ fn instantiate_prometheus_metrics_handler(
         )
         .with_memory(true),
     )
+    .with_resource(opentelemetry::sdk::Resource::new(vec![
+        opentelemetry::KeyValue::new("service.name", "unleash-edge"),
+        opentelemetry::KeyValue::new("edge.version", crate::types::build::PKG_VERSION),
+        opentelemetry::KeyValue::new("edge.githash", crate::types::build::SHORT_COMMIT),
+    ]))
     .build();
 
     let exporter = opentelemetry_prometheus::exporter(controller)


### PR DESCRIPTION
Building on our BuildInfo endpoint, this adds a couple of nice labels to all our prometheus metrics, allowing us to filter on versions of edge what's working/not working.