### PR TITLE
chore: update toolchain to rust 1.68

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust
-        run: rustup update 1.67.1 --no-self-update && rustup default 1.67.1
+        run: rustup update 1.68.0 --no-self-update && rustup default 1.68.0
       - name: Use rust cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["server"]
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "0.0.4"
 # The preferred Rust toolchain to use in CI (rustup toolchain syntax)
-rust-toolchain-version = "1.67.1"
+rust-toolchain-version = "1.68.0"
 # CI backends to support (see 'cargo dist generate-ci')
 ci = ["github"]
 # Target platforms to build apps for (Rust target-triple syntax)


### PR DESCRIPTION
Updates our rust toolchain to 1.68. This won't build until #103 is merged, due to a new Clippy warning

Edit: Oh. It passes, looks like we're not failing on Clippy warns