### PR TITLE
docs: update note about modes and docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ Unleash Edge is distributed as a binary and as a docker image.
 - For dockerhub use the coordinates `unleashorg/unleash-edge:<version>`.
 - For Github package registry use the coordinates `ghpr.io/unleash/unleash-edge:<version>`
 - If you'd like to live on the edge (sic) you can use the tag `edge`. This is built from `HEAD` on each commit
+- When running the docker image, the same CLI arguments that's available when running the binary is available to your `docker run` command. To start successfully you will need to decide which mode you're running in.
+  - If running in `edge` mode your command should be 
+    - `docker run -p 3063:3063 -e UPSTREAM_URL=<YOUR_UNLEASH_INSTANCE> unleashorg/unleash-edge:v2.0.1 edge`
+  - If running in `offline` mode you will need to provide a volume containing your feature toggles file. An example is available inside the examples folder. To use this, you can use the command
+    - `docker run -v ./examples:/edge/data -p 3063:3063 -e BOOTSTRAP_FILE=/edge/data/features.json -e TOKENS='my-secret-123' unleashorg/unleash-edge:v2.0.1 offline`
 
 ### Cargo/Rust
 


### PR DESCRIPTION
## About the changes
Update the docs to point out that even when running in docker you have to choose which mode you're running in.