### PR TITLE
chore: allow output from bad requests

### DIFF
--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -196,7 +196,9 @@ impl ResponseError for EdgeError {
                     "access": hydration_info
                 }))
             },
-            _ => HttpResponseBuilder::new(self.status_code()).finish()
+            _ => HttpResponseBuilder::new(self.status_code()).json(json!({
+                "error": self.to_string()
+            }))
         }
     }
 }


### PR DESCRIPTION
## Why

Currently, we have no way of knowing why an API request has failed outside of logging. This means that if we miss a log somewhere we have to patch the code in order to understand why it does what it does. This is worse for users because they can't do that and at very best it means fiddling with logging levels to try to figure out what's going on.

## What

This patches the response to include the scrubbed error message as yielded by the `impl Display for EdgeError` implementation. Incoming SDKs will not understand the response here but they will discard the output anyway. Humans, on the other hand, can now understand why a request failed and hopefully how to address it