### PR TITLE
chore: bump yggdrasil to pull through fix for rollout not working with random

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,9 +3081,9 @@ dependencies = [
 
 [[package]]
 name = "unleash-yggdrasil"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab8fc1501900e89d2287bef94018cc88bcc504d1abeb3bc9efc5d4472dc5658"
+checksum = "584b592b0236701b2280b1ca12e41d902f57ccf26897796d0d1b1f0fe8439291"
 dependencies = [
  "chrono",
  "convert_case 0.6.0",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -50,7 +50,7 @@ tracing = {version = "0.1.37", features = ["log"]}
 tracing-subscriber = {version = "0.3.17", features = ["json", "env-filter"]}
 ulid = "1.0.0"
 unleash-types = { version = "0.10.0", features = ["openapi", "hashes"]}
-unleash-yggdrasil = { version = "0.5.5" }
+unleash-yggdrasil = { version = "0.5.6" }
 utoipa = {version = "3", features = ["actix_extras", "chrono"]}
 utoipa-swagger-ui = {version = "3", features = ["actix-web"]}
 [dev-dependencies]


### PR DESCRIPTION
This bumps Yggdrasil to 0.5.6, which fixes an issue where gradual rollout with a random stickiness would always resolve to false