### PR TITLE
task: implement client metrics

### DIFF
--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -10,6 +10,7 @@ pub enum EdgeError {
     ClientFeaturesFetchError,
     ClientFeaturesParseError,
     DataSourceError(String),
+    EdgeMetricsError,
     EdgeTokenError,
     EdgeTokenParseError,
     InvalidBackupFile(String, String),
@@ -48,6 +49,7 @@ impl Display for EdgeError {
             EdgeError::AuthorizationPending => {
                 write!(f, "No validation for token has happened yet")
             }
+            EdgeError::EdgeMetricsError => write!(f, "Edge metrics error"),
         }
     }
 }
@@ -69,6 +71,7 @@ impl ResponseError for EdgeError {
             EdgeError::EdgeTokenError => StatusCode::BAD_REQUEST,
             EdgeError::EdgeTokenParseError => StatusCode::BAD_REQUEST,
             EdgeError::AuthorizationPending => StatusCode::UNAUTHORIZED,
+            EdgeError::EdgeMetricsError => StatusCode::BAD_REQUEST,
         }
     }
 

--- a/server/src/http/background_send_metrics.rs
+++ b/server/src/http/background_send_metrics.rs
@@ -18,12 +18,12 @@ pub async fn send_metrics_task(
             let metrics = metrics_lock.get_unsent_metrics();
 
             let request = BatchMetricsRequest {
-                applications: todo!(),
-                metrics: todo!(),
+                applications: metrics.applications,
+                metrics: metrics.metrics,
             };
 
             if let Err(error) = unleash_client.send_batch_metrics(request).await {
-                warn!("Failed to send metrics match");
+                warn!("Failed to send metrics: {error:?}");
             } else {
                 metrics_lock.reset_metrics();
             }

--- a/server/src/http/unleash_client.rs
+++ b/server/src/http/unleash_client.rs
@@ -111,7 +111,18 @@ impl UnleashClient {
     }
 
     pub async fn send_batch_metrics(&self, request: BatchMetricsRequest) -> EdgeResult<()> {
-        Ok(())
+        let result = self
+            .backing_client
+            .post(self.urls.edge_metrics_url.to_string())
+            .json(&request)
+            .send()
+            .await
+            .map_err(|_| EdgeError::EdgeMetricsError)?;
+        if result.status().is_success() {
+            Ok(())
+        } else {
+            Err(EdgeError::EdgeMetricsError)
+        }
     }
 
     pub async fn validate_tokens(

--- a/server/src/metrics/client_metrics.rs
+++ b/server/src/metrics/client_metrics.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
-use unleash_types::client_metrics::{ClientApplication, MetricBucket};
+use unleash_types::client_metrics::{ClientApplication, ClientMetricsEnv};
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
-pub struct MetricsKey {
+pub struct ApplicationKey {
     pub app_name: String,
     pub instance_id: String,
 }
 
-impl MetricsKey {
+impl ApplicationKey {
     pub fn from_app_name(app_name: String) -> Self {
         Self {
             app_name,
@@ -16,17 +16,32 @@ impl MetricsKey {
     }
 }
 
-pub struct MetricsBatch {}
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct MetricsKey {
+    pub app_name: String,
+    pub feature_name: String,
+}
+
+pub struct MetricsBatch {
+    pub applications: Vec<ClientApplication>,
+    pub metrics: Vec<ClientMetricsEnv>,
+}
 
 #[derive(Default)]
 pub struct MetricsCache {
-    pub applications: HashMap<MetricsKey, ClientApplication>,
-    pub metrics: HashMap<MetricsKey, MetricBucket>,
+    pub applications: HashMap<ApplicationKey, ClientApplication>,
+    pub metrics: HashMap<MetricsKey, ClientMetricsEnv>,
 }
 
 impl MetricsCache {
     pub fn get_unsent_metrics(&self) -> MetricsBatch {
-        MetricsBatch {}
+        MetricsBatch {
+            applications: self.applications.values().cloned().collect(),
+            metrics: self.metrics.values().cloned().collect(),
+        }
     }
-    pub fn reset_metrics(&mut self) {}
+    pub fn reset_metrics(&mut self) {
+        self.applications.clear();
+        self.metrics.clear();
+    }
 }

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -16,7 +16,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use shadow_rs::shadow;
 use unleash_types::client_features::ClientFeatures;
-use unleash_types::client_metrics::{ClientApplication, ClientMetrics, ClientMetricsEnv};
+use unleash_types::client_metrics::{ClientApplication, ClientMetricsEnv};
 
 pub type EdgeJsonResult<T> = Result<Json<T>, EdgeError>;
 pub type EdgeResult<T> = Result<T, EdgeError>;


### PR DESCRIPTION
My naïve implementation of client metrics with a flatter structure - Instead of storing buckets in the metrics cache and converting back and forth, we store them as ClientMetricsEnv. Also uses a `MetricsKey` as that hash key, based on `app_name` and `toggle_name` to identify each `ClientMetricsEnv`.