### PR TITLE
feat: add multiple env variables for configuring Redis

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -25,9 +25,15 @@ This document contains the help content for the `unleash-edge` command-line prog
 * `-i`, `--interface <INTERFACE>` — Which interfaces should this server listen for HTTP traffic on
 
   Default value: `0.0.0.0`
+* `-b`, `--base-path <BASE_PATH>` — Which base path should this server listen for HTTP traffic on
+
+  Default value: ``
 * `-w`, `--workers <WORKERS>` — How many workers should be started to handle requests. Defaults to number of physical cpus
 
   Default value: `16`
+* `--enable-post-features` — Exposes the api/client/features endpoint for POST requests. This may be removed in a future release
+
+  Default value: `false`
 * `--tls-enable` — Should we bind TLS
 
   Default value: `false`
@@ -38,7 +44,7 @@ This document contains the help content for the `unleash-edge` command-line prog
   Default value: `3043`
 * `--instance-id <INSTANCE_ID>` — Instance id. Used for metrics reporting
 
-  Default value: `01H02BTHPET4SB7M4ST7GQPC30`
+  Default value: `01H25S347DVN3YGHBYTV8GBRFM`
 * `-a`, `--app-name <APP_NAME>` — App name. Used for metrics reporting
 
   Default value: `unleash-edge`
@@ -55,7 +61,20 @@ Run in edge mode
 ###### **Options:**
 
 * `-u`, `--upstream-url <UPSTREAM_URL>` — Where is your upstream URL. Remember, this is the URL to your instance, without any trailing /api suffix
