### PR TITLE
fix: Move token cache resolution out of FromRequest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2752,9 +2752,9 @@ dependencies = [
 
 [[package]]
 name = "unleash-types"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37077eaa34746d302b170815c10a2b94261afed5428a6126fddd9fc6f5c8cfd3"
+checksum = "12c017f4f74da54723023692f157e9ee2d523548f2ffbbfca131e0cf80db8cca"
 dependencies = [
  "base64",
  "chrono",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -44,7 +44,7 @@ tokio = {version = "1.25.0", features = ["macros", "rt-multi-thread", "tracing",
 tracing = {version = "0.1.37", features = ["log"]}
 tracing-subscriber = {version = "0.3.16", features = ["json", "env-filter"]}
 ulid = "1.0.0"
-unleash-types = {version = "0.9.0", features = ["openapi", "hashes"]}
+unleash-types = {version = "0.9.1", features = ["openapi", "hashes"]}
 unleash-yggdrasil = "0.5.3"
 utoipa = {version = "3", features = ["actix_extras", "chrono"]}
 utoipa-swagger-ui = {version = "3", features = ["actix-web"]}

--- a/server/src/auth/token_validator.rs
+++ b/server/src/auth/token_validator.rs
@@ -62,7 +62,6 @@ impl TokenValidator {
                     tokens: token_strings_to_validate,
                 })
                 .await?;
-
             let tokens_to_sink: Vec<EdgeToken> = unknown_tokens
                 .into_iter()
                 .map(|maybe_valid| {

--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -85,12 +85,12 @@ pub(crate) fn build_offline_mode(
     for edge_token in edge_tokens {
         token_cache.insert(edge_token.token.clone(), edge_token.clone());
         features_cache.insert(
-            crate::tokens::cache_key(edge_token.clone()),
+            crate::tokens::cache_key(&edge_token),
             client_features.clone(),
         );
         let mut engine_state = EngineState::default();
         engine_state.take_state(client_features.clone());
-        engine_cache.insert(crate::tokens::cache_key(edge_token.clone()), engine_state);
+        engine_cache.insert(crate::tokens::cache_key(&edge_token), engine_state);
     }
     Ok((token_cache, features_cache, engine_cache))
 }

--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -26,12 +26,19 @@ use unleash_types::client_metrics::{
 pub async fn features(
     edge_token: EdgeToken,
     features_cache: web::Data<DashMap<String, ClientFeatures>>,
+    token_cache: web::Data<DashMap<String, EdgeToken>>,
 ) -> EdgeJsonResult<ClientFeatures> {
+    let validated_token = token_cache
+        .get(&edge_token.token)
+        .map(|e| e.value().clone())
+        .ok_or(EdgeError::AuthorizationDenied)?;
     features_cache
-        .get(&cache_key(edge_token.clone()))
+        .get(&cache_key(&edge_token))
         .map(|features| features.clone())
         .map(|client_features| ClientFeatures {
-            features: client_features.features.filter_by_projects(&edge_token),
+            features: client_features
+                .features
+                .filter_by_projects(&validated_token),
             ..client_features
         })
         .map(Json)
@@ -175,40 +182,10 @@ mod tests {
             .to_request()
     }
 
-    async fn make_features_request_with_development_token() -> Request {
+    async fn make_features_request_with_token(token: EdgeToken) -> Request {
         test::TestRequest::get()
             .uri("/api/client/features")
-            .insert_header((
-                "Authorization",
-                "*:development.03fa5f506428fe80ed5640c351c7232e38940814d2923b08f5c05fa7",
-            ))
-            .to_request()
-    }
-
-    async fn make_features_request_with_production_token() -> Request {
-        test::TestRequest::get()
-            .uri("/api/client/features")
-            .insert_header((
-                "Authorization",
-                "*:production.03fa5f506428fe80ed5640c351c7232e38940814d2923b08f5c05fa7",
-            ))
-            .to_request()
-    }
-
-    async fn make_features_request_with_demo_app_production_token() -> Request {
-        test::TestRequest::get()
-            .uri("/api/client/features")
-            .insert_header((
-                "Authorization",
-                "demo-app:production.03fa5f506428fe80ed5640c351c7232e38940814d2923b08f5c05fa7",
-            ))
-            .to_request()
-    }
-
-    async fn make_features_request_with_eg_dx_unleash_cloud_project_token() -> Request {
-        test::TestRequest::get()
-            .uri("/api/client/features")
-            .insert_header(("Authorization", "[]:production.puff_the_magic_dragon"))
+            .insert_header(("Authorization", token.token))
             .to_request()
     }
 
@@ -390,9 +367,11 @@ mod tests {
     #[tokio::test]
     async fn client_features_endpoint_correctly_returns_cached_features() {
         let features_cache: Arc<DashMap<String, ClientFeatures>> = Arc::new(DashMap::default());
+        let token_cache: Arc<DashMap<String, EdgeToken>> = Arc::new(DashMap::default());
         let app = test::init_service(
             App::new()
                 .app_data(Data::from(features_cache.clone()))
+                .app_data(Data::from(token_cache.clone()))
                 .service(web::scope("/api").service(features)),
         )
         .await;
@@ -400,10 +379,24 @@ mod tests {
         let example_features = features_from_disk(PathBuf::from("../examples/features.json"));
         features_cache.insert("development".into(), client_features.clone());
         features_cache.insert("production".into(), example_features.clone());
-        let req = make_features_request_with_development_token().await;
+        let mut token = EdgeToken::try_from(
+            "*:development.03fa5f506428fe80ed5640c351c7232e38940814d2923b08f5c05fa7".to_string(),
+        )
+        .unwrap();
+        token.token_type = Some(TokenType::Client);
+        token.status = TokenValidationStatus::Validated;
+        token_cache.insert(token.token.clone(), token.clone());
+        let req = make_features_request_with_token(token.clone()).await;
         let res: ClientFeatures = test::call_and_read_body_json(&app, req).await;
         assert_eq!(res.features, client_features.features);
-        let req = make_features_request_with_production_token().await;
+        let mut production_token = EdgeToken::try_from(
+            "*:production.03fa5f506428fe80ed5640c351c7232e38940814d2923b08f5c05fa7".to_string(),
+        )
+        .unwrap();
+        production_token.token_type = Some(TokenType::Client);
+        production_token.status = TokenValidationStatus::Validated;
+        token_cache.insert(production_token.token.clone(), production_token.clone());
+        let req = make_features_request_with_token(production_token.clone()).await;
         let res: ClientFeatures = test::call_and_read_body_json(&app, req).await;
         assert_eq!(res.features.len(), example_features.features.len());
     }
@@ -411,15 +404,24 @@ mod tests {
     #[tokio::test]
     async fn client_features_endpoint_filters_on_project_access_in_token() {
         let features_cache: Arc<DashMap<String, ClientFeatures>> = Arc::new(DashMap::default());
+        let token_cache: Arc<DashMap<String, EdgeToken>> = Arc::new(DashMap::default());
         let app = test::init_service(
             App::new()
                 .app_data(Data::from(features_cache.clone()))
+                .app_data(Data::from(token_cache.clone()))
                 .service(web::scope("/api").service(features)),
         )
         .await;
+        let mut edge_token = EdgeToken::try_from(
+            "demo-app:production.03fa5f506428fe80ed5640c351c7232e38940814d2923b08f5c05fa7"
+                .to_string(),
+        )
+        .unwrap();
+        edge_token.token_type = Some(TokenType::Client);
+        token_cache.insert(edge_token.token.clone(), edge_token.clone());
         let example_features = features_from_disk(PathBuf::from("../examples/features.json"));
         features_cache.insert("production".into(), example_features.clone());
-        let req = make_features_request_with_demo_app_production_token().await;
+        let req = make_features_request_with_token(edge_token.clone()).await;
         let res: ClientFeatures = test::call_and_read_body_json(&app, req).await;
         assert_eq!(res.features.len(), 5);
         assert!(res
@@ -445,10 +447,9 @@ mod tests {
         token.status = TokenValidationStatus::Validated;
         token.token_type = Some(TokenType::Client);
         token_cache.insert(token.token.clone(), token.clone());
-
         let example_features = features_from_disk(PathBuf::from("../examples/hostedexample.json"));
         features_cache.insert("production".into(), example_features.clone());
-        let req = make_features_request_with_eg_dx_unleash_cloud_project_token().await;
+        let req = make_features_request_with_token(token.clone()).await;
         let res: ClientFeatures = test::call_and_read_body_json(&app, req).await;
         assert_eq!(res.features.len(), 24);
         assert!(res

--- a/server/src/http/feature_refresher.rs
+++ b/server/src/http/feature_refresher.rs
@@ -93,7 +93,7 @@ impl FeatureRefresher {
                                     }
                                     ClientFeaturesResponse::Updated(features, etag) => {
                                         debug!("Got updated client features. Updating features");
-                                        let key = cache_key(refresh.token.clone());
+                                        let key = cache_key(&refresh.token);
                                         self.update_last_refresh(&refresh.token, etag);
                                         self.features_cache.entry(key.clone()).and_modify(|existing_data| {
                                             *existing_data = existing_data.clone().upsert(features.clone());

--- a/server/src/http/unleash_client.rs
+++ b/server/src/http/unleash_client.rs
@@ -11,7 +11,6 @@ use crate::types::{
     ValidateTokensRequest,
 };
 use reqwest::{header, Client};
-use tracing::debug;
 
 use crate::urls::UnleashUrls;
 use crate::{error::EdgeError, types::ClientFeaturesRequest};
@@ -112,10 +111,6 @@ impl UnleashClient {
     }
 
     pub async fn send_batch_metrics(&self, request: BatchMetricsRequestBody) -> EdgeResult<()> {
-        debug!(
-            "Posting metrics to {}",
-            self.urls.edge_metrics_url.to_string()
-        );
         let result = self
             .backing_client
             .post(self.urls.edge_metrics_url.to_string())
@@ -124,10 +119,8 @@ impl UnleashClient {
             .await
             .map_err(|_| EdgeError::EdgeMetricsError)?;
         if result.status().is_success() {
-            debug!("Succesfully posted metrics");
             Ok(())
         } else {
-            debug!("{}", result.status());
             Err(EdgeError::EdgeMetricsError)
         }
     }
@@ -149,7 +142,6 @@ impl UnleashClient {
                     .json::<EdgeTokens>()
                     .await
                     .map_err(|_| EdgeError::EdgeTokenParseError)?;
-
                 Ok(token_response
                     .tokens
                     .into_iter()

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -22,3 +22,18 @@ pub mod tls;
 pub mod tokens;
 pub mod types;
 pub mod urls;
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::io::BufReader;
+    use std::path::PathBuf;
+    use unleash_types::client_features::ClientFeatures;
+
+    pub fn features_from_disk(path: &str) -> ClientFeatures {
+        let path = PathBuf::from(path);
+        let file = fs::File::open(path).unwrap();
+        let reader = BufReader::new(file);
+        serde_json::from_reader(reader).unwrap()
+    }
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -64,7 +64,7 @@ async fn main() -> Result<(), anyhow::Error> {
         let mut app = App::new()
             .app_data(web::Data::new(mode_arg.clone()))
             .app_data(web::Data::new(connect_via.clone()))
-            .app_data(web::Data::new(metrics_cache.clone()))
+            .app_data(web::Data::from(metrics_cache.clone()))
             .app_data(web::Data::from(token_cache.clone()))
             .app_data(web::Data::from(features_cache.clone()))
             .app_data(web::Data::from(engine_cache.clone()));

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -190,7 +190,8 @@ impl ProjectFilter<ClientFeature> for Vec<ClientFeature> {
         self.iter()
             .filter(|feature| {
                 if let Some(feature_project) = &feature.project {
-                    token.projects.contains(&"*".to_string())
+                    token.projects.is_empty()
+                        || token.projects.contains(&"*".to_string())
                         || token.projects.contains(feature_project)
                 } else {
                     false
@@ -205,7 +206,8 @@ impl ProjectFilter<EvaluatedToggle> for Vec<EvaluatedToggle> {
     fn filter_by_projects(&self, token: &EdgeToken) -> Vec<EvaluatedToggle> {
         self.iter()
             .filter(|toggle| {
-                token.projects.contains(&"*".to_string())
+                token.projects.is_empty()
+                    || token.projects.contains(&"*".to_string())
                     || token.projects.contains(&toggle.project)
             })
             .cloned()

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -138,6 +138,8 @@ impl fmt::Debug for TokenRefresh {
     }
 }
 use dashmap::DashMap;
+use unleash_types::frontend::EvaluatedToggle;
+
 #[derive(Clone, Default)]
 pub struct CacheHolder {
     pub token_cache: Arc<DashMap<String, EdgeToken>>,
@@ -196,6 +198,18 @@ impl ProjectFilter<ClientFeature> for Vec<ClientFeature> {
             })
             .cloned()
             .collect::<Vec<ClientFeature>>()
+    }
+}
+
+impl ProjectFilter<EvaluatedToggle> for Vec<EvaluatedToggle> {
+    fn filter_by_projects(&self, token: &EdgeToken) -> Vec<EvaluatedToggle> {
+        self.iter()
+            .filter(|toggle| {
+                token.projects.contains(&"*".to_string())
+                    || token.projects.contains(&toggle.project)
+            })
+            .cloned()
+            .collect()
     }
 }
 


### PR DESCRIPTION
This was unfortunatley the wrong place to have it, it meant we never hit the middleware which validated our token. So unfortunately, we had to make our endpoints depend on the tokencache in order to have the up to date EdgeToken, rather than the one that comes in with the request.

I fear this has broken Offline Mode, so not quite ready to merge just yet

