### PR TITLE
feat: makes a post to api/client/features possible by setting a cli arg

### DIFF
--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -135,6 +135,13 @@ pub struct TlsOptions {
 }
 
 #[derive(Args, Debug, Clone)]
+pub struct ExperimentalArgs {
+    /// Exposes the api/client/features endpoint for POST requests. This may be removed in a future release
+    #[clap(env, long, default_value_t = false)]
+    pub enable_post_features: bool,
+}
+
+#[derive(Args, Debug, Clone)]
 pub struct HttpServerArgs {
     /// Which port should this server listen for HTTP traffic on
     #[clap(short, long, env, default_value_t = 3063)]
@@ -150,6 +157,9 @@ pub struct HttpServerArgs {
     /// Defaults to number of physical cpus
     #[clap(short, long, env, default_value_t = num_cpus::get_physical())]
     pub workers: usize,
+
+    #[clap(flatten)]
+    pub experimental: ExperimentalArgs,
 
     #[clap(flatten)]
     pub tls: TlsOptions,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -53,6 +53,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let metrics_cache = Arc::new(MetricsCache::default());
     let metrics_cache_clone = metrics_cache.clone();
+    let experimental_post_enabled = http_args.experimental.enable_post_features;
 
     let openapi = openapi::ApiDoc::openapi();
     let refresher_for_app_data = feature_refresher.clone();
@@ -102,7 +103,13 @@ async fn main() -> Result<(), anyhow::Error> {
                             middleware::validate_token::validate_token,
                         ))
                         .configure(client_api::configure_client_api)
-                        .configure(frontend_api::configure_frontend_api),
+                        .configure(frontend_api::configure_frontend_api)
+                        .configure(|cfg| {
+                            client_api::configure_experimental_post_features(
+                                cfg,
+                                experimental_post_enabled,
+                            )
+                        }),
                 )
                 .service(web::scope("/edge").configure(edge_api::configure_edge_api))
                 .service(


### PR DESCRIPTION
## What

This exposes a boolean CLI arg called `enable_post_features` that will allow POST requests to `api/client/features` 

## Why

This is to support a very specific but ephemeral need for a user. This doesn't do anything useful outside of this need and it's absolutely not useful for our SDKs. To that end, I've placed the CLI arg in a new `flatten`ed CliArg called `ExperimentalArgs` and kept the code here isolated so that it's easy to tear out at a later stage