### PR TITLE
task: updated workflow to use regex

### DIFF
--- a/.github/workflows/build-docker-release.yaml
+++ b/.github/workflows/build-docker-release.yaml
@@ -58,8 +58,8 @@ jobs:
             ghcr.io/Unleash/unleash-edge
           tags: |
             type=edge
-            type=semver,pattern={{ version }}
-            type=semver,pattern={{ major }}.{{ minor }}
+            type=match,pattern=unleash-edge-v(\d+\.\d+.\d+),group=1,prefix=v
+            type=match,pattern=unleash-edge-v(\d+\.\d+).*,group=1,prefix=v
       - name: Build tag and push images
         uses: docker/build-push-action@v4
         with:


### PR DESCRIPTION
Since we're prefixing tags with unleash-edge-, metadata-action's semver type fails to work on our released tags. This PR changes to using patterns for creating the {{ version }} and {{ major.minor }} tags.