### PR TITLE
fix: Save checked tokens even if invalid

### DIFF
--- a/server/src/auth/token_validator.rs
+++ b/server/src/auth/token_validator.rs
@@ -1,7 +1,9 @@
 use crate::error::EdgeError;
 use crate::http::unleash_client::UnleashClient;
 use crate::persistence::EdgePersistence;
-use crate::types::{EdgeResult, EdgeToken, TokenValidationStatus, ValidateTokensRequest};
+use crate::types::{
+    EdgeResult, EdgeToken, TokenType, TokenValidationStatus, ValidateTokensRequest,
+};
 use std::sync::Arc;
 
 use dashmap::DashMap;
@@ -77,6 +79,7 @@ impl TokenValidator {
                     } else {
                         EdgeToken {
                             status: crate::types::TokenValidationStatus::Invalid,
+                            token_type: Some(TokenType::Invalid),
                             ..maybe_valid
                         }
                     }

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -25,6 +25,7 @@ pub enum TokenType {
     Frontend,
     Client,
     Admin,
+    Invalid,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
To make sure we don't hammer upstream with validation requests even if edge is under heavy load, this PR allows Edge to save validation results for invalid tokens as well.

fixes: #119

