### PR TITLE
chore: removal of RW locks for dashmaps

### DIFF
--- a/server/src/data_sources/builder.rs
+++ b/server/src/data_sources/builder.rs
@@ -39,7 +39,7 @@ fn build_offline(offline_args: OfflineArgs) -> EdgeResult<Arc<dyn EdgeSource>> {
 }
 
 fn build_memory(features_refresh_interval_seconds: Duration) -> EdgeResult<DataProviderPair> {
-    let data_source = Arc::new(RwLock::new(MemoryProvider::new()));
+    let data_source = Arc::new(MemoryProvider::new());
     let facade = Arc::new(DataSourceFacade {
         features_refresh_interval: Some(features_refresh_interval_seconds),
         token_source: data_source.clone(),
@@ -58,7 +58,7 @@ fn build_redis(
     redis_url: String,
     features_refresh_interval_seconds: Duration,
 ) -> EdgeResult<DataProviderPair> {
-    let data_source = Arc::new(RwLock::new(RedisProvider::new(&redis_url)?));
+    let data_source = Arc::new(RedisProvider::new(&redis_url)?);
     let facade = Arc::new(DataSourceFacade {
         token_source: data_source.clone(),
         feature_source: data_source.clone(),
@@ -93,7 +93,7 @@ pub async fn build_source_and_sink(args: CliArgs) -> EdgeResult<RepositoryInfo> 
                 EdgeArg::InMemory => build_memory(refresh_interval),
             }?;
 
-            let mut token_validator = TokenValidator {
+            let token_validator = TokenValidator {
                 unleash_client: Arc::new(unleash_client.clone()),
                 edge_source: source.clone(),
                 edge_sink: sink.clone(),

--- a/server/src/data_sources/memory_provider.rs
+++ b/server/src/data_sources/memory_provider.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::types::TokenRefresh;
 use crate::types::{EdgeResult, EdgeToken};
 use actix_web::http::header::EntityTag;
@@ -13,8 +11,8 @@ use super::repository::{DataSink, DataSource};
 #[derive(Debug, Clone)]
 pub struct MemoryProvider {
     data_store: DashMap<String, ClientFeatures>,
-    token_store: HashMap<String, EdgeToken>,
-    tokens_to_refresh: HashMap<String, TokenRefresh>,
+    token_store: DashMap<String, EdgeToken>,
+    tokens_to_refresh: DashMap<String, TokenRefresh>,
 }
 
 fn key(token: &EdgeToken) -> String {
@@ -31,8 +29,8 @@ impl MemoryProvider {
     pub fn new() -> Self {
         Self {
             data_store: DashMap::new(),
-            token_store: HashMap::new(),
-            tokens_to_refresh: HashMap::new(),
+            token_store: DashMap::new(),
+            tokens_to_refresh: DashMap::new(),
         }
     }
 }
@@ -40,15 +38,19 @@ impl MemoryProvider {
 #[async_trait]
 impl DataSource for MemoryProvider {
     async fn get_tokens(&self) -> EdgeResult<Vec<EdgeToken>> {
-        Ok(self.token_store.values().into_iter().cloned().collect())
+        Ok(self.token_store.iter().map(|x| x.value().clone()).collect())
     }
 
     async fn get_token(&self, secret: &str) -> EdgeResult<Option<EdgeToken>> {
-        Ok(self.token_store.get(secret).cloned())
+        Ok(self.token_store.get(secret).map(|x| x.clone()))
     }
 
     async fn get_refresh_tokens(&self) -> EdgeResult<Vec<TokenRefresh>> {
-        Ok(self.tokens_to_refresh.values().cloned().collect())
+        Ok(self
+            .tokens_to_refresh
+            .iter()
+            .map(|x| x.value().clone())
+            .collect())
     }
 
     async fn get_client_features(&self, token: &EdgeToken) -> EdgeResult<Option<ClientFeatures>> {
@@ -58,27 +60,23 @@ impl DataSource for MemoryProvider {
 
 #[async_trait]
 impl DataSink for MemoryProvider {
-    async fn sink_tokens(&mut self, tokens: Vec<EdgeToken>) -> EdgeResult<()> {
+    async fn sink_tokens(&self, tokens: Vec<EdgeToken>) -> EdgeResult<()> {
         for token in tokens {
             self.token_store.insert(token.token.clone(), token.clone());
         }
         Ok(())
     }
 
-    async fn set_refresh_tokens(&mut self, tokens: Vec<&TokenRefresh>) -> EdgeResult<()> {
-        let new_tokens = tokens
-            .into_iter()
-            .map(|token| (token.token.token.clone(), token.clone()))
-            .collect();
-        self.tokens_to_refresh = new_tokens;
+    async fn set_refresh_tokens(&self, tokens: Vec<&TokenRefresh>) -> EdgeResult<()> {
+        self.tokens_to_refresh.clear();
+        tokens.into_iter().for_each(|refresh| {
+            self.tokens_to_refresh
+                .insert(refresh.token.token.clone(), refresh.clone());
+        });
         Ok(())
     }
 
-    async fn sink_features(
-        &mut self,
-        token: &EdgeToken,
-        features: ClientFeatures,
-    ) -> EdgeResult<()> {
+    async fn sink_features(&self, token: &EdgeToken, features: ClientFeatures) -> EdgeResult<()> {
         self.data_store
             .entry(key(token))
             .and_modify(|data| {
@@ -88,19 +86,19 @@ impl DataSink for MemoryProvider {
         Ok(())
     }
 
-    async fn update_last_check(&mut self, token: &EdgeToken) -> EdgeResult<()> {
-        if let Some(token) = self.tokens_to_refresh.get_mut(&token.token) {
+    async fn update_last_check(&self, token: &EdgeToken) -> EdgeResult<()> {
+        if let Some(mut token) = self.tokens_to_refresh.get_mut(&token.token) {
             token.last_check = Some(chrono::Utc::now());
         }
         Ok(())
     }
 
     async fn update_last_refresh(
-        &mut self,
+        &self,
         token: &EdgeToken,
         etag: Option<EntityTag>,
     ) -> EdgeResult<()> {
-        if let Some(token) = self.tokens_to_refresh.get_mut(&token.token) {
+        if let Some(mut token) = self.tokens_to_refresh.get_mut(&token.token) {
             token.last_check = Some(chrono::Utc::now());
             token.last_refreshed = Some(chrono::Utc::now());
             token.etag = etag;
@@ -117,7 +115,7 @@ mod tests {
 
     #[tokio::test]
     async fn memory_provider_correctly_deduplicates_tokens() {
-        let mut provider = MemoryProvider::default();
+        let provider = MemoryProvider::default();
         provider
             .sink_tokens(vec![EdgeToken {
                 token: "*:development.1d38eefdd7bf72676122b008dcf330f2f2aa2f3031438e1b7e8f0d1f"
@@ -141,7 +139,7 @@ mod tests {
 
     #[tokio::test]
     async fn memory_provider_correctly_determines_token_to_be_valid() {
-        let mut provider = MemoryProvider::default();
+        let provider = MemoryProvider::default();
         provider
             .sink_tokens(vec![EdgeToken {
                 token: "*:development.1d38eefdd7bf72676122b008dcf330f2f2aa2f3031438e1b7e8f0d1f"

--- a/server/src/data_sources/redis_provider.rs
+++ b/server/src/data_sources/redis_provider.rs
@@ -80,7 +80,7 @@ impl DataSource for RedisProvider {
 
 #[async_trait]
 impl DataSink for RedisProvider {
-    async fn sink_tokens(&mut self, tokens: Vec<EdgeToken>) -> EdgeResult<()> {
+    async fn sink_tokens(&self, tokens: Vec<EdgeToken>) -> EdgeResult<()> {
         let mut client = self.redis_client.write().await;
         let raw_stored_tokens: Option<String> = client.get(TOKENS_KEY)?;
 
@@ -99,7 +99,7 @@ impl DataSink for RedisProvider {
         Ok(())
     }
 
-    async fn set_refresh_tokens(&mut self, tokens: Vec<&TokenRefresh>) -> EdgeResult<()> {
+    async fn set_refresh_tokens(&self, tokens: Vec<&TokenRefresh>) -> EdgeResult<()> {
         let mut client = self.redis_client.write().await;
 
         let serialized_refresh_tokens = serde_json::to_string(&tokens)?;
@@ -108,11 +108,7 @@ impl DataSink for RedisProvider {
         Ok(())
     }
 
-    async fn sink_features(
-        &mut self,
-        token: &EdgeToken,
-        features: ClientFeatures,
-    ) -> EdgeResult<()> {
+    async fn sink_features(&self, token: &EdgeToken, features: ClientFeatures) -> EdgeResult<()> {
         let mut client = self.redis_client.write().await;
         let raw_stored_features: Option<String> = client.get(key(token))?;
 
@@ -130,7 +126,7 @@ impl DataSink for RedisProvider {
         Ok(())
     }
 
-    async fn update_last_check(&mut self, token: &EdgeToken) -> EdgeResult<()> {
+    async fn update_last_check(&self, token: &EdgeToken) -> EdgeResult<()> {
         let mut client = self.redis_client.write().await;
         let raw_refresh_tokens: Option<String> = client.get(REFRESH_TOKENS_KEY)?;
 
@@ -155,7 +151,7 @@ impl DataSink for RedisProvider {
     }
 
     async fn update_last_refresh(
-        &mut self,
+        &self,
         token: &EdgeToken,
         etag: Option<EntityTag>,
     ) -> EdgeResult<()> {

--- a/server/src/metrics/client_metrics.rs
+++ b/server/src/metrics/client_metrics.rs
@@ -92,7 +92,7 @@ impl MetricsCache {
                             .or_insert(*added_count);
                     });
                 })
-                .or_insert(metric.clone());
+                .or_insert_with(|| metric.clone());
         }
     }
 }

--- a/server/tests/redis_test.rs
+++ b/server/tests/redis_test.rs
@@ -28,7 +28,7 @@ async fn redis_stores_and_returns_data_correctly() {
     let docker = Cli::default();
     let (_client, url, _node) = setup_redis(&docker);
 
-    let mut redis: RedisProvider = RedisProvider::new(&url).unwrap();
+    let redis: RedisProvider = RedisProvider::new(&url).unwrap();
 
     let token = EdgeToken {
         status: TokenValidationStatus::Validated,
@@ -59,7 +59,7 @@ async fn redis_stores_and_returns_tokens_correctly() {
     let docker = Cli::default();
     let (_client, url, _node) = setup_redis(&docker);
 
-    let mut redis: RedisProvider = RedisProvider::new(&url).unwrap();
+    let redis: RedisProvider = RedisProvider::new(&url).unwrap();
 
     let token = EdgeToken {
         status: TokenValidationStatus::Validated,
@@ -80,7 +80,7 @@ async fn redis_stores_and_returns_refresh_tokens_correctly() {
     let docker = Cli::default();
     let (_client, url, _node) = setup_redis(&docker);
 
-    let mut redis: RedisProvider = RedisProvider::new(&url).unwrap();
+    let redis: RedisProvider = RedisProvider::new(&url).unwrap();
 
     let tokens = vec![TokenRefresh {
         etag: None,
@@ -107,7 +107,7 @@ async fn redis_store_marks_update_correctly() {
     let docker = Cli::default();
     let (_client, url, _node) = setup_redis(&docker);
 
-    let mut redis: RedisProvider = RedisProvider::new(&url).unwrap();
+    let redis: RedisProvider = RedisProvider::new(&url).unwrap();
 
     let token = EdgeToken {
         status: TokenValidationStatus::Validated,


### PR DESCRIPTION
## About the changes

This swaps out the underlying locks in the memory and Redis providers. Instead we use a DashMap, which holds internal locking primitives instead. This in turn means that we remove the lock contention issues when resolving features