### PR TITLE
fix: Move /api/client/register to a post request.

### DIFF
--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -65,7 +65,7 @@ pub struct CliArgs {
     #[command(subcommand)]
     pub mode: EdgeMode,
 
-    /// Instance id. Used for metrics reporting
+    /// Instance id. Used for metrics reporting.
     #[clap(long, env, default_value_t = ulid::Ulid::new().to_string())]
     pub instance_id: String,
 

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -64,6 +64,14 @@ pub struct CliArgs {
 
     #[command(subcommand)]
     pub mode: EdgeMode,
+
+    /// Instance id. Used for metrics reporting
+    #[clap(long, env, default_value_t = ulid::Ulid::new().to_string())]
+    pub instance_id: String,
+
+    /// App name. Used for metrics reporting.
+    #[clap(short, long, env, default_value = "unleash-edge")]
+    pub app_name: String,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/server/src/http/background_send_metrics.rs
+++ b/server/src/http/background_send_metrics.rs
@@ -7,7 +7,7 @@ use crate::types::{
     BatchMetricsRequest, BatchMetricsRequestBody, EdgeResult, EdgeSource, EdgeToken,
 };
 use std::sync::Arc;
-use tracing::warn;
+use tracing::{debug, warn};
 
 pub async fn send_metrics_task(
     metrics_cache: Arc<MetricsCache>,
@@ -22,6 +22,7 @@ pub async fn send_metrics_task(
 
             match api_key {
                 Ok(api_key) => {
+                    debug!("Going to post {metrics:?} for {api_key:?}");
                     let request = BatchMetricsRequest {
                         api_key: api_key.token.clone(),
                         body: BatchMetricsRequestBody {

--- a/server/src/http/unleash_client.rs
+++ b/server/src/http/unleash_client.rs
@@ -11,6 +11,7 @@ use crate::types::{
     ValidateTokensRequest,
 };
 use reqwest::{header, Client};
+use tracing::debug;
 
 use crate::urls::UnleashUrls;
 use crate::{error::EdgeError, types::ClientFeaturesRequest};
@@ -111,10 +112,13 @@ impl UnleashClient {
     }
 
     pub async fn send_batch_metrics(&self, request: BatchMetricsRequest) -> EdgeResult<()> {
+        debug!(
+            "Posting metrics to {}",
+            self.urls.edge_metrics_url.to_string()
+        );
         let result = self
             .backing_client
             .post(self.urls.edge_metrics_url.to_string())
-            .header(reqwest::header::AUTHORIZATION, request.api_key)
             .json(&request.body)
             .send()
             .await
@@ -122,6 +126,7 @@ impl UnleashClient {
         if result.status().is_success() {
             Ok(())
         } else {
+            debug!("{}", result.status());
             Err(EdgeError::EdgeMetricsError)
         }
     }

--- a/server/src/metrics/client_metrics.rs
+++ b/server/src/metrics/client_metrics.rs
@@ -47,6 +47,7 @@ impl PartialEq for MetricsKey {
     }
 }
 
+#[derive(Default, Debug)]
 pub struct MetricsBatch {
     pub applications: Vec<ClientApplication>,
     pub metrics: Vec<ClientMetricsEnv>,
@@ -106,7 +107,7 @@ mod test {
     use std::collections::HashMap;
 
     use chrono::{DateTime, Utc};
-    use unleash_types::client_metrics::ClientMetricsEnv;
+    use unleash_types::client_metrics::{ClientMetricsEnv, ConnectVia};
 
     #[test]
     fn cache_aggregates_data_correctly() {
@@ -274,5 +275,41 @@ mod test {
         assert!(!cache.metrics.is_empty());
         cache.reset_metrics();
         assert!(cache.metrics.is_empty());
+    }
+
+    #[test]
+    fn adding_another_connection_link_works() {
+        let client_application = ClientApplication {
+            app_name: "tests_help".into(),
+            connect_via: None,
+            environment: Some("development".into()),
+            instance_id: Some("test".into()),
+            interval: 60,
+            sdk_version: None,
+            started: Default::default(),
+            strategies: vec![],
+        };
+        let connected_via_test_instance = client_application.connect_via("test", "instance");
+        let connected_via_edge_as_well = connected_via_test_instance.connect_via("edge", "edgeid");
+        assert_eq!(
+            connected_via_test_instance.connect_via.unwrap(),
+            vec![ConnectVia {
+                app_name: "test".into(),
+                instance_id: "instance".into()
+            }]
+        );
+        assert_eq!(
+            connected_via_edge_as_well.connect_via.unwrap(),
+            vec![
+                ConnectVia {
+                    app_name: "test".into(),
+                    instance_id: "instance".into()
+                },
+                ConnectVia {
+                    app_name: "edge".into(),
+                    instance_id: "edgeid".into()
+                }
+            ]
+        )
     }
 }


### PR DESCRIPTION
Earlier we didn't accept metrics from downstream clients because we made a wrong assumption about Request Method type. This PR fixes this and starts accepting client metrics and posting them upstream.

There's a PR open on Unleash to make sure ConnectVia on unleash side is also expecting the { appName, instanceId } struct - https://github.com/Unleash/unleash/pull/3213

Closes #80
