### PR TITLE
feat: switch aws auth to oidc

### DIFF
--- a/.github/workflows/docker_ecr_arch64.yaml
+++ b/.github/workflows/docker_ecr_arch64.yaml
@@ -11,7 +11,9 @@ on:
       - ".github/workflows/docker_ecr_arch64.yaml"
     tags:
       - unleash-edge-v[0-9]+.*
-
+permissions:
+  id-token: write
+  contents: read
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -33,12 +35,11 @@ jobs:
       - name: Build release
         run: |
           cross build --release --target=aarch64-unknown-linux-gnu
-      - name: Configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        id: aws-eu-north
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::726824350591:role/unleash-github-ecr-private-publish-role
+          role-session-name: actions-push-to-ecr-private
           aws-region: eu-north-1
       - name: Login to ECR
         id: login-ecr-eu-north


### PR DESCRIPTION
This is to be more secure and rely on what repo it is rather than a secret to push to ECR
