### PR TITLE
chore: Added tests for edge and client_api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1458,6 +1458,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2720,6 +2726,7 @@ dependencies = [
  "env_logger",
  "futures",
  "futures-core",
+ "maplit",
  "num_cpus",
  "opentelemetry",
  "opentelemetry-prometheus",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -53,6 +53,7 @@ actix-http = "3.3.0"
 actix-http-test = "3.1.0"
 actix-service = "2.0.2"
 env_logger = "0.10.0"
+maplit = "1.0.2"
 test-case = "3.0.0"
 testcontainers = "0.14.0"
 

--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -3,7 +3,7 @@ use crate::metrics::client_metrics::{ApplicationKey, MetricsCache};
 use crate::tokens::cache_key;
 use crate::types::{EdgeJsonResult, EdgeResult, EdgeToken};
 use actix_web::web::{self, Json};
-use actix_web::{get, post, HttpRequest, HttpResponse};
+use actix_web::{get, post, HttpResponse};
 use dashmap::DashMap;
 use tracing::debug;
 use unleash_types::client_features::ClientFeatures;
@@ -49,8 +49,7 @@ pub async fn features(
 pub async fn register(
     edge_token: EdgeToken,
     connect_via: web::Data<ConnectVia>,
-    _req: HttpRequest,
-    client_application: web::Json<ClientApplication>,
+    client_application: Json<ClientApplication>,
     metrics_cache: web::Data<MetricsCache>,
 ) -> EdgeResult<HttpResponse> {
     let client_application = client_application.into_inner();
@@ -110,7 +109,9 @@ pub fn configure_client_api(cfg: &mut web::ServiceConfig) {
 #[cfg(test)]
 mod tests {
 
-    use std::{collections::HashMap, sync::Arc};
+    use std::io::BufReader;
+    use std::path::PathBuf;
+    use std::{collections::HashMap, fs, sync::Arc};
 
     use crate::metrics::client_metrics::MetricsKey;
 
@@ -123,12 +124,14 @@ mod tests {
         web::{self, Data},
         App,
     };
-    use chrono::{DateTime, Utc};
-    use serde_json::json;
+    use chrono::{DateTime, TimeZone, Utc};
+    use maplit::hashmap;
+    use reqwest::StatusCode;
     use ulid::Ulid;
-    use unleash_types::client_metrics::ClientMetricsEnv;
+    use unleash_types::client_features::{ClientFeature, Constraint, Operator, Strategy};
+    use unleash_types::client_metrics::{ClientMetricsEnv, MetricBucket, ToggleStats};
 
-    async fn make_test_request() -> Request {
+    async fn make_metrics_post_request() -> Request {
         test::TestRequest::post()
             .uri("/api/client/metrics")
             .insert_header(ContentType::json())
@@ -136,20 +139,54 @@ mod tests {
                 "Authorization",
                 "*:development.03fa5f506428fe80ed5640c351c7232e38940814d2923b08f5c05fa7",
             ))
-            .set_json(json!({
-                "appName": "some-app",
-                "instanceId": "some-instance",
-                "bucket": {
-                  "start": "1867-11-07T12:00:00Z",
-                  "stop": "1934-11-07T12:00:00Z",
-                  "toggles": {
-                    "some-feature": {
-                      "yes": 1,
-                      "no": 0
-                    }
-                  }
-                }
+            .set_json(Json(ClientMetrics {
+                app_name: "some-app".into(),
+                instance_id: Some("some-instance".into()),
+                bucket: MetricBucket {
+                    start: Utc.with_ymd_and_hms(1867, 11, 7, 12, 0, 0).unwrap(),
+                    stop: Utc.with_ymd_and_hms(1934, 11, 7, 12, 0, 0).unwrap(),
+                    toggles: hashmap! {
+                        "some-feature".to_string() => ToggleStats {
+                            yes: 1,
+                            no: 0,
+                            variants: hashmap! {}
+                        }
+                    },
+                },
+                environment: Some("development".into()),
             }))
+            .to_request()
+    }
+
+    async fn make_register_post_request(application: ClientApplication) -> Request {
+        test::TestRequest::post()
+            .uri("/api/client/register")
+            .insert_header(ContentType::json())
+            .insert_header((
+                "Authorization",
+                "*:development.03fa5f506428fe80ed5640c351c7232e38940814d2923b08f5c05fa7",
+            ))
+            .set_json(Json(application))
+            .to_request()
+    }
+
+    async fn make_features_get_request() -> Request {
+        test::TestRequest::get()
+            .uri("/api/client/features")
+            .insert_header((
+                "Authorization",
+                "*:development.03fa5f506428fe80ed5640c351c7232e38940814d2923b08f5c05fa7",
+            ))
+            .to_request()
+    }
+
+    async fn make_features_with_production_token() -> Request {
+        test::TestRequest::get()
+            .uri("/api/client/features")
+            .insert_header((
+                "Authorization",
+                "*:production.03fa5f506428fe80ed5640c351c7232e38940814d2923b08f5c05fa7",
+            ))
             .to_request()
     }
 
@@ -164,11 +201,11 @@ mod tests {
                     instance_id: Ulid::new().to_string(),
                 }))
                 .app_data(Data::from(metrics_cache.clone()))
-                .service(web::scope("/api").service(super::metrics)),
+                .service(web::scope("/api").service(metrics)),
         )
         .await;
 
-        let req = make_test_request().await;
+        let req = make_metrics_post_request().await;
         let _result = test::call_and_read_body(&app, req).await;
 
         let cache = metrics_cache.clone();
@@ -200,5 +237,152 @@ mod tests {
         assert_eq!(found_metric.yes, 1);
         assert_eq!(found_metric.no, 0);
         assert_eq!(found_metric.no, expected.no);
+    }
+
+    fn cached_client_features() -> ClientFeatures {
+        ClientFeatures {
+            version: 2,
+            features: vec![
+                ClientFeature {
+                    name: "feature_one".into(),
+                    feature_type: Some("release".into()),
+                    description: Some("test feature".into()),
+                    created_at: Some(Utc::now()),
+                    last_seen_at: None,
+                    enabled: true,
+                    stale: Some(false),
+                    impression_data: Some(false),
+                    project: Some("default".into()),
+                    strategies: Some(vec![
+                        Strategy {
+                            name: "standard".into(),
+                            sort_order: Some(500),
+                            segments: None,
+                            constraints: None,
+                            parameters: None,
+                        },
+                        Strategy {
+                            name: "gradualRollout".into(),
+                            sort_order: Some(100),
+                            segments: None,
+                            constraints: None,
+                            parameters: None,
+                        },
+                    ]),
+                    variants: None,
+                },
+                ClientFeature {
+                    name: "feature_two_no_strats".into(),
+                    feature_type: None,
+                    description: None,
+                    created_at: Some(Utc.with_ymd_and_hms(2022, 12, 5, 12, 31, 0).unwrap()),
+                    last_seen_at: None,
+                    enabled: true,
+                    stale: None,
+                    impression_data: None,
+                    project: Some("default".into()),
+                    strategies: None,
+                    variants: None,
+                },
+                ClientFeature {
+                    name: "feature_three".into(),
+                    feature_type: Some("release".into()),
+                    description: None,
+                    created_at: None,
+                    last_seen_at: None,
+                    enabled: true,
+                    stale: None,
+                    impression_data: None,
+                    project: Some("default".into()),
+                    strategies: Some(vec![
+                        Strategy {
+                            name: "gradualRollout".to_string(),
+                            sort_order: None,
+                            segments: None,
+                            constraints: Some(vec![Constraint {
+                                context_name: "version".to_string(),
+                                operator: Operator::SemverGt,
+                                case_insensitive: false,
+                                inverted: false,
+                                values: None,
+                                value: Some("1.5.0".into()),
+                            }]),
+                            parameters: None,
+                        },
+                        Strategy {
+                            name: "".to_string(),
+                            sort_order: None,
+                            segments: None,
+                            constraints: None,
+                            parameters: None,
+                        },
+                    ]),
+                    variants: None,
+                },
+            ],
+            segments: None,
+            query: None,
+        }
+    }
+
+    fn features_from_disk(path: PathBuf) -> ClientFeatures {
+        let file = fs::File::open(path).unwrap();
+        let reader = BufReader::new(file);
+        serde_json::from_reader(reader).unwrap()
+    }
+
+    #[tokio::test]
+    async fn register_endpoint_correctly_aggregates_applications() {
+        let metrics_cache = Arc::new(MetricsCache::default());
+        let our_app = ConnectVia {
+            app_name: "test".into(),
+            instance_id: Ulid::new().to_string(),
+        };
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(our_app.clone()))
+                .app_data(Data::from(metrics_cache.clone()))
+                .service(web::scope("/api").service(super::register)),
+        )
+        .await;
+        let mut client_app = ClientApplication::new("test_application", 15);
+        client_app.instance_id = Some("test_instance".into());
+        let req = make_register_post_request(client_app.clone()).await;
+        let res = test::call_service(&app, req).await;
+        assert_eq!(res.status(), StatusCode::ACCEPTED);
+        assert_eq!(metrics_cache.applications.len(), 1);
+        let application_key = ApplicationKey {
+            app_name: client_app.app_name.clone(),
+            instance_id: client_app.instance_id.unwrap(),
+        };
+        let saved_app = metrics_cache
+            .applications
+            .get(&application_key)
+            .unwrap()
+            .value()
+            .clone();
+        assert_eq!(saved_app.app_name, client_app.app_name);
+        assert_eq!(saved_app.connect_via, Some(vec![our_app]));
+    }
+
+    #[tokio::test]
+    async fn client_features_endpoint_correctly_returns_cached_features() {
+        let features_cache: Arc<DashMap<String, ClientFeatures>> = Arc::new(DashMap::default());
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::from(features_cache.clone()))
+                .service(web::scope("/api").service(features)),
+        )
+        .await;
+        let client_features = cached_client_features();
+        let example_features = features_from_disk(PathBuf::from("../examples/features.json"));
+        features_cache.insert("development".into(), client_features.clone());
+        features_cache.insert("production".into(), example_features.clone());
+        let req = make_features_get_request().await;
+        let res: ClientFeatures = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(res.features, client_features.features);
+        let req = make_features_with_production_token().await;
+        let res: ClientFeatures = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(res.features.len(), example_features.features.len());
     }
 }

