### PR TITLE
fix: Client features were not refreshing.

### DIFF
--- a/server/src/data_sources/memory_provider.rs
+++ b/server/src/data_sources/memory_provider.rs
@@ -4,7 +4,6 @@ use actix_web::http::header::EntityTag;
 use async_trait::async_trait;
 use dashmap::DashMap;
 use unleash_types::client_features::ClientFeatures;
-use unleash_types::Merge;
 
 use super::repository::{DataSink, DataSource};
 
@@ -77,12 +76,7 @@ impl DataSink for MemoryProvider {
     }
 
     async fn sink_features(&self, token: &EdgeToken, features: ClientFeatures) -> EdgeResult<()> {
-        self.data_store
-            .entry(key(token))
-            .and_modify(|data| {
-                *data = data.clone().merge(features.clone());
-            })
-            .or_insert(features);
+        self.data_store.insert(key(token), features);
         Ok(())
     }
 


### PR DESCRIPTION
We incorrectly assumed that our merge method would be enough here, but since the merge method retained the original and deduped, it seems like we tricked ourselves. The fix reduces the action to simply replacing whatever was cached with the newly fetched features from the server

Co-authored-by: Simon Hornby <liquidwicked64@gmail.com>
Co-authored-by: Nuno Gois <nuno.gois@getunleash.io>