### PR TITLE
task: Subsume keys to check

### DIFF
--- a/server/src/data_sources/memory_provider.rs
+++ b/server/src/data_sources/memory_provider.rs
@@ -53,9 +53,9 @@ impl MemoryProvider {
                 self.tokens_to_refresh
                     .entry(token.clone().token)
                     .or_insert(FeatureRefresh::new(token.clone()));
-                self.reduce_tokens_to_refresh();
             }
         }
+        self.reduce_tokens_to_refresh();
     }
     fn reduce_tokens_to_refresh(&mut self) {
         let tokens: Vec<EdgeToken> = self


### PR DESCRIPTION
This collapses the keys seen. Removing keys that have been subsumed by a wider key (a key that includes the same projects or more as existing keys).