### PR TITLE
task: Post appropriately sized metric batches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1822,6 +1822,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-static-metric"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8f30cdb09c39930b8fa5e0f23cbb895ab3f766b187403a0ba0956fc1ef4f0e5"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2737,11 +2749,13 @@ dependencies = [
  "env_logger",
  "futures",
  "futures-core",
+ "lazy_static",
  "maplit",
  "num_cpus",
  "opentelemetry",
  "opentelemetry-prometheus",
  "prometheus",
+ "prometheus-static-metric",
  "redis",
  "reqwest",
  "rustls",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -21,18 +21,20 @@ actix-service = "2.0.2"
 actix-web = {version = "4.3.1", features = ["rustls"]}
 actix-web-opentelemetry = {version = "0.13.0", features = ["metrics", "metrics-prometheus"]}
 
-anyhow = "1.0.69"
-async-trait = "0.1.66"
+anyhow = "1.0.70"
+async-trait = "0.1.67"
 chrono = {version = "0.4.24", features = ["serde"]}
 clap = {version = "4.1.13", features = ["derive", "env"]}
 dashmap = "5.4.0"
 dotenv = {version = "0.15.0", features = ["clap"]}
 futures = "0.3.27"
 futures-core = "0.3.27"
+lazy_static = "1.4.0"
 num_cpus = "1.15.0"
 opentelemetry = {version = "0.18.0", features = ["trace", "rt-tokio", "metrics"]}
 opentelemetry-prometheus = "0.11.0"
 prometheus = {version = "0.13.3", features = ["process"]}
+prometheus-static-metric = "0.5.1"
 redis = {version = "0.22.3", features = ["tokio-comp"]}
 reqwest = {version = "0.11.15", default-features = false, features = ["rustls", "json", "rustls-tls"]}
 rustls = "0.20.8"

--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -229,6 +229,7 @@ mod tests {
                 timestamp: DateTime::parse_from_rfc3339("1867-11-07T12:00:00Z")
                     .unwrap()
                     .with_timezone(&Utc),
+                environment: "development".into(),
             })
             .unwrap();
 

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -41,6 +41,7 @@ pub enum EdgeError {
     FrontendNotYetHydrated(FrontendHydrationMissing),
     PersistenceError(String),
     EdgeMetricsError,
+    EdgeMetricsRequestError(StatusCode),
     EdgeTokenError,
     EdgeTokenParseError,
     InvalidBackupFile(String, String),
@@ -83,6 +84,9 @@ impl Display for EdgeError {
             EdgeError::InvalidServerUrl(msg) => write!(f, "Failed to parse server url: [{msg}]"),
             EdgeError::EdgeTokenError => write!(f, "Edge token error"),
             EdgeError::EdgeTokenParseError => write!(f, "Failed to parse token response"),
+            EdgeError::EdgeMetricsRequestError(status_code) => {
+                write!(f, "Failed to post metrics with status code: {status_code}")
+            }
             EdgeError::AuthorizationPending => {
                 write!(f, "No validation for token has happened yet")
             }
@@ -114,6 +118,7 @@ impl ResponseError for EdgeError {
             EdgeError::EdgeMetricsError => StatusCode::BAD_REQUEST,
             EdgeError::ClientRegisterError => StatusCode::BAD_REQUEST,
             EdgeError::FrontendNotYetHydrated(_) => StatusCode::NETWORK_AUTHENTICATION_REQUIRED,
+            EdgeError::EdgeMetricsRequestError(status_code) => *status_code,
         }
     }
 

--- a/server/src/frontend_api.rs
+++ b/server/src/frontend_api.rs
@@ -586,6 +586,7 @@ mod tests {
             .get(&MetricsKey {
                 app_name: "some-app".into(),
                 feature_name: "some-feature".into(),
+                environment: "development".into(),
                 timestamp: DateTime::parse_from_rfc3339("1867-11-07T12:00:00Z")
                     .unwrap()
                     .with_timezone(&Utc),

--- a/server/src/http/background_send_metrics.rs
+++ b/server/src/http/background_send_metrics.rs
@@ -1,10 +1,29 @@
+use actix_web::http::StatusCode;
+use tracing::{error, warn};
+
 use super::unleash_client::UnleashClient;
 use std::time::Duration;
 
-use crate::metrics::client_metrics::MetricsCache;
-use crate::types::BatchMetricsRequestBody;
+use crate::{
+    error::EdgeError,
+    metrics::client_metrics::{size_of_batch, MetricsCache},
+};
+use lazy_static::lazy_static;
+use prometheus::{register_int_gauge, register_int_gauge_vec, IntGauge, IntGaugeVec, Opts};
 use std::sync::Arc;
-use tracing::warn;
+
+lazy_static! {
+    pub static ref METRICS_UPSTREAM_HTTP_ERRORS: IntGaugeVec = register_int_gauge_vec!(
+        Opts::new(
+            "metrics_upstream_http_errors",
+            "Failing requests against upstream metrics endpoint"
+        ),
+        &["status_code"]
+    )
+    .unwrap();
+    pub static ref METRICS_UNEXPECTED_ERRORS: IntGauge =
+        register_int_gauge!(Opts::new("metrics_send_error", "Failures to send metrics")).unwrap();
+}
 
 pub async fn send_metrics_task(
     metrics_cache: Arc<MetricsCache>,
@@ -12,16 +31,38 @@ pub async fn send_metrics_task(
     send_interval: u64,
 ) {
     loop {
-        let metrics = metrics_cache.get_unsent_metrics();
-        let body = BatchMetricsRequestBody {
-            applications: metrics.applications,
-            metrics: metrics.metrics,
-        };
-
-        if let Err(error) = unleash_client.send_batch_metrics(body).await {
-            warn!("Failed to send metrics: {error:?}");
-        } else {
-            metrics_cache.reset_metrics();
+        let batches = metrics_cache.get_appropriately_sized_batches();
+        for batch in batches {
+            if !batch.applications.is_empty() || !batch.metrics.is_empty() {
+                if let Err(edge_error) = unleash_client.send_batch_metrics(batch.clone()).await {
+                    match edge_error {
+                        EdgeError::EdgeMetricsRequestError(status_code) => {
+                            METRICS_UPSTREAM_HTTP_ERRORS
+                                .with_label_values(&[status_code.as_str()])
+                                .inc();
+                            match status_code {
+                                StatusCode::PAYLOAD_TOO_LARGE => error!(
+                                    "Metrics were too large. They were {}",
+                                    size_of_batch(&batch)
+                                ),
+                                StatusCode::BAD_REQUEST => {
+                                    error!(
+                                    "We couldn't format metrics properly. Will drop what we had"
+                                );
+                                }
+                                _ => {
+                                    warn!("Failed to send metrics. Status code was {status_code}. Will reinsert metrics for next attempt");
+                                    metrics_cache.reinsert_batch(batch);
+                                }
+                            }
+                        }
+                        _ => {
+                            warn!("Failed to send metrics: {edge_error:?}");
+                            METRICS_UNEXPECTED_ERRORS.inc();
+                        }
+                    }
+                }
+            }
         }
         tokio::time::sleep(Duration::from_secs(send_interval)).await;
     }

--- a/server/src/http/feature_refresher.rs
+++ b/server/src/http/feature_refresher.rs
@@ -213,12 +213,12 @@ impl FeatureRefresher {
 
         match features_result {
             Ok(feature_response) => match feature_response {
-                ClientFeaturesResponse::NoUpdate(_) => {
-                    debug!("No update needed. Will update last check time");
+                ClientFeaturesResponse::NoUpdate(tag) => {
+                    debug!("No update needed. Will update last check time with {tag}");
                     self.update_last_check(&refresh.token.clone());
                 }
                 ClientFeaturesResponse::Updated(features, etag) => {
-                    debug!("Got updated client features. Updating features");
+                    debug!("Got updated client features. Updating features with {etag:?}");
                     let key = cache_key(&refresh.token);
                     self.update_last_refresh(&refresh.token, etag);
                     self.features_cache

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -76,7 +76,8 @@ async fn main() -> Result<(), anyhow::Error> {
             Some(refresher) => app.app_data(web::Data::from(refresher)),
             None => app,
         };
-        app.wrap(Etag::default())
+        app.wrap(actix_web::middleware::Compress::default())
+            .wrap(Etag::default())
             .wrap(cors_middleware)
             .wrap(RequestTracing::new())
             .wrap(request_metrics.clone())

--- a/server/src/metrics/client_metrics.rs
+++ b/server/src/metrics/client_metrics.rs
@@ -1,7 +1,13 @@
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
+use tracing::{debug, instrument};
 use unleash_types::client_metrics::{ClientApplication, ClientMetricsEnv};
+
+pub const UPSTREAM_MAX_BODY_SIZE: usize = 100 * 1024;
+pub const BATCH_BODY_SIZE: usize = 95 * 1024;
+
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct ApplicationKey {
     pub app_name: String,
@@ -17,10 +23,31 @@ impl ApplicationKey {
     }
 }
 
+impl From<ClientApplication> for ApplicationKey {
+    fn from(value: ClientApplication) -> Self {
+        Self {
+            app_name: value.app_name,
+            instance_id: value.instance_id.unwrap_or_else(|| "default".into()),
+        }
+    }
+}
+
+impl From<ClientMetricsEnv> for MetricsKey {
+    fn from(value: ClientMetricsEnv) -> Self {
+        Self {
+            app_name: value.app_name,
+            feature_name: value.feature_name,
+            timestamp: value.timestamp,
+            environment: value.environment,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Eq)]
 pub struct MetricsKey {
     pub app_name: String,
     pub feature_name: String,
+    pub environment: String,
     pub timestamp: DateTime<Utc>,
 }
 
@@ -28,6 +55,7 @@ impl Hash for MetricsKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.app_name.hash(state);
         self.feature_name.hash(state);
+        self.environment.hash(state);
         to_time_key(&self.timestamp).hash(state);
     }
 }
@@ -43,11 +71,12 @@ impl PartialEq for MetricsKey {
 
         self.app_name == other.app_name
             && self.feature_name == other.feature_name
+            && self.environment == other.environment
             && self_hour_bin == other_hour_bin
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct MetricsBatch {
     pub applications: Vec<ClientApplication>,
     pub metrics: Vec<ClientMetricsEnv>,
@@ -59,29 +88,118 @@ pub struct MetricsCache {
     pub metrics: DashMap<MetricsKey, ClientMetricsEnv>,
 }
 
+pub fn size_of_batch(batch: &MetricsBatch) -> usize {
+    serde_json::to_string(batch)
+        .map(|s| s.as_bytes().len())
+        .unwrap_or(0)
+}
+
+pub fn sendable(batch: &MetricsBatch) -> bool {
+    size_of_batch(batch) < UPSTREAM_MAX_BODY_SIZE
+}
+
+#[instrument(skip(batch))]
+pub fn cut_into_sendable_batches(batch: MetricsBatch) -> Vec<MetricsBatch> {
+    let batch_count = (size_of_batch(&batch) / BATCH_BODY_SIZE) + 1;
+    let apps_count = batch.applications.len();
+    let apps_per_batch = apps_count / batch_count;
+
+    let metrics_count = batch.metrics.len();
+    let metrics_per_batch = metrics_count / batch_count;
+
+    debug!("Batch count: {batch_count}. Apps per batch: {apps_per_batch}, Metrics per batch: {metrics_per_batch}");
+    (0..=batch_count)
+        .map(|counter| {
+            let apps_iter = batch.applications.iter();
+            let metrics_iter = batch.metrics.iter();
+            let apps_take = if apps_per_batch == 0 && counter == 0 {
+                apps_count
+            } else {
+                apps_per_batch
+            };
+            let metrics_take = if metrics_per_batch == 0 && counter == 0 {
+                metrics_count
+            } else {
+                metrics_per_batch
+            };
+            MetricsBatch {
+                metrics: metrics_iter
+                    .skip(counter * metrics_per_batch)
+                    .take(metrics_take)
+                    .cloned()
+                    .collect(),
+                applications: apps_iter
+                    .skip(counter * apps_per_batch)
+                    .take(apps_take)
+                    .cloned()
+                    .collect(),
+            }
+        })
+        .filter(|b| !b.applications.is_empty() || !b.metrics.is_empty())
+        .collect::<Vec<MetricsBatch>>()
+}
+
 impl MetricsCache {
-    pub fn get_unsent_metrics(&self) -> MetricsBatch {
-        MetricsBatch {
+    /// This is a destructive call. We'll remove all metrics that is due for posting
+    /// Called from [crate::http::background_send_metrics::send_metrics_task] which will reinsert on 5xx server failures, but leave 413 and 400 failures on the floor
+    pub fn get_appropriately_sized_batches(&self) -> Vec<MetricsBatch> {
+        let batch = MetricsBatch {
             applications: self
                 .applications
                 .iter()
                 .map(|e| e.value().clone())
                 .collect(),
-            metrics: self.metrics.iter().map(|e| e.value().clone()).collect(),
+            metrics: self
+                .metrics
+                .iter()
+                .map(|e| e.value().clone())
+                .filter(|m| m.yes > 0 || m.no > 0) // Makes sure that we only return buckets that have values. We should have a test for this :P
+                .collect(),
+        };
+        for app in batch.applications.clone() {
+            self.applications.remove(&ApplicationKey::from(app.clone()));
+        }
+        for metric in batch.metrics.clone() {
+            self.metrics.remove(&MetricsKey::from(metric.clone()));
+        }
+        if sendable(&batch) {
+            vec![batch]
+        } else {
+            debug!(
+                "We have {} applications and {} metrics",
+                batch.applications.len(),
+                batch.metrics.len()
+            );
+            cut_into_sendable_batches(batch)
         }
     }
+
+    pub fn reinsert_batch(&self, batch: MetricsBatch) {
+        for application in batch.applications {
+            self.register_application(application);
+        }
+        self.sink_metrics(&batch.metrics);
+    }
+
     pub fn reset_metrics(&self) {
         self.applications.clear();
         self.metrics.clear();
     }
 
+    pub fn register_application(&self, application: ClientApplication) {
+        self.applications
+            .insert(ApplicationKey::from(application.clone()), application);
+    }
+
     pub fn sink_metrics(&self, metrics: &[ClientMetricsEnv]) {
+        debug!("Sinking {} metrics", metrics.len());
         for metric in metrics.iter() {
             self.metrics
                 .entry(MetricsKey {
                     app_name: metric.app_name.clone(),
                     feature_name: metric.feature_name.clone(),
                     timestamp: metric.timestamp,
+                    environment: metric.environment.clone(),
                 })
                 .and_modify(|feature_stats| {
                     feature_stats.yes += metric.yes;
@@ -104,9 +222,9 @@ impl MetricsCache {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::collections::HashMap;
-
     use chrono::{DateTime, Utc};
+    use std::collections::HashMap;
+    use test_case::test_case;
     use unleash_types::client_metrics::{ClientMetricsEnv, ConnectVia};
 
     #[test]
@@ -142,6 +260,7 @@ mod test {
                 timestamp: DateTime::parse_from_rfc3339("1867-11-07T12:00:00Z")
                     .unwrap()
                     .with_timezone(&Utc),
+                environment: "development".into(),
             })
             .unwrap();
 
@@ -201,6 +320,7 @@ mod test {
             .get(&MetricsKey {
                 app_name: "some-app".into(),
                 feature_name: "some-feature".into(),
+                environment: "development".into(),
                 timestamp: a_long_time_ago,
             })
             .unwrap();
@@ -220,6 +340,7 @@ mod test {
             .get(&MetricsKey {
                 app_name: "some-app".into(),
                 feature_name: "some-feature".into(),
+                environment: "development".into(),
                 timestamp: hundred_years_later,
             })
             .unwrap();
@@ -311,5 +432,96 @@ mod test {
                 }
             ]
         )
+    }
+
+    #[test_case(10, 100, 1; "10 apps 100 toggles. Will not be split")]
+    #[test_case(1, 10000, 16; "1 app 10k toggles, will be split into 16 batches")]
+    #[test_case(1000, 1000, 4; "1000 apps 1000 toggles, will be split into 4 batches")]
+    #[test_case(500, 5000, 10; "500 apps 5000 toggles, will be split into 10 batches")]
+    #[test_case(5000, 1, 14; "5000 apps 1 metric will be split")]
+    fn splits_successfully_into_sendable_chunks(apps: u64, toggles: u64, batch_count: usize) {
+        let apps: Vec<ClientApplication> = (1..=apps)
+            .map(|app_id| ClientApplication {
+                app_name: format!("app_name_{}", app_id),
+                environment: Some("development".into()),
+                instance_id: Some(format!("instance-{}", app_id)),
+                interval: 10,
+                connect_via: Some(vec![ConnectVia {
+                    app_name: "edge".into(),
+                    instance_id: "some-instance-id".into(),
+                }]),
+                sdk_version: Some("some-test-sdk".into()),
+                started: DateTime::parse_from_rfc3339("1867-11-07T12:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+                strategies: vec![],
+            })
+            .collect();
+
+        let toggles: Vec<ClientMetricsEnv> = (1..=toggles)
+            .map(|toggle_id| ClientMetricsEnv {
+                app_name: format!("app_name_{}", toggle_id),
+                feature_name: format!("toggle-{}", toggle_id),
+                environment: "development".into(),
+                timestamp: DateTime::parse_from_rfc3339("1867-11-07T12:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+                yes: 1,
+                no: 1,
+                variants: HashMap::new(),
+            })
+            .collect();
+
+        let cache = MetricsCache::default();
+        for app in apps.clone() {
+            cache.applications.insert(
+                ApplicationKey {
+                    app_name: app.app_name.clone(),
+                    instance_id: app.instance_id.clone().unwrap_or("unknown".into()),
+                },
+                app,
+            );
+        }
+        cache.sink_metrics(&toggles);
+        let batches = cache.get_appropriately_sized_batches();
+
+        assert_eq!(batches.len(), batch_count);
+        assert!(batches.iter().all(sendable));
+        // Check that we have no duplicates
+        let applications_sent_count = batches.iter().flat_map(|b| b.applications.clone()).count();
+
+        assert_eq!(applications_sent_count, apps.len());
+
+        let metrics_sent_count = batches.iter().flat_map(|b| b.metrics.clone()).count();
+        assert_eq!(metrics_sent_count, toggles.len());
+    }
+
+    #[test]
+    fn getting_unsent_metrics_filters_out_metrics_with_no_counters() {
+        let cache = MetricsCache::default();
+
+        let base_metric = ClientMetricsEnv {
+            app_name: "some-app".into(),
+            feature_name: "some-feature".into(),
+            environment: "development".into(),
+            timestamp: DateTime::parse_from_rfc3339("1867-11-07T12:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            yes: 0,
+            no: 0,
+            variants: HashMap::new(),
+        };
+
+        let metrics = vec![
+            ClientMetricsEnv {
+                ..base_metric.clone()
+            },
+            ClientMetricsEnv { ..base_metric },
+        ];
+
+        cache.sink_metrics(&metrics);
+        let metrics_batch = cache.get_appropriately_sized_batches();
+        assert_eq!(metrics_batch.len(), 1);
+        assert!(metrics_batch.get(0).unwrap().metrics.is_empty());
     }
 }

--- a/server/src/prom_metrics.rs
+++ b/server/src/prom_metrics.rs
@@ -11,6 +11,8 @@ use prometheus::process_collector::ProcessCollector;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::{EnvFilter, Registry};
 
+use crate::http::background_send_metrics;
+
 fn instantiate_tracing_and_logging() {
     let logger = tracing_subscriber::fmt::layer();
     let env_filter = EnvFilter::try_from_default_env()
@@ -26,6 +28,7 @@ pub fn instantiate(
 ) -> (PrometheusMetricsHandler, RequestMetrics) {
     instantiate_tracing_and_logging();
     let registry = registry.unwrap_or_else(instantiate_registry);
+    register_custom_metrics(&registry);
     instantiate_prometheus_metrics_handler(registry)
 }
 
@@ -67,4 +70,37 @@ fn instantiate_registry() -> prometheus::Registry {
     }
     #[cfg(not(target_os = "linux"))]
     prometheus::Registry::new()
+}
+
+fn register_custom_metrics(registry: &prometheus::Registry) {
+    registry
+        .register(Box::new(
+            background_send_metrics::METRICS_UNEXPECTED_ERRORS.clone(),
+        ))
+        .unwrap();
+    registry
+        .register(Box::new(
+            background_send_metrics::METRICS_UPSTREAM_HTTP_ERRORS.clone(),
+        ))
+        .unwrap();
+    registry
+        .register(Box::new(
+            crate::metrics::client_metrics::METRICS_SIZE_HISTOGRAM.clone(),
+        ))
+        .unwrap();
+    registry
+        .register(Box::new(
+            crate::http::unleash_client::CLIENT_FEATURE_FETCH_FAILURES.clone(),
+        ))
+        .unwrap();
+    registry
+        .register(Box::new(
+            crate::http::unleash_client::CLIENT_REGISTER_FAILURES.clone(),
+        ))
+        .unwrap();
+    registry
+        .register(Box::new(
+            crate::http::unleash_client::TOKEN_VALIDATION_FAILURES.clone(),
+        ))
+        .unwrap();
 }


### PR DESCRIPTION
Previously we would save unacknowledged metrics until upstream accepted the post. This PR, splits into 90kB chunks, listens for http status codes to decide what to do on failure.
* 400 will cause us to drop the metrics we tried to post
* 413 would be a surprise, since we already split into chunks to avoid just this
* other status codes will be reinserted to the cache and tried again next minute.

