### PR TITLE
fix: Fixes incorrect parsing of extra arguments.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2840,9 +2840,9 @@ dependencies = [
 
 [[package]]
 name = "unleash-types"
-version = "0.9.1"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c017f4f74da54723023692f157e9ee2d523548f2ffbbfca131e0cf80db8cca"
+checksum = "090b39230921b4172d055758306417f15d81202968305a063a62c4ab4975ae39"
 dependencies = [
  "base64",
  "chrono",
@@ -2904,9 +2904,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "utoipa"
-version = "3.1.2"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4587c9492e45df2055a581ca75380f5a11cfe2faaff203e6f3dda3a34bf41fa"
+checksum = "24e7ee17c9ef094b86e1e04170d90765bd76cb381921dacb4d3e175a267bdae6"
 dependencies = [
  "indexmap",
  "serde",
@@ -2916,16 +2916,16 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "3.1.2"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20afd136f55f5607cd6f4854f9900848a37f8ca3a6731bc86ce7be9e8aa31991"
+checksum = "df6f458e5abc811d44aca28455efc4163fb7565a7af2aa32d17611f3d1d9794d"
 dependencies = [
  "lazy_static",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "regex",
- "syn 1.0.109",
+ "syn 2.0.11",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -48,7 +48,7 @@ tokio = {version = "1.27.0", features = ["macros", "rt-multi-thread", "tracing",
 tracing = {version = "0.1.37", features = ["log"]}
 tracing-subscriber = {version = "0.3.16", features = ["json", "env-filter"]}
 ulid = "1.0.0"
-unleash-types = {version = "0.9.1", features = ["openapi", "hashes"]}
+unleash-types = {version = "0.9.4", features = ["openapi", "hashes"]}
 unleash-yggdrasil = "0.5.3"
 utoipa = {version = "3", features = ["actix_extras", "chrono"]}
 utoipa-swagger-ui = {version = "3", features = ["actix-web"]}

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -14,8 +14,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use shadow_rs::shadow;
 use unleash_types::client_features::{ClientFeature, ClientFeatures};
 use unleash_types::client_metrics::{ClientApplication, ClientMetricsEnv};
-use unleash_types::frontend::EvaluatedToggle;
-use unleash_yggdrasil::EngineState;
+use unleash_yggdrasil::{EngineState, ResolvedToggle};
 use utoipa::{IntoParams, ToSchema};
 
 pub type EdgeJsonResult<T> = Result<Json<T>, EdgeError>;
@@ -197,8 +196,8 @@ impl ProjectFilter<ClientFeature> for Vec<ClientFeature> {
     }
 }
 
-impl ProjectFilter<EvaluatedToggle> for Vec<EvaluatedToggle> {
-    fn filter_by_projects(&self, token: &EdgeToken) -> Vec<EvaluatedToggle> {
+impl ProjectFilter<ResolvedToggle> for Vec<ResolvedToggle> {
+    fn filter_by_projects(&self, token: &EdgeToken) -> Vec<ResolvedToggle> {
         self.iter()
             .filter(|toggle| {
                 token.projects.is_empty()


### PR DESCRIPTION
Currently we do not parse extra parameters into the properties holder for the context. This PR updates edge to make sure that overflows (properties we haven't explicitly defined) get parsed into the properties map
