### PR TITLE
chore: output logs for any response from feature query in debug output

### DIFF
--- a/server/src/http/feature_refresher.rs
+++ b/server/src/http/feature_refresher.rs
@@ -211,6 +211,11 @@ impl FeatureRefresher {
             })
             .await;
 
+        debug!(
+            "Made a request to unleash for features and received the following: {:#?}",
+            features_result
+        );
+
         match features_result {
             Ok(feature_response) => match feature_response {
                 ClientFeaturesResponse::NoUpdate(tag) => {


### PR DESCRIPTION
## What

Turns up the debug output to yield the full response from feature requests. Should be safe but will definitely be noisy

## Why

Debugging this is tremendously difficult if something goes wrong here and one of the log outputs is not triggered. This turns this up to 11 so that so long as a request is made and debug output is turned on, you should see __something__