### PR TITLE
feat: Added /api/frontend endpoint to match Unleash

### DIFF
--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -6,10 +6,14 @@ use utoipa::{
 #[derive(OpenApi)]
 #[openapi(
     paths(
-        crate::frontend_api::get_frontend_features,
-        crate::frontend_api::post_frontend_features,
-        crate::frontend_api::get_enabled_frontend_features,
-        crate::frontend_api::post_enabled_frontend_features,
+        crate::frontend_api::get_enabled_proxy,
+        crate::frontend_api::get_enabled_frontend,
+        crate::frontend_api::post_proxy_enabled_features,
+        crate::frontend_api::post_frontend_enabled_features,
+        crate::frontend_api::get_proxy_all_features,
+        crate::frontend_api::get_frontend_all_features,
+        crate::frontend_api::post_proxy_all_features,
+        crate::frontend_api::post_frontend_all_features,
         crate::client_api::features,
         crate::client_api::register,
         crate::client_api::metrics,


### PR DESCRIPTION
## What
This PR adds `/api/frontend` and `/api/frontend/all` for both POST and GET.

## Why
This is done to match the recommended URLs from Unleash server for frontend clients.

## Reminder
We also need to make sure we answer to the /api/frontend/client/register as well, but that's a different PR.