### PR TITLE
task: Prepare a token revalidator

### DIFF
--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -143,7 +143,7 @@ async fn build_edge(args: &EdgeArgs) -> EdgeResult<EdgeInfo> {
         unleash_client,
         feature_cache.clone(),
         engine_cache.clone(),
-        Duration::seconds(args.features_refresh_interval_seconds),
+        Duration::seconds(args.features_refresh_interval_seconds.try_into().unwrap()),
         persistence.clone(),
     ));
     let _ = token_validator.register_tokens(args.tokens.clone()).await;

--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -166,10 +166,7 @@ async fn build_edge(args: &EdgeArgs) -> EdgeResult<EdgeInfo> {
         .filter(|candidate| candidate.value().token_type == Some(TokenType::Client))
     {
         let _ = feature_refresher
-            .register_token_for_refresh(
-                validated_token.clone(),
-                args.features_refresh_interval_seconds,
-            )
+            .register_token_for_refresh(validated_token.clone())
             .await;
     }
     Ok((

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -30,7 +30,11 @@ pub struct EdgeArgs {
     pub metrics_interval_seconds: u64,
     /// How long between each refresh for a token
     #[clap(short, long, env, default_value_t = 10)]
-    pub features_refresh_interval_seconds: i64,
+    pub features_refresh_interval_seconds: u64,
+
+    /// How long between each revalidation of a token
+    #[clap(long, env, default_value_t = 3600)]
+    pub token_revalidation_interval_seconds: u64,
 
     /// Get data for these client tokens at startup. Hot starts your feature cache
     #[clap(short, long, env, value_delimiter = ',')]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -120,7 +120,7 @@ async fn main() -> Result<(), anyhow::Error> {
                     clean_shutdown(persistence.clone(), lazy_feature_cache.clone(), lazy_token_cache.clone(), refresher.tokens_to_refresh.clone()).await;
                     tracing::info!("Actix was shutdown properly");
                 },
-                _ = refresher.refresh_features() => {
+                _ = refresher.start_refresh_features_background_task() => {
                     tracing::info!("Feature refresher unexpectedly shut down");
                 }
                 _ = unleash_edge::http::background_send_metrics::send_metrics_task(metrics_cache_clone.clone(), refresher.unleash_client.clone(), edge.metrics_interval_seconds) => {

--- a/server/src/middleware/validate_token.rs
+++ b/server/src/middleware/validate_token.rs
@@ -1,5 +1,4 @@
 use crate::auth::token_validator::TokenValidator;
-use crate::cli::EdgeMode;
 use crate::http::feature_refresher::FeatureRefresher;
 use crate::types::{EdgeToken, TokenType, TokenValidationStatus};
 use actix_web::{
@@ -17,7 +16,6 @@ pub async fn validate_token(
 ) -> Result<ServiceResponse<impl MessageBody>, actix_web::Error> {
     let maybe_validator = req.app_data::<Data<TokenValidator>>();
     let maybe_refresher = req.app_data::<Data<FeatureRefresher>>();
-    let maybe_edge_mode = req.app_data::<Data<EdgeMode>>();
     let token_cache = req
         .app_data::<Data<DashMap<String, EdgeToken>>>()
         .unwrap()
@@ -41,17 +39,7 @@ pub async fn validate_token(
                         if maybe_refresher.is_some() {
                             let _ = maybe_refresher
                                 .unwrap()
-                                .register_token_for_refresh(
-                                    known_token.clone(),
-                                    maybe_edge_mode
-                                        .map(|e| match e.as_ref() {
-                                            EdgeMode::Offline(_) => 10,
-                                            EdgeMode::Edge(args) => {
-                                                args.features_refresh_interval_seconds
-                                            }
-                                        })
-                                        .unwrap_or(10),
-                                )
+                                .register_token_for_refresh(known_token.clone())
                                 .await;
                         }
                         if req.path().contains("/api/client") {


### PR DESCRIPTION
Edge caching tokens could cause tokens to become out of sync with Unleash Upstream, adding a scheduled background task which ensures that our known tokens are still valid will go a long way towards mitigating this.

Discussion point: Should this also reach into the FeatureRefresh cache if it finds an invalid token and remove the FeatureRefresh entry for invalid tokens.

I feel like it should, or rather, I feel like the FeatureRefresher should check status codes and if it receives 403's it should probably remove the token from its own cache.

TokenValidator being aware of the FeatureRefresh and Engine state caches feels like scope creep for the TokenValidator.

