### PR TITLE
docs: Note about Unleash 4.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,13 @@ Options:
   -t, --tokens <TOKENS>                  [env: TOKENS=]
 ```
 
-## Metrics
+## [Metrics](https://docs.getunleash.io/reference/api/unleash/metrics)
 
 **❗  Note:**  For Unleash to correctly register SDK usage metrics sent from Edge instances, your Unleash instance must be v4.22 or newer.
+
+Since Edge is designed to avoid overloading its upstream, Edge gathers and accumulates usage metrics from SDKs for a set interval (METRICS_INTERVAL_SECONDS) before posting a batch upstream.
+This reduces load on Unleash instances down to a single call every interval, instead of every single client posting to Unleash for updating metrics.
+Unleash installations older than 4.22 are not able to handle the batch format Edge posts, so with these installations, you won't see any metrics from clients connected to an Edge instance until you're able to update to 4.22 or newer.
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -56,19 +56,24 @@ Options:
 
 ## Getting Unleash Edge
 
-Unleash Edge is distributed as a binary and as a docker image. 
+Unleash Edge is distributed as a binary and as a docker image.
+
 ### Binary
- * The binary is downloadable from our [Releases page](https://github.com/Unleash/unleash-edge/releases/latest). 
- * We're currently building for linux x86_64, windows x86_64, darwin (OS X) x86_64 and darwin (OS X) aarch64 (M1/M2 macs)
- 
+
+- The binary is downloadable from our [Releases page](https://github.com/Unleash/unleash-edge/releases/latest).
+- We're currently building for linux x86_64, windows x86_64, darwin (OS X) x86_64 and darwin (OS X) aarch64 (M1/M2 macs)
+
 ### Docker
- * The docker image gets uploaded to dockerhub and Github Package registry.
- * For dockerhub use the coordinates `unleashorg/unleash-edge:<version>`.
- * For Github package registry use the coordinates `ghpr.io/unleash/unleash-edge:<version>`
- * If you'd like to live on the edge (sic) you can use the tag `edge`. This is built from `HEAD` on each commit
+
+- The docker image gets uploaded to dockerhub and Github Package registry.
+- For dockerhub use the coordinates `unleashorg/unleash-edge:<version>`.
+- For Github package registry use the coordinates `ghpr.io/unleash/unleash-edge:<version>`
+- If you'd like to live on the edge (sic) you can use the tag `edge`. This is built from `HEAD` on each commit
 
 ### Cargo/Rust
+
 If you have the [Rust toolchain](https://rustup.rs) installed you can build a binary for the platform you're running by cloning this repo and running `cargo build --release`. This will give you an `unleash-edge` binary in `./target/release`
+
 ## Concepts
 
 ### Modes
@@ -107,17 +112,17 @@ Edge mode also supports dynamic tokens, meaning that Edge doesn't need a token t
 
 Even though Edge supports dynamic tokens, you still have the option of providing a token through the command line argument or environment variable. This way, since Edge already knows about your token at start up, it will sync your features for that token and should be ready for your requests right away (_warm up / hot start_).
 
-[Front-end tokens](https://docs.getunleash.io/reference/api-tokens-and-client-keys#front-end-tokens) can also be used with `/api/frontend` and `/api/proxy` endpoints, however they are not allowed to fetch features upstream. In order to use these tokens correctly and make sure they return the correct information, it's important that the features they are allowed to access are already present in that Edge node's features cache. The easiest way to ensure this is by passing in at least one client token as one of the command line arguments, ensuring it has access to the same features as the front-end token you'll be using. If you're using a frontend token that doesn't have data in the node's feature cache, you will receive an HTTP Status code: 511 Network Authentication Required along with a body of which project and environment you will need to add a client token for. 
+[Front-end tokens](https://docs.getunleash.io/reference/api-tokens-and-client-keys#front-end-tokens) can also be used with `/api/frontend` and `/api/proxy` endpoints, however they are not allowed to fetch features upstream. In order to use these tokens correctly and make sure they return the correct information, it's important that the features they are allowed to access are already present in that Edge node's features cache. The easiest way to ensure this is by passing in at least one client token as one of the command line arguments, ensuring it has access to the same features as the front-end token you'll be using. If you're using a frontend token that doesn't have data in the node's feature cache, you will receive an HTTP Status code: 511 Network Authentication Required along with a body of which project and environment you will need to add a client token for.
+
 ```json
 {
-    "access": {
-        "environment": "default",
-        "project": "demo-app"
-    },
-    "explanation": "Edge does not yet have data for this token. Please make a call against /api/client/features with a client token that has the same access as your token"
+  "access": {
+    "environment": "default",
+    "project": "demo-app"
+  },
+  "explanation": "Edge does not yet have data for this token. Please make a call against /api/client/features with a client token that has the same access as your token"
 }
 ```
-
 
 To launch in this mode, run:
 
@@ -176,8 +181,14 @@ Options:
   -t, --tokens <TOKENS>                  [env: TOKENS=]
 ```
 
