### PR TITLE
feat: add base uri path to server

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Options:
           Which port should this server listen for HTTP traffic on [env: PORT=] [default: 3063]
   -i, --interface <INTERFACE>
           Which interfaces should this server listen for HTTP traffic on [env: INTERFACE=] [default: 0.0.0.0]
+  -b, --base-path <BASE_PATH>
+          Which base path should this server listen for HTTP traffic on [env: BASE_PATH=] [default: ]
   -w, --workers <WORKERS>
           How many workers should be started to handle requests. Defaults to number of physical cpus [env: WORKERS=] [default: number of physical cpus]
       --tls-enable
@@ -209,7 +211,7 @@ Options:
 
 ## [Metrics](https://docs.getunleash.io/reference/api/unleash/metrics)
 
-**❗  Note:**  For Unleash to correctly register SDK usage metrics sent from Edge instances, your Unleash instance must be v4.22 or newer.
+**❗ Note:** For Unleash to correctly register SDK usage metrics sent from Edge instances, your Unleash instance must be v4.22 or newer.
 
 Since Edge is designed to avoid overloading its upstream, Edge gathers and accumulates usage metrics from SDKs for a set interval (METRICS_INTERVAL_SECONDS) before posting a batch upstream.
 This reduces load on Unleash instances down to a single call every interval, instead of every single client posting to Unleash for updating metrics.

--- a/server/README.md
+++ b/server/README.md
@@ -40,6 +40,8 @@ Options:
           Which port should this server listen for HTTP traffic on [env: PORT=] [default: 3063]
   -i, --interface <INTERFACE>
           Which interfaces should this server listen for HTTP traffic on [env: INTERFACE=] [default: 0.0.0.0]
+  -b, --base-path <BASE_PATH>
+          Which base path should this server listen for HTTP traffic on [env: BASE_PATH=] [default: ]
   -w, --workers <WORKERS>
           How many workers should be started to handle requests. Defaults to number of physical cpus [env: WORKERS=] [default: number of physical cpus]
       --tls-enable
@@ -209,7 +211,7 @@ Options:
 
 ## [Metrics](https://docs.getunleash.io/reference/api/unleash/metrics)
 
-**❗  Note:**  For Unleash to correctly register SDK usage metrics sent from Edge instances, your Unleash instance must be v4.22 or newer.
+**❗ Note:** For Unleash to correctly register SDK usage metrics sent from Edge instances, your Unleash instance must be v4.22 or newer.
 
 Since Edge is designed to avoid overloading its upstream, Edge gathers and accumulates usage metrics from SDKs for a set interval (METRICS_INTERVAL_SECONDS) before posting a batch upstream.
 This reduces load on Unleash instances down to a single call every interval, instead of every single client posting to Unleash for updating metrics.

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -142,6 +142,9 @@ pub struct HttpServerArgs {
     /// Which interfaces should this server listen for HTTP traffic on
     #[clap(short, long, env, default_value = "0.0.0.0")]
     pub interface: String,
+    /// Which base path should this server listen for HTTP traffic on
+    #[clap(short, long, env, default_value = "")]
+    pub base_path: String,
 
     /// How many workers should be started to handle requests.
     /// Defaults to number of physical cpus

--- a/server/tests/base_path_test.rs
+++ b/server/tests/base_path_test.rs
@@ -1,0 +1,59 @@
+#[cfg(test)]
+mod base_path_tests {
+    use reqwest::Client;
+    use std::process::{Command, Stdio};
+    use unleash_edge::types::BuildInfo;
+
+    #[actix_web::test]
+    async fn test_base_path() {
+        let base_path = "/nuno/test";
+
+        // Run the app as a separate process
+        let mut app_process = Command::new("./../target/debug/unleash-edge")
+            .arg("-b")
+            .arg(&base_path)
+            .arg("edge")
+            .arg("-u")
+            .arg("http://localhost:4242")
+            .stdout(Stdio::null()) // Suppress stdout
+            .stderr(Stdio::null()) // Suppress stderr
+            .spawn()
+            .expect("Failed to start the app");
+
+        // Wait for the app to start up
+        std::thread::sleep(std::time::Duration::from_secs(2));
+
+        // Send a request to the app
+        let client = Client::new();
+        let base_url = "http://localhost:3063";
+        let endpoint = "/internal-backstage/info";
+        let url = format!("{}{}{}", base_url, base_path, endpoint);
+
+        let resp = client
+            .get(&url)
+            .send()
+            .await
+            .expect("Failed to send request");
+
+        // Assert that the response status is 200 OK
+        assert!(resp.status().is_success());
+
+        let body = resp
+            .bytes()
+            .await
+            .expect("Failed to retrieve response body as bytes");
+
+        // Deserialize the response body into BuildInfo struct
+        let info: BuildInfo =
+            serde_json::from_slice(&body).expect("Failed to deserialize response body");
+
+        // Assert that the app_name field matches the expected value
+        assert_eq!(info.app_name, "unleash-edge");
+
+        // Terminate the app process
+        app_process.kill().expect("Failed to kill the app process");
+        app_process
+            .wait()
+            .expect("Failed to wait for the app process");
+    }
+}

--- a/server/tests/base_path_test.rs
+++ b/server/tests/base_path_test.rs
@@ -50,6 +50,17 @@ mod base_path_tests {
         // Assert that the app_name field matches the expected value
         assert_eq!(info.app_name, "unleash-edge");
 
+        // Test a different endpoint
+        let url = format!("{}{}{}", base_url, base_path, "/api/client/features");
+        let resp = client
+            .get(&url)
+            .send()
+            .await
+            .expect("Failed to send request");
+
+        // Assert that the response status is 403 Forbidden
+        assert_eq!(resp.status(), 403);
+
         // Terminate the app process
         app_process.kill().expect("Failed to kill the app process");
         app_process

--- a/server/tests/base_path_test.rs
+++ b/server/tests/base_path_test.rs
@@ -6,15 +6,18 @@ mod base_path_tests {
 
     #[actix_web::test]
     async fn test_base_path() {
-        let base_path = "/nuno/test";
+        let base_path = "/test/path";
+        let token = "*:test.test";
 
         // Run the app as a separate process
         let mut app_process = Command::new("./../target/debug/unleash-edge")
             .arg("-b")
             .arg(&base_path)
-            .arg("edge")
-            .arg("-u")
-            .arg("http://localhost:4242")
+            .arg("offline")
+            .arg("-t")
+            .arg(&token)
+            .arg("-b")
+            .arg("../examples/features.json")
             .stdout(Stdio::null()) // Suppress stdout
             .stderr(Stdio::null()) // Suppress stderr
             .spawn()
@@ -53,13 +56,14 @@ mod base_path_tests {
         // Test a different endpoint
         let url = format!("{}{}{}", base_url, base_path, "/api/client/features");
         let resp = client
-            .get(&url)
+            .get(url)
+            .header("Authorization", token)
             .send()
             .await
             .expect("Failed to send request");
 
-        // Assert that the response status is 403 Forbidden
-        assert_eq!(resp.status(), 403);
+        // Assert that the response status is 200 OK
+        assert!(resp.status().is_success());
 
         // Terminate the app process
         app_process.kill().expect("Failed to kill the app process");


### PR DESCRIPTION
Adds support for a base uri path for the server.

E.g.: `unleash-edge -b nuno edge -t "MY_TOKEN" -u http://localhost:4242`
Will listen on `http://localhost:3063/nuno/api/...`

Closes #190