### PR TITLE
fix: allow multiple client tokens at startup

### DIFF
--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -173,7 +173,7 @@ async fn build_edge(args: &EdgeArgs) -> EdgeResult<EdgeInfo> {
         .iter()
         .filter(|candidate| candidate.value().token_type == Some(TokenType::Client))
     {
-        let _ = feature_refresher
+        feature_refresher
             .register_token_for_refresh(validated_token.clone(), None)
             .await;
     }


### PR DESCRIPTION
Fixes an issue where providing multiple tokens on startup with identical environments and projects would result in no tokens being registered.

This was caused by overeager subsumption of the tokens - identical tokens would subsume each other, and therefore the result of two identical tokens would be no tokens. I've patched this by creating a new list of only tokens that do not have a match for identical project/environment before we do the subsumption.