+## Metrics
+
+| :exclamation: | To see SDK usage metrics from Edge instances, you will need Unleash v4.22 or newer. |
+| ------------- | ----------------------------------------------------------------------------------- |
+
 ## Performance
-Unleash edge will scale linearly with CPU. There are k6 benchmarks in the benchmark folder and we've already got some initial numbers from [hey](https://github.com/rakyll/hey).
+
+Unleash Edge will scale linearly with CPU. There are k6 benchmarks in the benchmark folder. We've already got some initial numbers from [hey](https://github.com/rakyll/hey).
 
 Do note that the number of requests Edge can handle does depend on the total size of your toggle response. That is, Edge is faster if you only have 10 toggles with 1 strategy each, than it will be with 1000 toggles with multiple strategies on each. Benchmarks here were run with data fetched from the Unleash demo instance (roughly 100kB (350 features / 200 strategies)) as well as against a small dataset of 5 features with one strategy on each.
 
@@ -186,18 +197,18 @@ Edge was started using
 
 Then we run hey against the proxy endpoint, evaluating toggles
 
-
 ### Large Dataset (350 features (100kB))
+
 ```shell
 $ hey -z 10s -H "Authorization: <frontend token>" http://localhost:3063/api/frontend`
 ```
 
-| CPU | Memory | RPS | Endpoint | p95 | Data transferred |
-| --- | ------ | --- | -------- | --- | ---------------- |
-| 0.1 | 6.7 Mi | 600 | /api/frontend | 103ms | 76Mi |
-| 1 | 6.7 Mi | 6900 | /api/frontend | 7.4ms | 866Mi |
-| 4 | 9.5 | 25300 | /api/frontend | 2.4ms | 3.2Gi |
-| 8 | 15 | 40921 | /api/frontend | 1.6ms | 5.26Gi |
+| CPU | Memory | RPS   | Endpoint      | p95   | Data transferred |
+| --- | ------ | ----- | ------------- | ----- | ---------------- |
+| 0.1 | 6.7 Mi | 600   | /api/frontend | 103ms | 76Mi             |
+| 1   | 6.7 Mi | 6900  | /api/frontend | 7.4ms | 866Mi            |
+| 4   | 9.5    | 25300 | /api/frontend | 2.4ms | 3.2Gi            |
+| 8   | 15     | 40921 | /api/frontend | 1.6ms | 5.26Gi           |
 
 and against our client features endpoint.
 
@@ -205,12 +216,12 @@ and against our client features endpoint.
 $ hey -z 10s -H "Authorization: <client token>" http://localhost:3063/api/client/features
 ```
 
-| CPU | Memory observed | RPS | Endpoint | p95 | Data transferred |
-| --- | ------ | --- | -------- | --- | ---------------- |
-| 0.1 | 11 Mi | 309 | /api/client/features | 199ms | 300 Mi |
-| 1 | 11 Mi | 3236 | /api/client/features | 16ms | 3 Gi |
-| 4 | 11 Mi | 12815 | /api/client/features | 4.5ms | 14 Gi |
-| 8 | 17 Mi | 23207 | /api/client/features | 2.7ms | 26 Gi |
+| CPU | Memory observed | RPS   | Endpoint             | p95   | Data transferred |
+| --- | --------------- | ----- | -------------------- | ----- | ---------------- |
+| 0.1 | 11 Mi           | 309   | /api/client/features | 199ms | 300 Mi           |
+| 1   | 11 Mi           | 3236  | /api/client/features | 16ms  | 3 Gi             |
+| 4   | 11 Mi           | 12815 | /api/client/features | 4.5ms | 14 Gi            |
+| 8   | 17 Mi           | 23207 | /api/client/features | 2.7ms | 26 Gi            |
 
 ### Small Dataset (5 features (2kB))
 
