### PR TITLE
chore: adds a derive for TokenValidation status

### DIFF
--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -33,17 +33,12 @@ pub enum ClientFeaturesResponse {
     Updated(ClientFeatures, Option<EntityTag>),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Default, Deserialize, utoipa::ToSchema)]
 pub enum TokenValidationStatus {
     Invalid,
+    #[default]
     Unknown,
     Validated,
-}
-
-impl Default for TokenValidationStatus {
-    fn default() -> Self {
-        TokenValidationStatus::Unknown
-    }
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Adds a derive for TokenValidation status with a #[default] on the child enum. This is to prep for the update to Rust 1.68. This is due to an update to Clippy, not Rustc, still compiles on 1.67