-* `-r`, `--redis-url <REDIS_URL>` — A URL pointing to a running Redis instance. Edge will use this instance to persist feature and token data and read this back after restart. Mutually exclusive with the --backup-folder option
+* `--redis-url <REDIS_URL>`
+* `--redis-password <REDIS_PASSWORD>`
+* `--redis-username <REDIS_USERNAME>`
+* `--redis-port <REDIS_PORT>`
+* `--redis-host <REDIS_HOST>`
+* `--redis-secure`
+
+  Default value: `false`
+* `--redis-scheme <REDIS_SCHEME>`
+
+  Default value: `redis`
+
+  Possible values: `redis`, `rediss`, `redis-unix`, `unix`
+
 * `-b`, `--backup-folder <BACKUP_FOLDER>` — A path to a local folder. Edge will write feature and token data to disk in this folder and read this back after restart. Mutually exclusive with the --redis-url option
 * `-m`, `--metrics-interval-seconds <METRICS_INTERVAL_SECONDS>` — How often should we post metrics upstream?
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,6 +584,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-markdown"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "325f50228f76921784b6d9f2d62de6778d834483248eefecd27279174797e579"
+dependencies = [
+ "clap 4.2.7",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3030,6 +3039,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap 4.2.7",
+ "clap-markdown",
  "dashmap",
  "dotenv",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3018,7 +3018,7 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unleash-edge"
-version = "4.1.1"
+version = "5.0.0"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.0.0 (2023-06-01)
+
+### New Features
+
+ - <csr-id-4c187c622a78b7a91b8b3d868e51c51ddd0777c1/> makes a post to api/client/features possible by setting a cli arg
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 1 commit contributed to the release.
+ - 2 days passed between releases.
+ - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
+ - 1 unique issue was worked on: [#197](https://github.com/Unleash/unleash-edge/issues/197)
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **[#197](https://github.com/Unleash/unleash-edge/issues/197)**
+    - Makes a post to api/client/features possible by setting a cli arg ([`4c187c6`](https://github.com/Unleash/unleash-edge/commit/4c187c622a78b7a91b8b3d868e51c51ddd0777c1))
+</details>
+
 ## 4.1.1 (2023-05-30)
 
 ### Bug Fixes
@@ -15,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <csr-read-only-do-not-edit/>
 
- - 1 commit contributed to the release.
+ - 2 commits contributed to the release.
  - 6 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 1 unique issue was worked on: [#196](https://github.com/Unleash/unleash-edge/issues/196)
@@ -28,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  * **[#196](https://github.com/Unleash/unleash-edge/issues/196)**
     - Pulls in fixes from Unleash Types so that Segments correctly update ([`d60702d`](https://github.com/Unleash/unleash-edge/commit/d60702d1693d4723a22443245ffe02e0771cae82))
+ * **Uncategorized**
+    - Release unleash-edge v4.1.1 ([`2464099`](https://github.com/Unleash/unleash-edge/commit/2464099f18c8e5d9c82b377137a1e7679556fdae))
 </details>
 
 ## 4.1.0 (2023-05-23)

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/Unleash/unleash-edge"
 license = "MIT"
 name = "unleash-edge"
 repository = "https://github.com/Unleash/unleash-edge"
-version = "4.1.1"
+version = "5.0.0"
 
 [dependencies]
 actix-cors = "0.6.4"

--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -110,7 +110,7 @@ fn build_offline(offline_args: OfflineArgs) -> EdgeResult<CacheContainer> {
 }
 
 async fn get_data_source(args: &EdgeArgs) -> Option<Arc<dyn EdgePersistence>> {
-    if let Some(redis_url) = args.redis_url.clone() {
+    if let Some(redis_url) = args.redis.clone().and_then(|r| r.to_url()) {
         let redis_client = RedisPersister::new(&redis_url).expect("Failed to connect to Redis");
         return Some(Arc::new(redis_client));
     }

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -44,7 +44,7 @@ pub struct RedisArgs {
     pub redis_host: Option<String>,
     #[clap(long, env, default_value_t = false)]
     pub redis_secure: bool,
-    #[clap(long, env, default_value_t = RedisSchema::Redis, value_enum)]
+    #[clap(long, env, default_value_t = RedisScheme::Redis, value_enum)]
     pub redis_scheme: RedisScheme,
 }
 

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -13,20 +13,20 @@ pub enum EdgeMode {
 }
 
 #[derive(ValueEnum, Debug, Clone)]
-pub enum RedisSchema {
+pub enum RedisScheme {
     Redis,
     Rediss,
     RedisUnix,
     Unix,
 }
 
-impl Display for RedisSchema {
+impl Display for RedisScheme {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            RedisSchema::Redis => write!(f, "redis"),
-            RedisSchema::Rediss => write!(f, "rediss"),
-            RedisSchema::RedisUnix => write!(f, "redis+unix"),
-            RedisSchema::Unix => write!(f, "unix"),
+            RedisScheme::Redis => write!(f, "redis"),
+            RedisScheme::Rediss => write!(f, "rediss"),
+            RedisScheme::RedisUnix => write!(f, "redis+unix"),
+            RedisScheme::Unix => write!(f, "unix"),
         }
     }
 }
@@ -45,7 +45,7 @@ pub struct RedisArgs {
     #[clap(long, env, default_value_t = false)]
     pub redis_secure: bool,
     #[clap(long, env, default_value_t = RedisSchema::Redis, value_enum)]
-    pub redis_scheme: RedisSchema,
+    pub redis_scheme: RedisScheme,
 }
 
 impl RedisArgs {
@@ -71,9 +71,7 @@ impl RedisArgs {
             }).map(|almost_finished_url| {
                 let mut base_url = almost_finished_url;
                 if self.redis_secure {
-                    println!("Yves should be secure");
-                    let scheme = "rediss";
-                    base_url.set_scheme(scheme).expect("Failed to set redis scheme");
+                    base_url.set_scheme("rediss").expect("Failed to set redis scheme");
                 }
                 base_url
         }).map(|f| f.to_string())


### PR DESCRIPTION
In #199 and #200 we discussed that there are instances of Redis where configuring it with a single REDIS_URL variable doesn't make sense. This PR keeps compatibility with previous REDIS_URL configuration, but allows you to use REDIS_HOST, REDIS_USER, REDIS_PASSWORD, REDIS_PORT, REDIS_SCHEME and REDIS_SECURE (overrides scheme and sets it to rediss) to configure Redis as well.

Combinations like REDIS_URL and REDIS_USER and REDIS_PASSWORD is supported. If connecting to REDIS v5 with password you *must* set the REDIS_USER variable to `default`