### PR TITLE
chore: redesign source and sinks to store features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
  "bytes",
+ "futures-core",
  "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1814,11 +1818,17 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa8455fa3621f6b41c514946de66ea0531f57ca017b2e6c7cc368035ea5b46df"
 dependencies = [
+ "async-trait",
+ "bytes",
  "combine",
+ "futures-util",
  "itoa",
  "percent-encoding",
+ "pin-project-lite",
  "ryu",
  "sha1_smol",
+ "tokio",
+ "tokio-util",
  "url",
 ]
 
@@ -2597,9 +2607,9 @@ dependencies = [
 
 [[package]]
 name = "unleash-types"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c9406af268aefe139c799b042e0302ae9aa2db23aa99bc13e94e53e980e35c9"
+checksum = "da0eefe0c369edee821dabfde210321a53faf5b87813f1ef1e0e343295033ad9"
 dependencies = [
  "base64",
  "chrono",
@@ -2612,9 +2622,9 @@ dependencies = [
 
 [[package]]
 name = "unleash-yggdrasil"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ca2f7be042583e03b25523182c9b5a59296157f88b410d34f4fcbb8735f2ce"
+checksum = "d305fb6bd0a899fdca19f4e1b278d5af7978323a118a8eb5ca3b76739ce2bbc4"
 dependencies = [
  "chrono",
  "convert_case 0.6.0",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -31,7 +31,7 @@ futures-core = "0.3.26"
 opentelemetry = {version = "0.18.0", features = ["trace", "rt-tokio", "metrics"]}
 opentelemetry-prometheus = "0.11.0"
 prometheus = {version = "0.13.3", features = ["process"]}
-redis = "0.22.3"
+redis = {version = "0.22.3", features = ["tokio-comp"]}
 reqwest = {version = "0.11.14", default-features = false, features = ["rustls", "json", "rustls-tls"]}
 rustls = "0.20.8"
 rustls-pemfile = "1.0.2"
@@ -42,8 +42,8 @@ tokio = {version = "1.25.0", features = ["macros", "rt-multi-thread", "tracing"]
 tracing = {version = "0.1.37", features = ["log"]}
 tracing-subscriber = {version = "0.3.16", features = ["json", "env-filter"]}
 ulid = "1.0.0"
-unleash-types = {version = "0.8.1", features = ["openapi", "hashes"]}
-unleash-yggdrasil = "0.4.4"
+unleash-types = {version = "0.8.2", features = ["openapi", "hashes"]}
+unleash-yggdrasil = "0.4.5"
 [dev-dependencies]
 actix-http = "3.3.0"
 actix-http-test = "3.1.0"

--- a/server/src/data_sources/mod.rs
+++ b/server/src/data_sources/mod.rs
@@ -1,4 +1,28 @@
+use unleash_types::client_features::ClientFeature;
+
+use crate::types::EdgeToken;
+
 pub mod builder;
 pub mod memory_provider;
 pub mod offline_provider;
 pub mod redis_provider;
+
+trait ProjectFilter<T> {
+    fn filter_by_projects(&self, token: &EdgeToken) -> Vec<T>;
+}
+
+impl ProjectFilter<ClientFeature> for Vec<ClientFeature> {
+    fn filter_by_projects(&self, token: &EdgeToken) -> Vec<ClientFeature> {
+        self.iter()
+            .filter(|feature| {
+                if let Some(feature_project) = &feature.project {
+                    token.projects.contains(&"*".to_string())
+                        || token.projects.contains(feature_project)
+                } else {
+                    false
+                }
+            })
+            .cloned()
+            .collect::<Vec<ClientFeature>>()
+    }
+}

--- a/server/src/data_sources/offline_provider.rs
+++ b/server/src/data_sources/offline_provider.rs
@@ -1,9 +1,8 @@
 use crate::error::EdgeError;
 use crate::types::{
-    ClientFeaturesResponse, EdgeResult, EdgeSink, EdgeSource, EdgeToken, FeatureSink,
-    FeaturesSource, TokenSink, TokenSource, TokenValidationStatus,
+    EdgeResult, EdgeSink, EdgeSource, EdgeToken, FeatureSink, FeaturesSource, TokenSink,
+    TokenSource, TokenValidationStatus,
 };
-use actix_web::http::header::EntityTag;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::fs::File;
@@ -72,11 +71,6 @@ impl FeatureSink for OfflineProvider {
         _features: ClientFeatures,
     ) -> EdgeResult<()> {
         todo!()
-    }
-    async fn fetch_features(&mut self, _token: &EdgeToken) -> EdgeResult<ClientFeaturesResponse> {
-        Ok(ClientFeaturesResponse::NoUpdate(EntityTag::new_weak(
-            "this_provider_does_not_support_refreshing_features".into(),
-        )))
     }
 }
 

--- a/server/src/frontend_api.rs
+++ b/server/src/frontend_api.rs
@@ -125,8 +125,8 @@ mod tests {
 
     use crate::data_sources::builder::DataProviderPair;
     use crate::types::{
-        ClientFeaturesResponse, EdgeResult, EdgeSink, EdgeSource, EdgeToken, FeatureSink,
-        FeaturesSource, TokenSink, TokenSource, TokenValidationStatus,
+        EdgeResult, EdgeSink, EdgeSource, EdgeToken, FeatureSink, FeaturesSource, TokenSink,
+        TokenSource, TokenValidationStatus,
     };
     use actix_web::{
         http::header::ContentType,
@@ -214,12 +214,6 @@ mod tests {
             _token: &EdgeToken,
             _features: ClientFeatures,
         ) -> EdgeResult<()> {
-            todo!()
-        }
-        async fn fetch_features(
-            &mut self,
-            _token: &EdgeToken,
-        ) -> EdgeResult<ClientFeaturesResponse> {
             todo!()
         }
     }

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -223,7 +223,6 @@ pub trait FeatureSink {
         token: &EdgeToken,
         features: ClientFeatures,
     ) -> EdgeResult<()>;
-    async fn fetch_features(&mut self, token: &EdgeToken) -> EdgeResult<ClientFeaturesResponse>;
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/server/tests/redis_test.rs
+++ b/server/tests/redis_test.rs
@@ -1,54 +1,242 @@
-// use std::fs;
+use std::str::FromStr;
 
-// use redis::{Client, Commands};
-// use testcontainers::{clients::Cli, images::redis::Redis, Container};
-// use unleash_edge::{
-//     data_sources::redis_provider::{RedisProvider, FEATURE_PREFIX, TOKENS_KEY},
-//     types::{EdgeProvider, EdgeToken},
-// };
+use redis::{Client, Commands};
+use testcontainers::{clients::Cli, images::redis::Redis, Container};
+use tokio::sync::mpsc;
 
-// const TOKEN: &str = "*:development.03fa5f506428fe80ed5640c351c7232e38940814d2923b08f5c05fa7";
+use unleash_edge::{
+    data_sources::redis_provider::{RedisProvider, FEATURE_PREFIX},
+    types::{EdgeSink, EdgeSource, EdgeToken, TokenValidationStatus},
+};
+use unleash_types::client_features::{ClientFeature, ClientFeatures};
 
-// fn setup_redis(docker: &Cli) -> (Client, String, Container<Redis>) {
-//     let node: Container<Redis> = docker.run(Redis::default());
-//     let host_port = node.get_host_port_ipv4(6379);
-//     let url = format!("redis://127.0.0.1:{host_port}");
+const TOKEN: &str = "*:development.03fa5f506428fe80ed5640c351c7232e38940814d2923b08f5c05fa7";
 
-//     (redis::Client::open(url.clone()).unwrap(), url, node)
-// }
+fn setup_redis(docker: &Cli) -> (Client, String, Container<Redis>) {
+    let node: Container<Redis> = docker.run(Redis::default());
+    let host_port = node.get_host_port_ipv4(6379);
+    let url = format!("redis://127.0.0.1:{host_port}");
 
-// #[tokio::test]
-// async fn redis_provider_returns_expected_data() {
-//     let docker = Cli::default();
-//     let (mut client, url, _node) = setup_redis(&docker);
+    (redis::Client::open(url.clone()).unwrap(), url, node)
+}
 
-//     let content = fs::read_to_string("../examples/features.json").expect("Could not read file");
+fn build_features_key(token: &EdgeToken) -> String {
+    token
+        .environment
+        .as_ref()
+        .map(|environment| format!("{FEATURE_PREFIX}{environment}"))
+        .expect("Tying to resolve features for a token that hasn't been validated")
+}
 
-//     //This wants a type hint but we don't care about the result so we immediately discard the data coming back
-//     let _: () = client.set(FEATURE_PREFIX, content).unwrap();
+#[tokio::test]
+async fn redis_sink_returns_stores_data_correctly() {
+    let docker = Cli::default();
+    let (mut client, url, _node) = setup_redis(&docker);
 
-//     let provider: Box<dyn EdgeProvider> = Box::new(RedisProvider::new(&url).unwrap());
+    let (send, _) = mpsc::channel::<EdgeToken>(32);
 
-//     let features = provider
-//         .get_client_features(&EdgeToken::try_from(TOKEN.to_string()).unwrap())
-//         .await
-//         .unwrap();
+    let mut sink: Box<dyn EdgeSink> = Box::new(RedisProvider::new(&url, send).unwrap());
 
-//     assert!(!features.features.is_empty());
-// }
+    let token = EdgeToken {
+        status: TokenValidationStatus::Validated,
+        environment: Some("some-env-1".to_string()),
+        projects: vec!["default".to_string()],
+        ..EdgeToken::from_str(TOKEN).unwrap()
+    };
 
-// #[tokio::test]
-// async fn redis_provider_returns_token_info() {
-//     let docker = Cli::default();
-//     let (mut client, url, _node) = setup_redis(&docker);
+    let features = ClientFeatures {
+        features: vec![ClientFeature {
+            name: "test".to_string(),
+            ..ClientFeature::default()
+        }],
+        query: None,
+        segments: None,
+        version: 2,
+    };
 
-//     let _: () = client.set(TOKENS_KEY, format!("[\"{TOKEN}\"]")).unwrap();
+    let key = build_features_key(&token);
 
-//     let provider: Box<dyn EdgeProvider> = Box::new(RedisProvider::new(&url).unwrap());
+    sink.sink_features(&token, features.clone()).await.unwrap();
+    let stored_features: String = client.get::<&str, String>(key.as_str()).unwrap();
+    let stored_features: ClientFeatures = serde_json::from_str(&stored_features).unwrap();
+    assert_eq!(stored_features, features.clone());
+}
 
-//     let tokens = provider.get_known_tokens().await.unwrap();
-//     assert_eq!(
-//         *tokens[0].environment.as_ref().unwrap(),
-//         "development".to_string()
-//     );
-// }
+#[tokio::test]
+async fn redis_sink_returns_merges_features_by_environment() {
+    let docker = Cli::default();
+    let (mut client, url, _node) = setup_redis(&docker);
+
+    let (send, _) = mpsc::channel::<EdgeToken>(32);
+
+    let mut sink: Box<dyn EdgeSink> = Box::new(RedisProvider::new(&url, send).unwrap());
+
+    let token = EdgeToken {
+        environment: Some("some-env-2".to_string()),
+        status: TokenValidationStatus::Validated,
+        projects: vec!["default".to_string()],
+        ..EdgeToken::from_str(TOKEN).unwrap()
+    };
+
+    let key = build_features_key(&token);
+
+    let features1 = ClientFeatures {
+        features: vec![ClientFeature {
+            name: "test".to_string(),
+            ..ClientFeature::default()
+        }],
+        query: None,
+        segments: None,
+        version: 2,
+    };
+
+    sink.sink_features(&token, features1.clone()).await.unwrap();
+
+    let features2 = ClientFeatures {
+        features: vec![ClientFeature {
+            name: "some-other-test".to_string(),
+            ..ClientFeature::default()
+        }],
+        query: None,
+        segments: None,
+        version: 2,
+    };
+
+    sink.sink_features(&token, features2.clone()).await.unwrap();
+
+    let first_expected_toggle = ClientFeature {
+        name: "some-other-test".to_string(),
+        ..ClientFeature::default()
+    };
+
+    let second_expected_toggle = ClientFeature {
+        name: "test".to_string(),
+        ..ClientFeature::default()
+    };
+
+    let stored_features: String = client.get::<&str, String>(key.as_str()).unwrap();
+    let stored_features: ClientFeatures = serde_json::from_str(&stored_features).unwrap();
+    assert!(stored_features.features.contains(&first_expected_toggle));
+    assert!(stored_features.features.contains(&second_expected_toggle));
+}
+
+#[tokio::test]
+async fn redis_sink_returns_splits_out_data_with_different_environments() {
+    let docker = Cli::default();
+    let (mut client, url, _node) = setup_redis(&docker);
+
+    let (send, _) = mpsc::channel::<EdgeToken>(32);
+
+    let mut sink: Box<dyn EdgeSink> = Box::new(RedisProvider::new(&url, send).unwrap());
+
+    let dev_token = EdgeToken {
+        status: TokenValidationStatus::Validated,
+        environment: Some("some-env-3".to_string()),
+        projects: vec!["default".to_string()],
+        ..EdgeToken::from_str(TOKEN).unwrap()
+    };
+
+    let prod_token = EdgeToken {
+        status: TokenValidationStatus::Validated,
+        environment: Some("some-env-4".to_string()),
+        projects: vec!["default".to_string()],
+        ..EdgeToken::from_str(TOKEN).unwrap()
+    };
+
+    let dev_key = build_features_key(&dev_token);
+
+    let features1 = ClientFeatures {
+        features: vec![ClientFeature {
+            name: "test".to_string(),
+            ..ClientFeature::default()
+        }],
+        query: None,
+        segments: None,
+        version: 2,
+    };
+
+    sink.sink_features(&dev_token, features1.clone())
+        .await
+        .unwrap();
+
+    let features2 = ClientFeatures {
+        features: vec![ClientFeature {
+            name: "some-other-test".to_string(),
+            ..ClientFeature::default()
+        }],
+        query: None,
+        segments: None,
+        version: 2,
+    };
+
+    sink.sink_features(&prod_token, features2.clone())
+        .await
+        .unwrap();
+
+    let expected = ClientFeatures {
+        features: vec![ClientFeature {
+            name: "test".to_string(),
+            ..ClientFeature::default()
+        }],
+        query: None,
+        segments: None,
+        version: 2,
+    };
+
+    let stored_features: String = client.get::<&str, String>(dev_key.as_str()).unwrap();
+    let stored_features: ClientFeatures = serde_json::from_str(&stored_features).unwrap();
+    assert_eq!(stored_features, expected);
+}
+
+#[tokio::test]
+async fn redis_source_filters_by_projects() {
+    let docker = Cli::default();
+    let (_client, url, _node) = setup_redis(&docker);
+
+    let (send, _) = mpsc::channel::<EdgeToken>(32);
+    let (other_send, _) = mpsc::channel::<EdgeToken>(32);
+
+    let source: Box<dyn EdgeSource> = Box::new(RedisProvider::new(&url, send).unwrap());
+    let mut sink: Box<dyn EdgeSink> = Box::new(RedisProvider::new(&url, other_send).unwrap());
+
+    let features = ClientFeatures {
+        features: vec![
+            ClientFeature {
+                name: "some-other-test".to_string(),
+                project: Some("some-project".to_string()),
+                ..ClientFeature::default()
+            },
+            ClientFeature {
+                name: "some-other-test".to_string(),
+                project: Some("some-other-project".to_string()),
+                ..ClientFeature::default()
+            },
+        ],
+        query: None,
+        segments: None,
+        version: 2,
+    };
+
+    let token = EdgeToken {
+        status: TokenValidationStatus::Validated,
+        environment: Some("some-env-5".to_string()),
+        projects: vec!["some-project".to_string()],
+        ..EdgeToken::from_str(TOKEN).unwrap()
+    };
+
+    let expected = ClientFeatures {
+        features: vec![ClientFeature {
+            name: "some-other-test".to_string(),
+            project: Some("some-project".to_string()),
+            ..ClientFeature::default()
+        }],
+        query: None,
+        segments: None,
+        version: 2,
+    };
+
+    sink.sink_features(&token, features.clone()).await.unwrap();
+
+    let stored_features = source.get_client_features(&token).await.unwrap();
+    assert_eq!(stored_features, expected);
+}


### PR DESCRIPTION
This redesigns the way we store data in the memory and Redis providers to store incoming features by environment rather the token string. This means that incoming features for an environment will be merged in the case that the come from the same environment but different tokens. To handle this in the sources, outgoing data is filtered by project