### PR TITLE
fix: Make offline mode handle non-Unleash tokens as valid secrets

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -29,6 +29,7 @@ use utoipa::OpenApi;
 async fn main() -> Result<(), anyhow::Error> {
     dotenv::dotenv().ok();
     let args = CliArgs::parse();
+    let mode_arg = args.clone().mode;
     let http_args = args.clone().http;
     let (metrics_handler, request_metrics) = prom_metrics::instantiate(None);
     let repo_info = build_source_and_sink(args).await.unwrap();
@@ -51,6 +52,7 @@ async fn main() -> Result<(), anyhow::Error> {
             .allow_any_method();
         let mut app = App::new()
             .app_data(edge_source)
+            .app_data(web::Data::new(mode_arg.clone()))
             .app_data(web::Data::from(metrics_cache.clone()));
         if validator.is_some() {
             app = app.app_data(web::Data::from(validator.clone().unwrap()))


### PR DESCRIPTION
So, our FromRequest for EdgeToken was failing for offline mode now that we had changed our try_from to only allow tokens following the UnleashToken spec to actually parse successfully, thus 403'ing all requests against an unleash server in offline mode. This fixes that so that offline mode again supports users using secret123 as their token if they so desire. 