### PR TITLE
feat: Add more visible info and warn logging for http errors

### DIFF
--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -130,7 +130,12 @@ async fn build_edge(args: &EdgeArgs) -> EdgeResult<EdgeInfo> {
 
     let unleash_client = Url::parse(&args.upstream_url.clone())
         .map(|url| {
-            UnleashClient::from_url(url, args.skip_ssl_verification, args.client_tls.clone())
+            UnleashClient::from_url(
+                url,
+                args.skip_ssl_verification,
+                args.client_tls.clone(),
+                args.upstream_certificate_file.clone(),
+            )
         })
         .map(|c| c.with_custom_client_headers(args.custom_client_headers.clone()))
         .map(Arc::new)

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -12,7 +12,7 @@ pub enum EdgeMode {
 }
 
 #[derive(Args, Debug, Clone)]
-pub struct ClientTls {
+pub struct ClientIdentity {
     /// Client certificate chain in PEM encoded X509 format with the leaf certificate first.
     /// The certificate chain should contain any intermediate certificates that should be sent to clients to allow them to build a chain to a trusted root
     #[clap(long, env)]
@@ -26,10 +26,6 @@ pub struct ClientTls {
     #[clap(long, env)]
     /// Passphrase used to unlock the pkcs12 file
     pub pkcs12_passphrase: Option<String>,
-
-    /// Extra certificate passed to the client for building its trust chain. Needs to be in PEM format (crt or pem extensions usually are)
-    #[clap(long, env)]
-    pub upstream_certificate_file: Option<PathBuf>,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -74,7 +70,11 @@ pub struct EdgeArgs {
     pub skip_ssl_verification: bool,
 
     #[clap(flatten)]
-    pub client_tls: Option<ClientTls>,
+    pub client_tls: Option<ClientIdentity>,
+
+    /// Extra certificate passed to the client for building its trust chain. Needs to be in PEM format (crt or pem extensions usually are)
+    #[clap(long, env)]
+    pub upstream_certificate_file: Option<PathBuf>,
 }
 
 pub fn string_to_header_tuple(s: &str) -> Result<(String, String), String> {

--- a/server/src/http/feature_refresher.rs
+++ b/server/src/http/feature_refresher.rs
@@ -326,8 +326,12 @@ mod tests {
 
     #[tokio::test]
     pub async fn registering_token_for_refresh_works() {
-        let unleash_client =
-            UnleashClient::from_url(Url::parse("http://localhost:4242").unwrap(), false, None);
+        let unleash_client = UnleashClient::from_url(
+            Url::parse("http://localhost:4242").unwrap(),
+            false,
+            None,
+            None,
+        );
         let features_cache = Arc::new(DashMap::default());
         let engines_cache = Arc::new(DashMap::default());
 
@@ -350,8 +354,12 @@ mod tests {
 
     #[tokio::test]
     pub async fn registering_multiple_non_overlapping_tokens_will_keep_all() {
-        let unleash_client =
-            UnleashClient::from_url(Url::parse("http://localhost:4242").unwrap(), false, None);
+        let unleash_client = UnleashClient::from_url(
+            Url::parse("http://localhost:4242").unwrap(),
+            false,
+            None,
+            None,
+        );
         let features_cache = Arc::new(DashMap::default());
         let engines_cache = Arc::new(DashMap::default());
         let duration = Duration::seconds(5);
@@ -386,8 +394,12 @@ mod tests {
 
     #[tokio::test]
     pub async fn registering_wildcard_project_token_only_keeps_the_wildcard() {
-        let unleash_client =
-            UnleashClient::from_url(Url::parse("http://localhost:4242").unwrap(), false, None);
+        let unleash_client = UnleashClient::from_url(
+            Url::parse("http://localhost:4242").unwrap(),
+            false,
+            None,
+            None,
+        );
         let features_cache = Arc::new(DashMap::default());
         let engines_cache = Arc::new(DashMap::default());
         let duration = Duration::seconds(5);
@@ -431,8 +443,12 @@ mod tests {
 
     #[tokio::test]
     pub async fn registering_tokens_with_multiple_projects_overwrites_single_tokens() {
-        let unleash_client =
-            UnleashClient::from_url(Url::parse("http://localhost:4242").unwrap(), false, None);
+        let unleash_client = UnleashClient::from_url(
+            Url::parse("http://localhost:4242").unwrap(),
+            false,
+            None,
+            None,
+        );
         let features_cache = Arc::new(DashMap::default());
         let engines_cache = Arc::new(DashMap::default());
         let duration = Duration::seconds(5);
@@ -480,8 +496,12 @@ mod tests {
 
     #[tokio::test]
     pub async fn registering_a_token_that_is_already_subsumed_does_nothing() {
-        let unleash_client =
-            UnleashClient::from_url(Url::parse("http://localhost:4242").unwrap(), false, None);
+        let unleash_client = UnleashClient::from_url(
+            Url::parse("http://localhost:4242").unwrap(),
+            false,
+            None,
+            None,
+        );
         let features_cache = Arc::new(DashMap::default());
         let engines_cache = Arc::new(DashMap::default());
 
@@ -514,8 +534,12 @@ mod tests {
 
     #[tokio::test]
     pub async fn simplification_only_happens_in_same_environment() {
-        let unleash_client =
-            UnleashClient::from_url(Url::parse("http://localhost:4242").unwrap(), false, None);
+        let unleash_client = UnleashClient::from_url(
+            Url::parse("http://localhost:4242").unwrap(),
+            false,
+            None,
+            None,
+        );
         let features_cache = Arc::new(DashMap::default());
         let engines_cache = Arc::new(DashMap::default());
 
@@ -543,8 +567,12 @@ mod tests {
 
     #[tokio::test]
     pub async fn is_able_to_only_fetch_for_tokens_due_to_refresh() {
-        let unleash_client =
-            UnleashClient::from_url(Url::parse("http://localhost:4242").unwrap(), false, None);
+        let unleash_client = UnleashClient::from_url(
+            Url::parse("http://localhost:4242").unwrap(),
+            false,
+            None,
+            None,
+        );
         let features_cache = Arc::new(DashMap::default());
         let engines_cache = Arc::new(DashMap::default());
 


### PR DESCRIPTION
### What
Make sure that upstream certificate and client identity do not depend on each other.
In addition adds more warn and info logging for all upstream communication attempts. Most are added at info!, but the features_fetch call is important enough that we're adding a warn message.