### PR TITLE
chore: test auto-assign-pr action

### DIFF
--- a/.github/workflows/auto-assign-pr-author.yaml
+++ b/.github/workflows/auto-assign-pr-author.yaml
@@ -1,0 +1,14 @@
+name: Auto Assign Author
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v1.6.2

--- a/server/src/http/unleash_client.rs
+++ b/server/src/http/unleash_client.rs
@@ -132,7 +132,7 @@ impl UnleashClient {
                     .into_iter()
                     .map(|t| {
                         let remaining_info =
-                            EdgeToken::try_from(t.token.clone()).unwrap_or(t.clone());
+                            EdgeToken::try_from(t.token.clone()).unwrap_or_else(|_| t.clone());
                         EdgeToken {
                             token: t.token.clone(),
                             token_type: t.token_type,


### PR DESCRIPTION
## About the changes
Having the author of the PR assigned to it can help triage the issues and PRs. This is to test if it's worthy, based on: https://unleash-internal.slack.com/archives/C048ELND3QD/p1672653600233719 (also open for comments)