--- a/server/src/edge_api.rs
+++ b/server/src/edge_api.rs
@@ -40,13 +40,16 @@ pub async fn validate(
                     .collect(),
             }))
         }
-        None => Ok(Json(ValidatedTokens {
-            tokens: token_cache
+        None => {
+            let tokens_to_check = tokens.into_inner().tokens;
+            let valid_tokens: Vec<EdgeToken> = tokens_to_check
                 .iter()
-                .filter(|t| t.token_type.is_some())
-                .map(|e| e.value().clone())
-                .collect(),
-        })),
+                .filter_map(|t| token_cache.get(t).map(|e| e.value().clone()))
+                .collect();
+            Ok(Json(ValidatedTokens {
+                tokens: valid_tokens,
+            }))
+        }
     }
 }
 
@@ -71,4 +74,176 @@ pub async fn metrics(
 
 pub fn configure_edge_api(cfg: &mut web::ServiceConfig) {
     cfg.service(validate).service(metrics);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::auth::token_validator::TokenValidator;
+    use crate::edge_api::{metrics, validate};
+    use crate::metrics::client_metrics::MetricsCache;
+    use crate::types::{
+        BatchMetricsRequestBody, EdgeToken, TokenStrings, TokenType, TokenValidationStatus,
+        ValidatedTokens,
+    };
+    use actix_web::http::header::ContentType;
+    use actix_web::web::Json;
+    use actix_web::{test, web, App};
+    use chrono::Utc;
+    use dashmap::DashMap;
+    use reqwest::StatusCode;
+    use std::sync::Arc;
+    use unleash_types::client_metrics::{ClientApplication, ClientMetricsEnv};
+
+    #[tokio::test]
+    pub async fn posting_bulk_metrics_gets_cached_properly() {
+        let metrics_cache = Arc::new(MetricsCache::default());
+        let token_cache: Arc<DashMap<String, EdgeToken>> = Arc::new(DashMap::default());
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::from(metrics_cache.clone()))
+                .app_data(web::Data::from(token_cache.clone()))
+                .service(web::scope("/edge").service(metrics).service(validate)),
+        )
+        .await;
+
+        let request_body = BatchMetricsRequestBody {
+            applications: vec![
+                ClientApplication::new("app_one", 10),
+                ClientApplication::new("app_two", 20),
+            ],
+            metrics: vec![
+                ClientMetricsEnv {
+                    feature_name: "test_feature_one".to_string(),
+                    app_name: "test_application".to_string(),
+                    environment: "development".to_string(),
+                    timestamp: Utc::now(),
+                    yes: 100,
+                    no: 50,
+                    variants: Default::default(),
+                },
+                ClientMetricsEnv {
+                    feature_name: "test_feature_two".to_string(),
+                    app_name: "test_application".to_string(),
+                    environment: "production".to_string(),
+                    timestamp: Utc::now(),
+                    yes: 1000,
+                    no: 800,
+                    variants: Default::default(),
+                },
+            ],
+        };
+        let req = test::TestRequest::post()
+            .uri("/edge/metrics")
+            .insert_header(ContentType::json())
+            .set_json(Json(request_body))
+            .to_request();
+        let res = test::call_service(&app, req).await;
+        assert_eq!(res.status(), StatusCode::ACCEPTED);
+    }
+
+    #[tokio::test]
+    pub async fn validating_incorrect_tokens_returns_empty_list() {
+        let metrics_cache = Arc::new(MetricsCache::default());
+        let token_cache: Arc<DashMap<String, EdgeToken>> = Arc::new(DashMap::default());
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::from(metrics_cache.clone()))
+                .app_data(web::Data::from(token_cache.clone()))
+                .service(web::scope("/edge").service(metrics).service(validate)),
+        )
+        .await;
+        let mut valid_token =
+            EdgeToken::try_from("test-app:development.abcdefghijklmnopqrstu".to_string()).unwrap();
+        valid_token.token_type = Some(TokenType::Client);
+        valid_token.status = TokenValidationStatus::Validated;
+        token_cache.insert(valid_token.token.clone(), valid_token.clone());
+        let token_strings = TokenStrings {
+            tokens: vec!["random_token:rqweqwew.qweqwjeqwkejlqwe".into()],
+        };
+        let req = test::TestRequest::post()
+            .uri("/edge/validate")
+            .insert_header(ContentType::json())
+            .set_json(Json(token_strings))
+            .to_request();
+        let res: ValidatedTokens = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(res.tokens.len(), 0);
+    }
+
+    #[tokio::test]
+    pub async fn validating_a_mix_of_tokens_only_returns_valid_tokens() {
+        let metrics_cache = Arc::new(MetricsCache::default());
+        let token_cache: Arc<DashMap<String, EdgeToken>> = Arc::new(DashMap::default());
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::from(metrics_cache.clone()))
+                .app_data(web::Data::from(token_cache.clone()))
+                .service(web::scope("/edge").service(metrics).service(validate)),
+        )
+        .await;
+        let mut valid_token =
+            EdgeToken::try_from("test-app:development.abcdefghijklmnopqrstu".to_string()).unwrap();
+        valid_token.token_type = Some(TokenType::Client);
+        valid_token.status = TokenValidationStatus::Validated;
+        token_cache.insert(valid_token.token.clone(), valid_token.clone());
+
+        let token_strings = TokenStrings {
+            tokens: vec![
+                "test-app:development.abcdefghijklmnopqrstu".into(),
+                "probablyaninvalidproject:development.some_crazy_secret".into(),
+            ],
+        };
+        let req = test::TestRequest::post()
+            .uri("/edge/validate")
+            .insert_header(ContentType::json())
+            .set_json(Json(token_strings))
+            .to_request();
+        let res: ValidatedTokens = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(res.tokens.len(), 1);
+        assert!(res.tokens.iter().any(|t| t.token == valid_token.token));
+    }
+
+    #[tokio::test]
+    pub async fn adding_a_token_validator_filters_so_only_validated_tokens_are_returned() {
+        let metrics_cache = Arc::new(MetricsCache::default());
+        let token_cache: Arc<DashMap<String, EdgeToken>> = Arc::new(DashMap::default());
+        let token_validator = TokenValidator {
+            unleash_client: Arc::new(Default::default()),
+            token_cache: token_cache.clone(),
+            persistence: None,
+        };
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::from(metrics_cache.clone()))
+                .app_data(web::Data::from(token_cache.clone()))
+                .app_data(web::Data::new(token_validator))
+                .service(web::scope("/edge").service(metrics).service(validate)),
+        )
+        .await;
+        let mut valid_token =
+            EdgeToken::try_from("test-app:development.abcdefghijklmnopqrstu".to_string()).unwrap();
+        valid_token.token_type = Some(TokenType::Client);
+        valid_token.status = TokenValidationStatus::Validated;
+        let mut invalid_token = EdgeToken::try_from(
+            "probablyaninvalidproject:development.some_crazy_secret".to_string(),
+        )
+        .unwrap();
+        invalid_token.status = TokenValidationStatus::Invalid;
+        invalid_token.token_type = Some(TokenType::Admin);
+        token_cache.insert(valid_token.token.clone(), valid_token.clone());
+        token_cache.insert(invalid_token.token.clone(), invalid_token.clone());
+        let token_strings = TokenStrings {
+            tokens: vec![
+                "test-app:development.abcdefghijklmnopqrstu".into(),
+                "probablyaninvalidproject:development.some_crazy_secret".into(),
+            ],
+        };
+        let req = test::TestRequest::post()
+            .uri("/edge/validate")
+            .insert_header(ContentType::json())
+            .set_json(Json(token_strings))
+            .to_request();
+        let res: ValidatedTokens = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(res.tokens.len(), 1);
+        assert!(res.tokens.iter().any(|t| t.token == valid_token.token));
+    }
 }

