### PR TITLE
feat: switch to backing with HashMap<token, EdgeToken>

### DIFF
--- a/server/src/data_sources/memory_provider.rs
+++ b/server/src/data_sources/memory_provider.rs
@@ -86,12 +86,12 @@ impl TokenSource for MemoryProvider {
     }
 
     async fn get_valid_tokens(&self, secrets: Vec<String>) -> EdgeResult<Vec<EdgeToken>> {
-        Ok(self
-            .token_store
-            .clone()
-            .into_iter()
-            .filter(|(k, t)| t.status == TokenValidationStatus::Validated && secrets.contains(k))
-            .map(|(_k, t)| t)
+        Ok(secrets
+            .iter()
+            .map(|s| self.token_store.get(s))
+            .flatten()
+            .filter(|s| s.status == TokenValidationStatus::Validated)
+            .cloned()
             .collect())
     }
 }

--- a/server/src/data_sources/memory_provider.rs
+++ b/server/src/data_sources/memory_provider.rs
@@ -88,8 +88,7 @@ impl TokenSource for MemoryProvider {
     async fn get_valid_tokens(&self, secrets: Vec<String>) -> EdgeResult<Vec<EdgeToken>> {
         Ok(secrets
             .iter()
-            .map(|s| self.token_store.get(s))
-            .flatten()
+            .filter_map(|s| self.token_store.get(s))
             .filter(|s| s.status == TokenValidationStatus::Validated)
             .cloned()
             .collect())

--- a/server/src/frontend_api.rs
+++ b/server/src/frontend_api.rs
@@ -126,7 +126,7 @@ mod tests {
     use crate::data_sources::builder::DataProviderPair;
     use crate::types::{
         ClientFeaturesResponse, EdgeProvider, EdgeResult, EdgeSink, EdgeSource, EdgeToken,
-        FeatureSink, FeaturesSource, TokenSink, TokenSource,
+        FeatureSink, FeaturesSource, TokenSink, TokenSource, TokenValidationStatus,
     };
     use actix_web::{
         http::header::ContentType,
@@ -177,12 +177,12 @@ mod tests {
             todo!()
         }
 
-        async fn secret_is_valid(
+        async fn get_token_validation_status(
             &self,
             _secret: &str,
             _: Arc<Sender<EdgeToken>>,
-        ) -> EdgeResult<bool> {
-            Ok(true)
+        ) -> EdgeResult<TokenValidationStatus> {
+            Ok(TokenValidationStatus::Validated)
         }
 
         async fn token_details(&self, _secret: String) -> EdgeResult<Option<EdgeToken>> {

--- a/server/src/middleware/validate_token.rs
+++ b/server/src/middleware/validate_token.rs
@@ -5,7 +5,7 @@ use actix_web::{
     HttpResponse,
 };
 
-use crate::types::{EdgeSource, EdgeToken};
+use crate::types::{EdgeSource, EdgeToken, TokenValidationStatus};
 use tokio::sync::{mpsc::Sender, RwLock};
 
 pub async fn validate_token(
@@ -15,16 +15,22 @@ pub async fn validate_token(
     req: ServiceRequest,
     srv: crate::middleware::as_async_middleware::Next<impl MessageBody + 'static>,
 ) -> Result<ServiceResponse<impl MessageBody>, actix_web::Error> {
-    let res = if provider
+    let res = match provider
         .read()
         .await
-        .secret_is_valid(token.token.as_str(), sender.into_inner())
-        .await?
+        .get_token_validation_status(token.token.as_str(), sender.into_inner())
+        .await
     {
-        srv.call(req).await?.map_into_left_body()
-    } else {
-        req.into_response(HttpResponse::Forbidden().finish())
-            .map_into_right_body()
+        Ok(TokenValidationStatus::Validated) => srv.call(req).await?.map_into_left_body(),
+        Ok(TokenValidationStatus::Unknown) => req
+            .into_response(HttpResponse::Unauthorized().finish())
+            .map_into_right_body(),
+        Ok(TokenValidationStatus::Invalid) => req
+            .into_response(HttpResponse::Forbidden().finish())
+            .map_into_right_body(),
+        Err(_e) => req
+            .into_response(HttpResponse::Unauthorized().finish())
+            .map_into_right_body(),
     };
     Ok(res)
 }

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -208,7 +208,11 @@ pub trait FeaturesSource {
 #[async_trait]
 pub trait TokenSource {
     async fn get_known_tokens(&self) -> EdgeResult<Vec<EdgeToken>>;
-    async fn secret_is_valid(&self, secret: &str, job: Arc<Sender<EdgeToken>>) -> EdgeResult<bool>;
+    async fn get_token_validation_status(
+        &self,
+        secret: &str,
+        job: Arc<Sender<EdgeToken>>,
+    ) -> EdgeResult<TokenValidationStatus>;
     async fn token_details(&self, secret: String) -> EdgeResult<Option<EdgeToken>>;
     async fn get_valid_tokens(&self, tokens: Vec<String>) -> EdgeResult<Vec<EdgeToken>>;
 }

--- a/server/tests/redis_test.rs
+++ b/server/tests/redis_test.rs
@@ -3,6 +3,7 @@ use std::{fs, sync::Arc};
 use redis::{Client, Commands};
 use testcontainers::{clients::Cli, images::redis::Redis, Container};
 use tokio::sync::mpsc;
+use unleash_edge::types::TokenValidationStatus;
 use unleash_edge::{
     data_sources::redis_provider::{RedisProvider, FEATURE_KEY, TOKENS_KEY},
     types::{EdgeProvider, EdgeToken},
@@ -66,8 +67,8 @@ async fn redis_provider_correctly_determines_secret_to_be_valid() {
     let provider: Box<dyn EdgeProvider> = Box::new(RedisProvider::new(&url).unwrap());
 
     let is_valid_token = provider
-        .secret_is_valid(TOKEN, Arc::new(send))
+        .get_token_validation_status(TOKEN, Arc::new(send))
         .await
         .unwrap();
-    assert!(is_valid_token)
+    assert_eq!(is_valid_token, TokenValidationStatus::Validated)
 }


### PR DESCRIPTION
There's one test failing here, because I haven't had time to fix the redisprovider defaulting to unknown for validationstatus (seems correct, we just need to mock that it is validated)