### PR TITLE
fix: Building context parameters using map syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2870,7 +2870,9 @@ dependencies = [
 
 [[package]]
 name = "unleash-yggdrasil"
-version = "0.5.3"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac52da497190a30d7d636ef7c01fa7d57daac39748a2301519266b7ebdb9d63"
 dependencies = [
  "chrono",
  "convert_case 0.6.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2215,6 +2215,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_qs"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0431a35568651e363364210c91983c1da5eb29404d9f0928b67d4ebcfa7d330c"
+dependencies = [
+ "actix-web",
+ "futures",
+ "percent-encoding",
+ "serde",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2825,6 +2839,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
+ "serde_qs",
  "shadow-rs",
  "test-case",
  "testcontainers",
@@ -2841,8 +2856,6 @@ dependencies = [
 [[package]]
 name = "unleash-types"
 version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090b39230921b4172d055758306417f15d81202968305a063a62c4ab4975ae39"
 dependencies = [
  "base64",
  "chrono",
@@ -2856,8 +2869,6 @@ dependencies = [
 [[package]]
 name = "unleash-yggdrasil"
 version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd697f12aea246f16aeab33428db8ed2c9989807a6b9f90ce55b4bd3e8d1e7e"
 dependencies = [
  "chrono",
  "convert_case 0.6.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2855,7 +2855,9 @@ dependencies = [
 
 [[package]]
 name = "unleash-types"
-version = "0.9.4"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fa6ce806a0ce981000da3b532126281e5d07fda344467ac39b03d308f4b792"
 dependencies = [
  "base64",
  "chrono",

--- a/examples/with_custom_constraint.json
+++ b/examples/with_custom_constraint.json
@@ -1,0 +1,41 @@
+{
+  "version": 2,
+  "features": [
+    {
+      "strategies": [
+        {
+          "name": "default",
+          "constraints": [
+            {
+              "values": [
+                "bricks"
+              ],
+              "inverted": false,
+              "operator": "IN",
+              "contextName": "companyId",
+              "caseInsensitive": false
+            }
+          ],
+          "parameters": {}
+        }
+      ],
+      "impressionData": false,
+      "enabled": true,
+      "name": "custom.constraint",
+      "description": "",
+      "project": "default",
+      "stale": false,
+      "type": "release",
+      "variants": []
+    }
+  ],
+  "query": {
+    "environment": "development",
+    "inlineSegmentConstraints": true
+  },
+  "meta": {
+    "revisionId": 21,
+    "etag": "\"76d8bb0e:21\"",
+    "queryHash": "76d8bb0e"
+  }
+}

--- a/proxyclienttest/app.js
+++ b/proxyclienttest/app.js
@@ -1,0 +1,15 @@
+let config = {
+  url: "http://localhost:3063/api/frontend",
+  clientKey: "*:development.38bd47b093eb2ff2f1467276c3ce7ee58407f982138c77cb9bc7ad4e",
+  refreshInterval: 5,
+  appName: 'myExample'
+};
+
+let client = new unleash.UnleashClient(config);
+client.updateContext({ userId: "123", properties: { companyId: 'bricks' }});client.start();
+
+console.log(client.isEnabled('custom.constraint'));
+
+setInterval(() => {
+  console.log(client.isEnabled('custom.constraint'));
+}, 1000);

--- a/proxyclienttest/index.html
+++ b/proxyclienttest/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+  </head>
+  <body>
+    <script src="https://unpkg.com/unleash-proxy-client@2.4.3/build/main.min.js"></script>
+    <script src="/app.js"></script>
+  </body>
+  </html>

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -50,7 +50,7 @@ tracing = {version = "0.1.37", features = ["log"]}
 tracing-subscriber = {version = "0.3.16", features = ["json", "env-filter"]}
 ulid = "1.0.0"
 unleash-types = { version = "0.10.0", features = ["openapi", "hashes"]}
-unleash-yggdrasil = { path = "/home/chriswk/src/github.com/Unleash/yggdrasil/unleash-yggdrasil" }
+unleash-yggdrasil = { version = "0.5.4" }
 utoipa = {version = "3", features = ["actix_extras", "chrono"]}
 utoipa-swagger-ui = {version = "3", features = ["actix-web"]}
 [dev-dependencies]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -43,13 +43,14 @@ rustls = "0.20.8"
 rustls-pemfile = "1.0.2"
 serde = {version = "1.0.160", features = ["derive"]}
 serde_json = "1.0.96"
+serde_qs = { version = "0.12.0", features = ["actix4", "tracing"] }
 shadow-rs = "0.21.0"
 tokio = {version = "1.27.0", features = ["macros", "rt-multi-thread", "tracing", "fs"]}
 tracing = {version = "0.1.37", features = ["log"]}
 tracing-subscriber = {version = "0.3.16", features = ["json", "env-filter"]}
 ulid = "1.0.0"
-unleash-types = {version = "0.9.4", features = ["openapi", "hashes"]}
-unleash-yggdrasil = "0.5.3"
+unleash-types = { path = "/home/chriswk/src/github.com/Unleash/unleash-types-rs", features = ["openapi", "hashes"]}
+unleash-yggdrasil = { path = "/home/chriswk/src/github.com/Unleash/yggdrasil/unleash-yggdrasil"}
 utoipa = {version = "3", features = ["actix_extras", "chrono"]}
 utoipa-swagger-ui = {version = "3", features = ["actix-web"]}
 [dev-dependencies]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -49,8 +49,8 @@ tokio = {version = "1.27.0", features = ["macros", "rt-multi-thread", "tracing",
 tracing = {version = "0.1.37", features = ["log"]}
 tracing-subscriber = {version = "0.3.16", features = ["json", "env-filter"]}
 ulid = "1.0.0"
-unleash-types = { path = "/home/chriswk/src/github.com/Unleash/unleash-types-rs", features = ["openapi", "hashes"]}
-unleash-yggdrasil = { path = "/home/chriswk/src/github.com/Unleash/yggdrasil/unleash-yggdrasil"}
+unleash-types = { version = "0.10.0", features = ["openapi", "hashes"]}
+unleash-yggdrasil = { path = "/home/chriswk/src/github.com/Unleash/yggdrasil/unleash-yggdrasil" }
 utoipa = {version = "3", features = ["actix_extras", "chrono"]}
 utoipa-swagger-ui = {version = "3", features = ["actix-web"]}
 [dev-dependencies]

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -52,6 +52,7 @@ pub enum EdgeError {
     NoTokenProvider,
     TlsError,
     TokenParseError,
+    ContextParseError,
 }
 
 impl Error for EdgeError {}
@@ -98,6 +99,9 @@ impl Display for EdgeError {
             EdgeError::FrontendNotYetHydrated(hydration_info) => {
                 write!(f, "Edge not yet hydrated for {hydration_info:?}")
             }
+            EdgeError::ContextParseError => {
+                write!(f, "Failed to parse query parameters to frontend api")
+            }
         }
     }
 }
@@ -123,6 +127,7 @@ impl ResponseError for EdgeError {
             EdgeError::EdgeMetricsError => StatusCode::BAD_REQUEST,
             EdgeError::ClientRegisterError => StatusCode::BAD_REQUEST,
             EdgeError::FrontendNotYetHydrated(_) => StatusCode::NETWORK_AUTHENTICATION_REQUIRED,
+            EdgeError::ContextParseError => StatusCode::BAD_REQUEST,
             EdgeError::EdgeMetricsRequestError(status_code) => *status_code,
         }
     }

--- a/server/src/frontend_api.rs
+++ b/server/src/frontend_api.rs
@@ -7,6 +7,7 @@ use actix_web::{
 };
 use dashmap::DashMap;
 use serde_qs::actix::QsQuery;
+use tracing::debug;
 use unleash_types::client_features::Context;
 use unleash_types::client_metrics::{ClientApplication, ConnectVia};
 use unleash_types::{
@@ -172,6 +173,7 @@ async fn get_enabled_frontend(
     token_cache: Data<DashMap<String, EdgeToken>>,
     context: QsQuery<Context>,
 ) -> EdgeJsonResult<FrontendResult> {
+    debug!("{context:?}");
     get_enabled_features(edge_token, engine_cache, token_cache, context.into_inner())
 }
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -57,9 +57,14 @@ mod tests {
             token_cache: upstream_token_cache.clone(),
             persistence: None,
         });
+
         test_server(move || {
+            let config = serde_qs::actix::QsQueryConfig::default()
+                .qs_config(serde_qs::Config::new(5, false));
+
             HttpService::new(map_config(
                 App::new()
+                    .app_data(config)
                     .app_data(web::Data::from(token_validator.clone()))
                     .app_data(web::Data::from(upstream_features_cache.clone()))
                     .app_data(web::Data::from(upstream_engine_cache.clone()))

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -56,12 +56,16 @@ async fn main() -> Result<(), anyhow::Error> {
     let openapi = openapi::ApiDoc::openapi();
     let refresher_for_app_data = feature_refresher.clone();
     let server = HttpServer::new(move || {
+        let qs_config =
+            serde_qs::actix::QsQueryConfig::default().qs_config(serde_qs::Config::new(5, false));
+
         let cors_middleware = Cors::default()
             .allow_any_origin()
             .send_wildcard()
             .allow_any_header()
             .allow_any_method();
         let mut app = App::new()
+            .app_data(qs_config)
             .app_data(web::Data::new(mode_arg.clone()))
             .app_data(web::Data::new(connect_via.clone()))
             .app_data(web::Data::from(metrics_cache.clone()))


### PR DESCRIPTION
Currently Edge only supports the explicit context variables; properties[key]=value does not work. Since the proxy clients use the `properties[key]` syntax for setting custom context, this PR adds serde-qs for parsing query strings using the `properties[key]=value` syntax.

It also adds a quick proxy-client-js app for verifying that we can set custom context.
 
fixes: #158 