### PR TITLE
fix: Move to distroless with libc

### DIFF
--- a/.github/workflows/build-docker-release.yaml
+++ b/.github/workflows/build-docker-release.yaml
@@ -30,10 +30,10 @@ jobs:
           cargo install cross
       - name: Build release for aarch64
         run: |
-          cross build --release --target=aarch64-unknown-linux-musl
+          cross build --release --target=aarch64-unknown-linux-gnu
       - name: Build release for x86_64
         run: |
-          cross build --release --target=x86_64-unknown-linux-musl
+          cross build --release --target=x86_64-unknown-linux-gnu
       - name: Login to docker hub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/docker_ecr_arch64.yaml
+++ b/.github/workflows/docker_ecr_arch64.yaml
@@ -30,7 +30,7 @@ jobs:
           cargo install cross
       - name: Build release
         run: |
-          cross build --release --target=aarch64-unknown-linux-musl
+          cross build --release --target=aarch64-unknown-linux-gnu
       - name: Setup QEMU (to support multiplatform)
         uses: docker/setup-qemu-action@v2
       - name: Configure aws credentials

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM gcr.io/distroless:cc
 
-COPY target/aarch64-unknown-linux-musl/release/unleash-edge /unleash-edge
+COPY target/aarch64-unknown-linux-gnu/release/unleash-edge /unleash-edge
 ENTRYPOINT ["/unleash-edge"]

--- a/Dockerfile.publish
+++ b/Dockerfile.publish
@@ -1,9 +1,9 @@
 # FINAL arch images
-FROM --platform=amd64 scratch as final-amd64
-COPY target/x86_64-unknown-linux-musl/release/unleash-edge /unleash-edge
+FROM --platform=amd64 gcr.io/distroless:cc as final-amd64
+COPY target/x86_64-unknown-linux-gnu/release/unleash-edge /unleash-edge
 
-FROM --platform=arm64 scratch as final-arm64
-COPY target/aarch64-unknown-linux-musl/release/unleash-edge /unleash-edge
+FROM --platform=arm64 gcr.io/distroless:cc as final-arm64
+COPY target/aarch64-unknown-linux-gnu/release/unleash-edge /unleash-edge
 
 # Final image
 

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -1,5 +1,0 @@
-FROM alpine:3.17
-
-WORKDIR /app
-COPY target/x86_64-unknown-linux-musl/release/unleash-edge /app/
-ENTRYPOINT ["/app/unleash-edge"]


### PR DESCRIPTION
Performance with musl images was awful. This PR changes to use distroless and makes our builds build for -gnu instead of -musl

## Future improvement
- Use non-root user, I have a template for how to do it, but this PR just moves us to distroless for now
