### PR TITLE
task: added ecr-public login and push target

### DIFF
--- a/.github/workflows/build-docker-release.yaml
+++ b/.github/workflows/build-docker-release.yaml
@@ -36,6 +36,15 @@ jobs:
       - name: Build release for aarch64
         run: |
           cross build --release --target=aarch64-unknown-linux-gnu
+      - name: Login to AWS ECR
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registry-type: public
+          aws-region: 'us-east-1'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secret.AWS_ECR_PUBLIC_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secret.AWS_ECR_PUBLIC_SECRET_ACCESS_KEY }}
       - name: Login to docker hub
         uses: docker/login-action@v2
         with:
@@ -56,6 +65,7 @@ jobs:
           images: |
             unleashorg/unleash-edge
             ghcr.io/Unleash/unleash-edge
+            ${{ steps.login-ecr-public-outputs.registry}}/unleashorg/unleash-edge
           tags: |
             type=edge
             type=match,pattern=unleash-edge-v(\d+\.\d+.\d+),group=1,prefix=v


### PR DESCRIPTION
We've had requests for unleash-proxy to be pushed to ECR public gallery. So in order to get ahead of possible requests, this pushes to ECR public gallery as well as dockerhub and Github Package Registry.

Already added a separate ecr-public role and added the needed secrets.
