### PR TITLE
docs: Updated benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ Besides dynamic tokens, Edge mode also supports metrics and other advanced featu
 To launch in this mode, run:
 
 ```bash
-$ ./unleash-edge edge --help
+$ unleash-edge edge -h
+Run in edge mode
+
 Usage: unleash-edge edge [OPTIONS] --upstream-url <UPSTREAM_URL>
 
 Options:
@@ -98,12 +100,16 @@ Options:
           Where is your upstream URL. Remember, this is the URL to your instance, without any trailing /api suffix [env: UPSTREAM_URL=]
   -r, --redis-url <REDIS_URL>
           [env: REDIS_URL=]
+  -b, --backup-folder <BACKUP_FOLDER>
+          Edge can periodically persist its state to disk. Tell us where? [env: BACKUP_FOLDER=]
   -m, --metrics-interval-seconds <METRICS_INTERVAL_SECONDS>
           How often should we post metrics upstream? [env: METRICS_INTERVAL_SECONDS=] [default: 60]
   -f, --features-refresh-interval-seconds <FEATURES_REFRESH_INTERVAL_SECONDS>
           How long between each refresh for a token [env: FEATURES_REFRESH_INTERVAL_SECONDS=] [default: 10]
   -t, --tokens <TOKENS>
           Get data for these client tokens at startup. Hot starts your feature cache [env: TOKENS=]
+  -h, --help
+          Print help
 
 ```
 
@@ -138,22 +144,28 @@ Options:
   -t, --tokens <TOKENS>                  [env: TOKENS=]
 ```
 
-### Performance (more to come)
+## Performance
 Unleash edge will scale linearly with CPU. There are k6 benchmarks in the benchmark folder and we've already got some initial numbers from [hey](https://github.com/rakyll/hey).
 
+Do note that the number of requests Edge can handle does depend on the total size of your toggle response. That is, Edge is faster if you only have 10 toggles with 1 strategy each, than it will be with 1000 toggles with multiple strategies on each. Benchmarks here were run with data fetched from the Unleash demo instance (roughly 100kB (350 features / 200 strategies)) as well as against a small dataset of 5 features with one strategy on each. 
+
 Edge was started using
-`docker run --cpus="<cpu>" --memory=128M -p 3063:3063 -e UPSTREAM_URL=<upstream> -e TOKENS="<client token>" unleashorg/unleash-edge:edge -w <number of cpus> edge`
+`docker run --cpus="<cpu>" --memory=128M -p 3063:3063 -e UPSTREAM_URL=<upstream> -e TOKENS="<client token>" unleashorg/unleash-edge:edge -w <number of cpus rounded up to closest integer> edge`
 
 Then we run hey against the proxy endpoint, evaluating toggles
 
+
+### Large Dataset (350 features (100kB))
 ```shell
-$ hey -z 10s -H "Authorization: <frontend token>" http://localhost:3063/api/proxy`
+$ hey -z 10s -H "Authorization: <frontend token>" http://localhost:3063/api/frontend`
 ```
 
-| CPU | Memory | RPS | Endpoint | p95 | 
-| --- | ------ | --- | -------- | --- |  
-| 0.1 | 6.7 Mi | 600 | /api/proxy | 19ms | 
-| 1 | 6.7 Mi | 8000 | /api/proxy | 7.4ms |
+| CPU | Memory | RPS | Endpoint | p95 | Data transferred | 
+| --- | ------ | --- | -------- | --- | ---------------- |
+| 0.1 | 6.7 Mi | 600 | /api/frontend | 103ms | 76Mi | 
+| 1 | 6.7 Mi | 6900 | /api/frontend | 7.4ms | 866Mi |
+| 4 | 9.5 | 25300 | /api/frontend | 2.4ms | 3.2Gi |
+| 8 | 15 | 40921 | /api/frontend | 1.6ms | 5.26Gi |
 
 and against our client features endpoint.
 
@@ -161,12 +173,38 @@ and against our client features endpoint.
 $ hey -z 10s -H "Authorization: <client token>" http://localhost:3063/api/client/features
 ```
 
-| CPU | Memory observed | RPS | Endpoint | p95 | 
-| --- | ------ | --- | -------- | --- |  
-| 0.1 | 6 Mi | 1370 | /api/client/features | 97ms | 
-| 1 | 7 Mi | 15000 | /api/client/features | 4ms |
+| CPU | Memory observed | RPS | Endpoint | p95 | Data transferred |
+| --- | ------ | --- | -------- | --- | ---------------- |
+| 0.1 | 11 Mi | 309 | /api/client/features | 199ms | 300 Mi |
+| 1 | 11 Mi | 3236 | /api/client/features | 16ms | 3 Gi |
+| 4 | 11 Mi | 12815 | /api/client/features | 4.5ms | 14 Gi | 
+| 8 | 17 Mi | 23207 | /api/client/features | 2.7ms | 26 Gi | 
 
+### Small Dataset (5 features (2kB))
 
+```shell
+$ hey -z 10s -H "Authorization: <frontend token>" http://localhost:3063/api/frontend`
+```
+
+| CPU | Memory | RPS | Endpoint | p95 | Data transferred | 
+| --- | ------ | --- | -------- | --- | ---------------- |
+| 0.1 | 4.3 Mi | 3673 | /api/frontend | 93ms | 9Mi | 
+| 1 | 6.7 Mi | 39000 | /api/frontend | 1.6ms | 80Mi |
+| 4 | 6.9 Mi | 110000 | /api/frontend | 600μs | 252Mi |
+| 8 | 12.5 Mi | 141090 | /api/frontend | 600μs | 324Mi |
+
+and against our client features endpoint.
+
+```shell
+$ hey -z 10s -H "Authorization: <client token>" http://localhost:3063/api/client/features
+```
+
+| CPU | Memory observed | RPS | Endpoint | p95 | Data transferred |
+| --- | ------ | --- | -------- | --- | ---------------- |
+| 0.1 | 4 Mi | 3298 | /api/client/features | 92ms | 64 Mi |
+| 1 | 4 Mi | 32360 | /api/client/features | 2ms | 527Mi |
+| 4 | 11 Mi | 95838 | /api/client/features | 600μs | 2.13 Gi | 
+| 8 | 17 Mi | 129381 | /api/client/features | 490μs | 2.87 Gi | 
 
 ## Development
 


### PR DESCRIPTION
### What
This updates docs with benchmarks ran today (March 7th) after having merged our redesign branch that made sure that we cache Yggdrasils computed state per token, rather than rebuild the state for each request that comes in.