### PR TITLE
feat: allow controlling http server workers spun up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2701,6 +2701,7 @@ dependencies = [
  "env_logger",
  "futures",
  "futures-core",
+ "num_cpus",
  "opentelemetry",
  "opentelemetry-prometheus",
  "prometheus",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Options:
   -i, --interface <INTERFACE>
           Which interfaces should this server listen for HTTP traffic on [env: INTERFACE=] [default: 0.0.0.0]
   -w, --workers <WORKERS>
-          How many workers should be started to handle requests. Defaults to number of physical cpus [env: WORKERS=] [default: 8]
+          How many workers should be started to handle requests. Defaults to number of physical cpus [env: WORKERS=] [default: number of physical cpus]
       --tls-enable
           Should we bind TLS [env: TLS_ENABLE=]
       --tls-server-key <TLS_SERVER_KEY>

--- a/README.md
+++ b/README.md
@@ -7,15 +7,20 @@ Unleash Edge is the successor to the [Unleash Proxy](https://docs.getunleash.io/
 Unleash Edge is compiled to a single binary. You can configure it by passing in arguments or setting environment variables.
 
 ```shell
-$ ./unleash-edge --help
+Usage: unleash-edge [OPTIONS] <COMMAND>
+
 Commands:
   edge     Run in edge mode
   offline  Run in offline mode
+  help     Print this message or the help of the given subcommand(s)
+
 Options:
   -p, --port <PORT>
           Which port should this server listen for HTTP traffic on [env: PORT=] [default: 3063]
   -i, --interface <INTERFACE>
           Which interfaces should this server listen for HTTP traffic on [env: INTERFACE=] [default: 0.0.0.0]
+  -w, --workers <WORKERS>
+          How many workers should be started to handle requests. Defaults to number of physical cpus (or logical, if we can't get physical) [env: WORKERS=] [default: 8]
       --tls-enable
           Should we bind TLS [env: TLS_ENABLE=]
       --tls-server-key <TLS_SERVER_KEY>
@@ -24,6 +29,8 @@ Options:
           Server Cert to use for TLS [env: TLS_SERVER_CERT=]
       --tls-server-port <TLS_SERVER_PORT>
           Port to listen for https connection on (will use the interfaces already defined) [env: TLS_SERVER_PORT=] [default: 3043]
+  -h, --help
+          Print help
 ```
 
 ## Concepts

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Options:
   -i, --interface <INTERFACE>
           Which interfaces should this server listen for HTTP traffic on [env: INTERFACE=] [default: 0.0.0.0]
   -w, --workers <WORKERS>
-          How many workers should be started to handle requests. Defaults to number of physical cpus (or logical, if we can't get physical) [env: WORKERS=] [default: 8]
+          How many workers should be started to handle requests. Defaults to number of physical cpus [env: WORKERS=] [default: 8]
       --tls-enable
           Should we bind TLS [env: TLS_ENABLE=]
       --tls-server-key <TLS_SERVER_KEY>

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -29,6 +29,7 @@ dashmap = "5.4.0"
 dotenv = {version = "0.15.0", features = ["clap"]}
 futures = "0.3.26"
 futures-core = "0.3.26"
+num_cpus = "1.15.0"
 opentelemetry = {version = "0.18.0", features = ["trace", "rt-tokio", "metrics"]}
 opentelemetry-prometheus = "0.11.0"
 prometheus = {version = "0.13.3", features = ["process"]}

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -90,6 +90,12 @@ pub struct HttpServerArgs {
     /// Which interfaces should this server listen for HTTP traffic on
     #[clap(short, long, env, default_value = "0.0.0.0")]
     pub interface: String,
+
+    /// How many workers should be started to handle requests.
+    /// Defaults to number of physical cpus (or logical, if we can't get physical)
+    #[clap(short, long, env, default_value_t = num_cpus::get_physical())]
+    pub workers: usize,
+
     #[clap(flatten)]
     pub tls: TlsOptions,
 }

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -92,7 +92,7 @@ pub struct HttpServerArgs {
     pub interface: String,
 
     /// How many workers should be started to handle requests.
-    /// Defaults to number of physical cpus (or logical, if we can't get physical)
+    /// Defaults to number of physical cpus
     #[clap(short, long, env, default_value_t = num_cpus::get_physical())]
     pub workers: usize,
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -88,7 +88,7 @@ async fn main() -> Result<(), anyhow::Error> {
     } else {
         server.bind(http_args.http_server_tuple())
     };
-    let server = server?.shutdown_timeout(5);
+    let server = server?.workers(http_args.workers).shutdown_timeout(5);
 
     if let Some(sink_info) = sink_info {
         tokio::select! {


### PR DESCRIPTION
So, since some of our users might not want edge to start up a thread on each physical CPU they have available, this PR makes the number of workers configurable as an environment parameter as well as a CLI argument. 

This allows a less resource hungry deployment of Edge for local development.