### PR TITLE
chore: remove rwlock from validator, client and builder

### DIFF
--- a/server/src/data_sources/builder.rs
+++ b/server/src/data_sources/builder.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use chrono::Duration;
 use reqwest::Url;
-use tokio::sync::RwLock;
 
 use crate::{
     auth::token_validator::TokenValidator,
@@ -26,7 +25,7 @@ pub struct RepositoryInfo {
 pub struct SinkInfo {
     pub sink: Arc<dyn EdgeSink>,
     pub unleash_client: UnleashClient,
-    pub token_validator: Arc<RwLock<TokenValidator>>,
+    pub token_validator: Arc<TokenValidator>,
     pub metrics_interval_seconds: u64,
 }
 
@@ -106,7 +105,7 @@ pub async fn build_source_and_sink(args: CliArgs) -> EdgeResult<RepositoryInfo> 
                 sink_info: Some(SinkInfo {
                     sink,
                     unleash_client,
-                    token_validator: Arc::new(RwLock::new(token_validator)),
+                    token_validator: Arc::new(token_validator),
                     metrics_interval_seconds: edge_args.metrics_interval_seconds,
                 }),
             })

--- a/server/src/edge_api.rs
+++ b/server/src/edge_api.rs
@@ -62,9 +62,7 @@ pub async fn metrics(
     batch_metrics_request: web::Json<BatchMetricsRequestBody>,
     metrics_cache: web::Data<MetricsCache>,
 ) -> EdgeResult<HttpResponse> {
-    {
-        metrics_cache.sink_metrics(&batch_metrics_request.metrics);
-    }
+    metrics_cache.sink_metrics(&batch_metrics_request.metrics);
     Ok(HttpResponse::Accepted().finish())
 }
 

--- a/server/src/internal_backstage.rs
+++ b/server/src/internal_backstage.rs
@@ -4,7 +4,6 @@ use actix_web::{
 };
 use actix_web_opentelemetry::PrometheusMetricsHandler;
 use serde::Serialize;
-use tokio::sync::RwLock;
 
 use crate::types::{BuildInfo, EdgeJsonResult, EdgeSource, EdgeToken};
 
@@ -32,10 +31,8 @@ pub async fn info() -> EdgeJsonResult<BuildInfo> {
 }
 
 #[get("/tokens")]
-pub async fn tokens(
-    edge_source: web::Data<RwLock<dyn EdgeSource>>,
-) -> EdgeJsonResult<Vec<EdgeToken>> {
-    let all_tokens = edge_source.read().await.get_tokens().await?;
+pub async fn tokens(edge_source: web::Data<dyn EdgeSource>) -> EdgeJsonResult<Vec<EdgeToken>> {
+    let all_tokens = edge_source.get_tokens().await?;
     Ok(Json(all_tokens))
 }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -9,7 +9,6 @@ use actix_web_opentelemetry::RequestTracing;
 use clap::Parser;
 use cli::CliArgs;
 
-use tokio::sync::RwLock;
 use unleash_edge::client_api;
 use unleash_edge::data_sources::builder::build_source_and_sink;
 use unleash_edge::edge_api;
@@ -38,7 +37,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let sink_info = repo_info.sink_info;
     let validator = sink_info.as_ref().map(|sink| sink.token_validator.clone());
 
-    let metrics_cache = Arc::new(RwLock::new(MetricsCache::default()));
+    let metrics_cache = Arc::new(MetricsCache::default());
     let metrics_cache_clone = metrics_cache.clone();
 
     let openapi = openapi::ApiDoc::openapi();

--- a/server/src/metrics/client_metrics.rs
+++ b/server/src/metrics/client_metrics.rs
@@ -1,8 +1,7 @@
 use chrono::{DateTime, Utc};
-use std::collections::HashMap;
+use dashmap::DashMap;
 use std::hash::{Hash, Hasher};
 use unleash_types::client_metrics::{ClientApplication, ClientMetricsEnv};
-
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct ApplicationKey {
     pub app_name: String,
@@ -55,23 +54,27 @@ pub struct MetricsBatch {
 
 #[derive(Default, Debug)]
 pub struct MetricsCache {
-    pub applications: HashMap<ApplicationKey, ClientApplication>,
-    pub metrics: HashMap<MetricsKey, ClientMetricsEnv>,
+    pub applications: DashMap<ApplicationKey, ClientApplication>,
+    pub metrics: DashMap<MetricsKey, ClientMetricsEnv>,
 }
 
 impl MetricsCache {
     pub fn get_unsent_metrics(&self) -> MetricsBatch {
         MetricsBatch {
-            applications: self.applications.values().cloned().collect(),
-            metrics: self.metrics.values().cloned().collect(),
+            applications: self
+                .applications
+                .iter()
+                .map(|e| e.value().clone())
+                .collect(),
+            metrics: self.metrics.iter().map(|e| e.value().clone()).collect(),
         }
     }
-    pub fn reset_metrics(&mut self) {
+    pub fn reset_metrics(&self) {
         self.applications.clear();
         self.metrics.clear();
     }
 
-    pub fn sink_metrics(&mut self, metrics: &[ClientMetricsEnv]) {
+    pub fn sink_metrics(&self, metrics: &[ClientMetricsEnv]) {
         for metric in metrics.iter() {
             self.metrics
                 .entry(MetricsKey {
@@ -107,7 +110,7 @@ mod test {
 
     #[test]
     fn cache_aggregates_data_correctly() {
-        let mut cache = MetricsCache::default();
+        let cache = MetricsCache::default();
 
         let base_metric = ClientMetricsEnv {
             app_name: "some-app".into(),
@@ -161,7 +164,7 @@ mod test {
 
     #[test]
     fn cache_aggregates_data_correctly_across_date_boundaries() {
-        let mut cache = MetricsCache::default();
+        let cache = MetricsCache::default();
         let a_long_time_ago = DateTime::parse_from_rfc3339("1867-11-07T12:00:00Z")
             .unwrap()
             .with_timezone(&Utc);
@@ -245,7 +248,7 @@ mod test {
 
     #[test]
     fn cache_clears_metrics_correctly() {
-        let mut cache = MetricsCache::default();
+        let cache = MetricsCache::default();
         let time_stamp = DateTime::parse_from_rfc3339("1867-11-07T12:00:00Z")
             .unwrap()
             .with_timezone(&Utc);


### PR DESCRIPTION
This removes some additional RWLocks that we no longer need