### PR TITLE
fix: features get refreshed.

### DIFF
--- a/server/src/frontend_api.rs
+++ b/server/src/frontend_api.rs
@@ -113,7 +113,10 @@ fn resolve_frontend_features(
 }
 
 pub fn configure_frontend_api(cfg: &mut web::ServiceConfig) {
-    cfg.service(get_frontend_features);
+    cfg.service(get_frontend_features)
+        .service(post_enabled_frontend_features)
+        .service(post_frontend_features)
+        .service(post_enabled_frontend_features);
 }
 
 #[cfg(test)]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -2,7 +2,7 @@ use actix_cors::Cors;
 
 use actix_middleware_etag::Etag;
 use actix_web::middleware::Logger;
-use actix_web::{http, web, App, HttpServer};
+use actix_web::{web, App, HttpServer};
 use actix_web_opentelemetry::RequestTracing;
 use clap::Parser;
 use cli::CliArgs;


### PR DESCRIPTION
Previously our spin loop slept for 15 seconds and then hit the await on the channel for a new token to validate.
This PR changes that to use tokio::select to either refresh features for known tokens each 10th second, or receive a new token to validate.

Should allow us to use more than one token and get them refreshed

