### PR TITLE
task: added etag middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
  "actix-tls",
  "actix-utils",
  "ahash",
- "base64",
+ "base64 0.21.0",
  "bitflags",
  "brotli",
  "bytes",
@@ -82,6 +82,19 @@ checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "actix-middleware-etag"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44ad18cee06216ed944a2bf2d0b9565a879a89ea52d738f8dd8173c8910cd768"
+dependencies = [
+ "actix-service",
+ "actix-web",
+ "base64 0.13.1",
+ "futures",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -326,6 +339,12 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -818,12 +837,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -842,6 +877,12 @@ dependencies = [
  "futures-task",
  "futures-util",
 ]
+
+[[package]]
+name = "futures-io"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-macro"
@@ -872,10 +913,13 @@ version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1685,7 +1729,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64",
+ "base64 0.21.0",
 ]
 
 [[package]]
@@ -2229,6 +2273,7 @@ name = "unleash-edge"
 version = "0.0.0"
 dependencies = [
  "actix-cors",
+ "actix-middleware-etag",
  "actix-tls",
  "actix-web",
  "actix-web-opentelemetry",
@@ -2509,6 +2554,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "735a71d46c4d68d71d4b24d03fdc2b98e38cea81730595801db779c04fe80d70"
 
 [[package]]
 name = "zstd"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -10,9 +10,11 @@ homepage = "https://github.com/Unleash/unleash-edge"
 
 [dependencies]
 actix-cors = "0.6.4"
+actix-middleware-etag = "0.1.1"
 actix-tls = { version = "3.0.3", features = ["rustls"] }
 actix-web = { version = "4.3.0", features = ["rustls"] }
 actix-web-opentelemetry = { version = "0.13.0", features = ["metrics", "metrics-prometheus"] }
+
 anyhow = "1.0.68"
 chrono = { version = "0.4.23", features = ["serde"] }
 clap = { version = "4.1.4", features = ["derive", "env"] }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::cli::EdgeMode;
 use crate::offline_provider::OfflineProvider;
 use actix_cors::Cors;
+use actix_middleware_etag::Etag;
 use actix_web::{http, middleware, web, App, HttpServer};
 use actix_web_opentelemetry::RequestTracing;
 use clap::Parser;
@@ -45,6 +46,7 @@ async fn main() -> Result<(), anyhow::Error> {
             .allowed_header(http::header::CONTENT_TYPE);
         App::new()
             .app_data(client_provider_data)
+            .wrap(Etag::default())
             .wrap(cors_middleware)
             .wrap(RequestTracing::new())
             .wrap(request_metrics.clone())


### PR DESCRIPTION
So, to save our clients more computation, this PR adds an ETag middleware, which will calculate the hash of the body of responses to GET requests.

It uses https://github.com/chriswk/actix-middleware-etag for now

Future improvement particularly for the /api/client/features endpoint might be to use the fact that our hash is a lot more static, since we know when we update our content, we could use that to calculate the hash when refreshing.

I'm not advanced enough to know how to get that to work for now. I ended up fighting the type system and our expectations for what a middleware should do, so this is a nice compromise. If anyone feels like we're too slow/paying too much cpu to calculate the responses, we could revisit this in the future.