@@ -218,12 +229,12 @@ $ hey -z 10s -H "Authorization: <client token>" http://localhost:3063/api/client
 $ hey -z 10s -H "Authorization: <frontend token>" http://localhost:3063/api/frontend`
 ```
 
-| CPU | Memory | RPS | Endpoint | p95 | Data transferred |
-| --- | ------ | --- | -------- | --- | ---------------- |
-| 0.1 | 4.3 Mi | 3673 | /api/frontend | 93ms | 9Mi |
-| 1 | 6.7 Mi | 39000 | /api/frontend | 1.6ms | 80Mi |
-| 4 | 6.9 Mi | 1.0.10 | /api/frontend | 600μs | 252Mi |
-| 8 | 12.5 Mi | 141090 | /api/frontend | 600μs | 324Mi |
+| CPU | Memory  | RPS    | Endpoint      | p95   | Data transferred |
+| --- | ------- | ------ | ------------- | ----- | ---------------- |
+| 0.1 | 4.3 Mi  | 3673   | /api/frontend | 93ms  | 9Mi              |
+| 1   | 6.7 Mi  | 39000  | /api/frontend | 1.6ms | 80Mi             |
+| 4   | 6.9 Mi  | 1.0.10 | /api/frontend | 600μs | 252Mi            |
+| 8   | 12.5 Mi | 141090 | /api/frontend | 600μs | 324Mi            |
 
 and against our client features endpoint.
 
@@ -231,12 +242,12 @@ and against our client features endpoint.
 $ hey -z 10s -H "Authorization: <client token>" http://localhost:3063/api/client/features
 ```
 
-| CPU | Memory observed | RPS | Endpoint | p95 | Data transferred |
-| --- | ------ | --- | -------- | --- | ---------------- |
-| 0.1 | 4 Mi | 3298 | /api/client/features | 92ms | 64 Mi |
-| 1 | 4 Mi | 32360 | /api/client/features | 2ms | 527Mi |
-| 4 | 11 Mi | 95838 | /api/client/features | 600μs | 2.13 Gi |
-| 8 | 17 Mi | 129381 | /api/client/features | 490μs | 2.87 Gi |
+| CPU | Memory observed | RPS    | Endpoint             | p95   | Data transferred |
+| --- | --------------- | ------ | -------------------- | ----- | ---------------- |
+| 0.1 | 4 Mi            | 3298   | /api/client/features | 92ms  | 64 Mi            |
+| 1   | 4 Mi            | 32360  | /api/client/features | 2ms   | 527Mi            |
+| 4   | 11 Mi           | 95838  | /api/client/features | 600μs | 2.13 Gi          |
+| 8   | 17 Mi           | 129381 | /api/client/features | 490μs | 2.87 Gi          |
 
 ## Why choose Unleash Edge over the Unleash Proxy?
 

--- a/README.md
+++ b/README.md
@@ -183,8 +183,7 @@ Options:
 
 ## Metrics
 
-| :exclamation: | To see SDK usage metrics from Edge instances, you will need Unleash v4.22 or newer. |
-| ------------- | ----------------------------------------------------------------------------------- |
+**❗  Note:**  For Unleash to correctly register SDK usage metrics sent from Edge instances, your Unleash instance must be v4.22 or newer.
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Options:
 
 Since Edge is designed to avoid overloading its upstream, Edge gathers and accumulates usage metrics from SDKs for a set interval (METRICS_INTERVAL_SECONDS) before posting a batch upstream.
 This reduces load on Unleash instances down to a single call every interval, instead of every single client posting to Unleash for updating metrics.
-Unleash installations older than 4.22 are not able to handle the batch format Edge posts, so with these installations, you won't see any metrics from clients connected to an Edge instance until you're able to update to 4.22 or newer.
+Unleash instances running on versions older than 4.22 are not able to handle the batch format posted by Edge, which means you won't see any metrics from clients connected to an Edge instance until you're able to update to 4.22 or newer.
 
 ## Performance
 


### PR DESCRIPTION
So. Due to bulk metrics not being added to Unleash before 4.22, this adds a note to the doc pointing out that you'll need 4.22 in order for metrics to show up.

The important change is L184-L188, the rest is IntelliJ/VSCode trying to be helpful and formatting my markdown file. I'm very open to suggestions to the phrasing here :)