### PR TITLE
task: Make Feature refresher register as client

### DIFF
--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -166,7 +166,10 @@ async fn build_edge(args: &EdgeArgs) -> EdgeResult<EdgeInfo> {
         .filter(|candidate| candidate.value().token_type == Some(TokenType::Client))
     {
         let _ = feature_refresher
-            .register_token_for_refresh(validated_token.clone())
+            .register_token_for_refresh(
+                validated_token.clone(),
+                args.features_refresh_interval_seconds,
+            )
             .await;
     }
     Ok((

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -9,6 +9,7 @@ pub enum EdgeError {
     AuthorizationPending,
     ClientFeaturesFetchError,
     ClientFeaturesParseError,
+    ClientRegisterError,
     PersistenceError(String),
     EdgeMetricsError,
     EdgeTokenError,
@@ -43,6 +44,9 @@ impl Display for EdgeError {
             EdgeError::ClientFeaturesParseError => {
                 write!(f, "Failed to parse client features")
             }
+            EdgeError::ClientRegisterError => {
+                write!(f, "Failed to register client")
+            }
             EdgeError::InvalidServerUrl(msg) => write!(f, "Failed to parse server url: [{msg}]"),
             EdgeError::EdgeTokenError => write!(f, "Edge token error"),
             EdgeError::EdgeTokenParseError => write!(f, "Failed to parse token response"),
@@ -72,6 +76,7 @@ impl ResponseError for EdgeError {
             EdgeError::EdgeTokenParseError => StatusCode::BAD_REQUEST,
             EdgeError::AuthorizationPending => StatusCode::UNAUTHORIZED,
             EdgeError::EdgeMetricsError => StatusCode::BAD_REQUEST,
+            EdgeError::ClientRegisterError => StatusCode::BAD_REQUEST,
         }
     }
 

--- a/server/src/http/feature_refresher.rs
+++ b/server/src/http/feature_refresher.rs
@@ -28,13 +28,13 @@ pub struct FeatureRefresher {
     pub persistence: Option<Arc<dyn EdgePersistence>>,
 }
 
-fn client_application_from_token(token: EdgeToken) -> ClientApplication {
+fn client_application_from_token(token: EdgeToken, refresh_interval: i64) -> ClientApplication {
     ClientApplication {
         app_name: "unleash_edge".into(),
         connect_via: None,
         environment: token.environment,
         instance_id: None,
-        interval: 5,
+        interval: refresh_interval as u32,
         sdk_version: Some(format!("unleash-edge:{}", build::PKG_VERSION)),
         started: Utc::now(),
         strategies: vec![],
@@ -72,13 +72,17 @@ impl FeatureRefresher {
             .collect()
     }
 
-    pub async fn register_token_for_refresh(&self, token: EdgeToken) -> EdgeResult<()> {
+    pub async fn register_token_for_refresh(
+        &self,
+        token: EdgeToken,
+        features_refresh_interval: i64,
+    ) -> EdgeResult<()> {
         if !self.tokens_to_refresh.contains_key(&token.token) {
             let _ = self
                 .unleash_client
                 .register_as_client(
                     token.token.clone(),
-                    client_application_from_token(token.clone()),
+                    client_application_from_token(token.clone(), features_refresh_interval),
                 )
                 .await;
             let mut registered_tokens: Vec<TokenRefresh> =
@@ -203,7 +207,9 @@ mod tests {
         );
         let token =
             EdgeToken::try_from("*:development.abcdefghijklmnopqrstuvwxyz".to_string()).unwrap();
-        let _ = feature_refresher.register_token_for_refresh(token).await;
+        let _ = feature_refresher
+            .register_token_for_refresh(token, 10)
+            .await;
 
         assert_eq!(feature_refresher.tokens_to_refresh.len(), 1);
     }
@@ -231,13 +237,13 @@ mod tests {
             EdgeToken::try_from("projectc:development.abcdefghijklmnopqrstuvwxyz".to_string())
                 .unwrap();
         let _ = feature_refresher
-            .register_token_for_refresh(project_a_token)
+            .register_token_for_refresh(project_a_token, 10)
             .await;
         let _ = feature_refresher
-            .register_token_for_refresh(project_b_token)
+            .register_token_for_refresh(project_b_token, 10)
             .await;
         let _ = feature_refresher
-            .register_token_for_refresh(project_c_token)
+            .register_token_for_refresh(project_c_token, 10)
             .await;
 
         assert_eq!(feature_refresher.tokens_to_refresh.len(), 3);
@@ -269,16 +275,16 @@ mod tests {
             EdgeToken::try_from("*:development.abcdefghijklmnopqrstuvwxyz".to_string()).unwrap();
 
         let _ = feature_refresher
-            .register_token_for_refresh(project_a_token)
+            .register_token_for_refresh(project_a_token, 10)
             .await;
         let _ = feature_refresher
-            .register_token_for_refresh(project_b_token)
+            .register_token_for_refresh(project_b_token, 10)
             .await;
         let _ = feature_refresher
-            .register_token_for_refresh(project_c_token)
+            .register_token_for_refresh(project_c_token, 10)
             .await;
         let _ = feature_refresher
-            .register_token_for_refresh(wildcard_token)
+            .register_token_for_refresh(wildcard_token, 10)
             .await;
 
         assert_eq!(feature_refresher.tokens_to_refresh.len(), 1);
@@ -314,19 +320,19 @@ mod tests {
         project_a_and_c_token.projects = vec!["projecta".into(), "projectc".into()];
 
         feature_refresher
-            .register_token_for_refresh(project_a_token)
+            .register_token_for_refresh(project_a_token, 10)
             .await
             .unwrap();
         feature_refresher
-            .register_token_for_refresh(project_b_token)
+            .register_token_for_refresh(project_b_token, 10)
             .await
             .unwrap();
         feature_refresher
-            .register_token_for_refresh(project_c_token)
+            .register_token_for_refresh(project_c_token, 10)
             .await
             .unwrap();
         feature_refresher
-            .register_token_for_refresh(project_a_and_c_token)
+            .register_token_for_refresh(project_a_and_c_token, 10)
             .await
             .unwrap();
 
@@ -360,11 +366,11 @@ mod tests {
                 .unwrap();
 
         feature_refresher
-            .register_token_for_refresh(star_token)
+            .register_token_for_refresh(star_token, 10)
             .await
             .unwrap();
         feature_refresher
-            .register_token_for_refresh(project_a_token)
+            .register_token_for_refresh(project_a_token, 10)
             .await
             .unwrap();
 
@@ -394,11 +400,11 @@ mod tests {
         let production_wildcard_token =
             EdgeToken::try_from("*:production.abcdefghijklmnopqrstuvwxyz".to_string()).unwrap();
         feature_refresher
-            .register_token_for_refresh(project_a_token)
+            .register_token_for_refresh(project_a_token, 10)
             .await
             .unwrap();
         feature_refresher
-            .register_token_for_refresh(production_wildcard_token)
+            .register_token_for_refresh(production_wildcard_token, 10)
             .await
             .unwrap();
         assert_eq!(feature_refresher.tokens_to_refresh.len(), 2);


### PR DESCRIPTION
When a new token for registration comes in, feature refresher registers as a client upstream

We've discussed this before. After talking to Gard and looking at what we were using client registrations for, it made sense for Edge to register as a client for Client tokens that it's fetching data for.