--- a/server/src/http/mod.rs
+++ b/server/src/http/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(not(tarpaulin_include))]
 pub mod background_send_metrics;
 pub mod feature_refresher;
 pub mod unleash_client;

--- a/server/src/internal_backstage.rs
+++ b/server/src/internal_backstage.rs
@@ -3,10 +3,9 @@ use actix_web::{
     web::{self, Json},
 };
 use actix_web_opentelemetry::PrometheusMetricsHandler;
-use dashmap::DashMap;
 use serde::Serialize;
 
-use crate::types::{BuildInfo, EdgeJsonResult, EdgeToken};
+use crate::types::{BuildInfo, EdgeJsonResult};
 
 #[derive(Debug, Serialize)]
 pub struct EdgeStatus {
@@ -31,21 +30,12 @@ pub async fn info() -> EdgeJsonResult<BuildInfo> {
     Ok(Json(data))
 }
 
-#[get("/tokens")]
-pub async fn tokens(
-    edge_source: web::Data<DashMap<String, EdgeToken>>,
-) -> EdgeJsonResult<Vec<EdgeToken>> {
-    let all_tokens = edge_source.iter().map(|e| e.value().clone()).collect();
-    Ok(Json(all_tokens))
-}
-
 pub fn configure_internal_backstage(
     cfg: &mut web::ServiceConfig,
     metrics_handler: PrometheusMetricsHandler,
 ) {
     cfg.service(health)
         .service(info)
-        .service(tokens)
         .service(web::resource("/metrics").route(web::get().to(metrics_handler)));
 }
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,19 +1,24 @@
-pub mod metrics;
-pub mod prom_metrics;
-
 pub mod auth;
+#[cfg(not(tarpaulin_include))]
 pub mod builder;
+#[cfg(not(tarpaulin_include))]
 pub mod cli;
 pub mod client_api;
 pub mod edge_api;
+#[cfg(not(tarpaulin_include))]
 pub mod error;
 pub mod frontend_api;
 pub mod http;
+pub mod internal_backstage;
+pub mod metrics;
 pub mod middleware;
+#[cfg(not(tarpaulin_include))]
 pub mod openapi;
 pub mod persistence;
+#[cfg(not(tarpaulin_include))]
+pub mod prom_metrics;
+#[cfg(not(tarpaulin_include))]
+pub mod tls;
 pub mod tokens;
 pub mod types;
 pub mod urls;
-
-pub mod internal_backstage;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -16,7 +16,6 @@ use unleash_edge::types::{EdgeToken, TokenRefresh};
 use unleash_types::client_features::ClientFeatures;
 use unleash_types::client_metrics::ConnectVia;
 
-use unleash_edge::client_api;
 use unleash_edge::edge_api;
 use unleash_edge::frontend_api;
 use unleash_edge::internal_backstage;
@@ -24,10 +23,11 @@ use unleash_edge::metrics::client_metrics::MetricsCache;
 use unleash_edge::openapi;
 use unleash_edge::prom_metrics;
 use unleash_edge::{cli, middleware};
-use utoipa_swagger_ui::SwaggerUi;
-mod tls;
+use unleash_edge::{client_api, tls};
 use utoipa::OpenApi;
+use utoipa_swagger_ui::SwaggerUi;
 
+#[cfg(not(tarpaulin_include))]
 #[actix_web::main]
 async fn main() -> Result<(), anyhow::Error> {
     dotenv::dotenv().ok();
@@ -145,6 +145,7 @@ async fn main() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+#[cfg(not(tarpaulin_include))]
 async fn clean_shutdown(
     persistence: Option<Arc<dyn EdgePersistence>>,
     feature_cache: Arc<DashMap<String, ClientFeatures>>,

--- a/server/src/persistence/mod.rs
+++ b/server/src/persistence/mod.rs
@@ -20,6 +20,7 @@ pub trait EdgePersistence: Send + Sync {
     async fn save_features(&self, features: Vec<(String, ClientFeatures)>) -> EdgeResult<()>;
 }
 
+#[cfg(not(tarpaulin_include))]
 pub async fn persist_data(
     persistence: Option<Arc<dyn EdgePersistence>>,
     token_cache: Arc<DashMap<String, EdgeToken>>,

--- a/server/src/tls.rs
+++ b/server/src/tls.rs
@@ -4,9 +4,9 @@ use rustls::{Certificate, PrivateKey, ServerConfig};
 use rustls_pemfile::{certs, pkcs8_private_keys};
 
 use crate::cli::TlsOptions;
-use unleash_edge::error::EdgeError;
+use crate::error::EdgeError;
 
-pub(crate) fn config(tls_config: TlsOptions) -> Result<ServerConfig, EdgeError> {
+pub fn config(tls_config: TlsOptions) -> Result<ServerConfig, EdgeError> {
     let config = ServerConfig::builder()
         .with_safe_defaults()
         .with_no_client_auth();

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -179,7 +179,7 @@ pub struct BatchMetricsRequestBody {
     pub metrics: Vec<ClientMetricsEnv>,
 }
 
-trait ProjectFilter<T> {
+pub trait ProjectFilter<T> {
     fn filter_by_projects(&self, token: &EdgeToken) -> Vec<T>;
 }
 

--- a/server/tarpaulin.toml
+++ b/server/tarpaulin.toml
@@ -1,2 +1,0 @@
-[all]
-exclude-files= ["src/main.rs", ""

--- a/server/tarpaulin.toml
+++ b/server/tarpaulin.toml
@@ -1,0 +1,2 @@
+[all]
+exclude-files= ["src/main.rs", ""


### PR DESCRIPTION
Also added some Tarpaulin exclusion arguments to better reflect code coverage across code that we actually want to cover.

There's still some work to do with regards to having the possibility to instantiate the entire application as a test service for full integration/e2e tests, but this at least covers more logic and also exposed a bug in how we validated keys when not using a token validator (offline mode))

