### PR TITLE
Task/healthcheck subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ed2379f8603fa2b7509891660e802b88c70a79a6427a70abb5968054de2c28"
+checksum = "401a4694d2bf92537b6867d94de48c4842089645fdcdf6c71865b175d836e9c2"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -595,7 +595,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "325f50228f76921784b6d9f2d62de6778d834483248eefecd27279174797e579"
 dependencies = [
- "clap 4.3.1",
+ "clap 4.3.2",
 ]
 
 [[package]]
@@ -613,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e9ef9a08ee1c0e1f2e162121665ac45ac3783b0f897db7244ae75ad9a8f65b"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3081,7 +3081,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "clap 4.3.1",
+ "clap 4.3.2",
  "clap-markdown",
  "dashmap",
  "dotenv",

--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ Options:
           Print help
 ```
 
+### Built-in Health check
+There is now (from 5.1.0) a subcommand named `health` which will ping your health endpoint and exit with status 0 provided the health endpoint returns 200 OK.
+
+Example:
+```shell
+./unleash-edge health
+```
+will check an Edge process running on http://localhost:3063. If you're using base-path or the port variable you should use the `-e --edge-url` CLI arg (or the EDGE_URL environment variable) to tell the health checker where edge is running.
+
+If you're hosting Edge with a self-signed certificate using the tls cli arguments, you should use the `--ca-certificate-file <file_containing_your_ca_and_key_in_pem_format>` flag (or the CA_CERTIFICATE_FILE environment variable) to allow the health checker to trust the self signed certificate.
+
 ## Getting Unleash Edge
 
 Unleash Edge is distributed as a binary and as a docker image.

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -37,6 +37,8 @@ services:
     ports:
       - "3063:3063"
     command: ["edge"]
+    healthcheck:
+      test: "./unleash-edge health"
   redis:
     image: redis:5-alpine
     command: ["redis-server", "--appendonly", "yes"]

--- a/proxyclienttest/index.html
+++ b/proxyclienttest/index.html
@@ -1,5 +1,7 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
   <head>
+    <title>Unleash proxy client SDK test</title>
   </head>
   <body>
     <script src="https://unpkg.com/unleash-proxy-client@2.4.3/build/main.min.js"></script>

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -24,7 +24,7 @@ actix-web = {version = "4.3.1", features = ["rustls", "compress-zstd"]}
 anyhow = "1.0.71"
 async-trait = "0.1.68"
 chrono = {version = "0.4.26", features = ["serde"]}
-clap = {version = "4.3.1", features = ["derive", "env"]}
+clap = {version = "4.3.2", features = ["derive", "env"]}
 clap-markdown = "0.1.3"
 dashmap = "5.4.0"
 dotenv = {version = "0.15.0", features = ["clap"]}

--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -191,5 +191,6 @@ pub async fn build_caches_and_refreshers(args: CliArgs) -> EdgeResult<EdgeInfo> 
             build_offline(offline_args).map(|cache| (cache, None, None, None))
         }
         EdgeMode::Edge(edge_args) => build_edge(&edge_args).await,
+        EdgeMode::Health(_) => unreachable!("Trying to build caches for health check"),
     }
 }

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -10,6 +10,8 @@ pub enum EdgeMode {
     Edge(EdgeArgs),
     /// Run in offline mode
     Offline(OfflineArgs),
+    /// Perform a health check against a running edge instance
+    Health(HealthCheckArgs),
 }
 
 #[derive(ValueEnum, Debug, Clone)]
@@ -167,6 +169,17 @@ pub struct OfflineArgs {
     pub tokens: Vec<String>,
 }
 
+#[derive(Args, Debug, Clone)]
+pub struct HealthCheckArgs {
+    /// Where the instance you want to health check is running
+    #[clap(short, long, env, default_value = "http://localhost:3063")]
+    pub edge_url: String,
+
+    /// If you're hosting Edge using a self-signed TLS certificate use this to tell healthcheck about your CA
+    #[clap(short, long, env)]
+    pub ca_certificate_file: Option<PathBuf>,
+}
+
 #[derive(Parser, Debug, Clone)]
 pub struct CliArgs {
     #[clap(flatten)]
@@ -271,6 +284,7 @@ mod tests {
                 assert_eq!(api_key.1, "mysecret")
             }
             EdgeMode::Offline(_) => unreachable!(),
+            EdgeMode::Health(_) => unreachable!(),
         }
     }
 
@@ -295,6 +309,7 @@ mod tests {
                 assert_eq!(api_key.1, "mysecret")
             }
             EdgeMode::Offline(_) => unreachable!(),
+            EdgeMode::Health(_) => unreachable!(),
         }
     }
 
@@ -316,6 +331,7 @@ mod tests {
                 assert_eq!(auth.1, "test:test.secret");
             }
             EdgeMode::Offline(_) => unreachable!(),
+            EdgeMode::Health(_) => unreachable!(),
         }
     }
 

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -97,6 +97,7 @@ pub enum EdgeError {
     EdgeTokenParseError,
     InvalidBackupFile(String, String),
     InvalidServerUrl(String),
+    HealthCheckError(String),
     JsonParseError(String),
     NoFeaturesFile,
     NoTokenProvider,
@@ -156,6 +157,9 @@ impl Display for EdgeError {
             EdgeError::ContextParseError => {
                 write!(f, "Failed to parse query parameters to frontend api")
             }
+            EdgeError::HealthCheckError(message) => {
+                write!(f, "{message}")
+            }
         }
     }
 }
@@ -185,6 +189,7 @@ impl ResponseError for EdgeError {
             EdgeError::FrontendNotYetHydrated(_) => StatusCode::NETWORK_AUTHENTICATION_REQUIRED,
             EdgeError::ContextParseError => StatusCode::BAD_REQUEST,
             EdgeError::EdgeMetricsRequestError(status_code) => *status_code,
+            EdgeError::HealthCheckError(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 

--- a/server/src/health_checker.rs
+++ b/server/src/health_checker.rs
@@ -1,0 +1,117 @@
+use crate::cli::HealthCheckArgs;
+use crate::error::EdgeError;
+use crate::tls::build_upstream_certificate;
+use reqwest::{ClientBuilder, Url};
+
+fn build_health_url(url: &Url) -> Url {
+    let mut with_path = url.clone();
+    with_path
+        .path_segments_mut()
+        .expect("Could not build health check url")
+        .push("internal-backstage")
+        .push("health");
+    with_path
+}
+
+pub async fn check_health(health_check_args: HealthCheckArgs) -> Result<(), EdgeError> {
+    let client = match build_upstream_certificate(health_check_args.ca_certificate_file)? {
+        Some(cert) => ClientBuilder::new()
+            .add_root_certificate(cert)
+            .build()
+            .expect("Failed to build health check client"),
+        None => reqwest::Client::default(),
+    };
+    let base_url = Url::parse(&health_check_args.edge_url)
+        .map_err(|p| EdgeError::HealthCheckError(format!("Invalid health check url: {p:?}")))?;
+    let health_check_url = build_health_url(&base_url);
+    client
+        .get(health_check_url)
+        .send()
+        .await
+        .map_err(|e| EdgeError::HealthCheckError(format!("{e:?}")))
+        .map(|r| {
+            if r.status() == 200 {
+                Ok(())
+            } else {
+                Err(EdgeError::HealthCheckError(
+                    "Healthcheck had different status than 200".into(),
+                ))
+            }
+        })?
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cli::HealthCheckArgs;
+    use crate::health_checker::check_health;
+    use crate::internal_backstage::health;
+    use actix_http::HttpService;
+    use actix_http_test::test_server;
+    use actix_service::map_config;
+    use actix_web::dev::AppConfig;
+    use actix_web::{web, App, HttpResponse};
+
+    #[tokio::test]
+    pub async fn runs_health_check() {
+        let srv = test_server(move || {
+            HttpService::new(map_config(
+                App::new().service(web::scope("/internal-backstage").service(health)),
+                |_| AppConfig::default(),
+            ))
+            .tcp()
+        })
+        .await;
+        let url = srv.url("/");
+        let check_result = check_health(HealthCheckArgs {
+            ca_certificate_file: None,
+            edge_url: url,
+        })
+        .await;
+        assert!(check_result.is_ok());
+    }
+
+    #[tokio::test]
+    pub async fn errors_if_health_check_fails() {
+        let check_result = check_health(HealthCheckArgs {
+            ca_certificate_file: None,
+            edge_url: "http://bogusurl".into(),
+        })
+        .await;
+        assert!(check_result.is_err());
+    }
+
+    async fn conflict() -> HttpResponse {
+        HttpResponse::Conflict().finish()
+    }
+
+    #[tokio::test]
+    pub async fn errors_if_health_check_returns_different_status_than_200() {
+        let srv = test_server(move || {
+            HttpService::new(map_config(
+                App::new().service(
+                    web::scope("/internal-backstage").route("/health", web::get().to(conflict)),
+                ),
+                |_| AppConfig::default(),
+            ))
+            .tcp()
+        })
+        .await;
+        let url = srv.url("/");
+        let check_result = check_health(HealthCheckArgs {
+            ca_certificate_file: None,
+            edge_url: url,
+        })
+        .await;
+        assert!(check_result.is_err());
+    }
+
+    #[tokio::test]
+    pub async fn fails_if_given_an_invalid_url() {
+        let check_result = check_health(HealthCheckArgs {
+            ca_certificate_file: None,
+            edge_url: ":\\///\\/".into(),
+        })
+        .await;
+        assert!(check_result.is_err());
+    }
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -8,6 +8,7 @@ pub mod edge_api;
 #[cfg(not(tarpaulin_include))]
 pub mod error;
 pub mod frontend_api;
+pub mod health_checker;
 pub mod http;
 pub mod internal_backstage;
 pub mod metrics;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -14,7 +14,7 @@ use unleash_edge::types::{EdgeToken, TokenRefresh, TokenValidationStatus};
 use unleash_types::client_features::ClientFeatures;
 use unleash_types::client_metrics::ConnectVia;
 
-use unleash_edge::edge_api;
+use unleash_edge::cli::EdgeMode;
 use unleash_edge::frontend_api;
 use unleash_edge::internal_backstage;
 use unleash_edge::metrics::client_metrics::MetricsCache;
@@ -23,6 +23,7 @@ use unleash_edge::openapi;
 use unleash_edge::prom_metrics;
 use unleash_edge::{cli, middleware};
 use unleash_edge::{client_api, tls};
+use unleash_edge::{edge_api, health_checker};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
@@ -35,6 +36,14 @@ async fn main() -> Result<(), anyhow::Error> {
         clap_markdown::print_help_markdown::<CliArgs>();
         return Ok(());
     }
+    match args.mode {
+        EdgeMode::Health(args) => {
+            return health_checker::check_health(args)
+                .await
+                .map_err(|e| e.into())
+        }
+        _ => {}
+    };
     let schedule_args = args.clone();
     let mode_arg = args.clone().mode;
     let http_args = args.clone().http;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -36,13 +36,10 @@ async fn main() -> Result<(), anyhow::Error> {
         clap_markdown::print_help_markdown::<CliArgs>();
         return Ok(());
     }
-    match args.mode {
-        EdgeMode::Health(args) => {
-            return health_checker::check_health(args)
-                .await
-                .map_err(|e| e.into())
-        }
-        _ => {}
+    if let EdgeMode::Health(args) = args.mode {
+        return health_checker::check_health(args)
+            .await
+            .map_err(|e| e.into());
     };
     let schedule_args = args.clone();
     let mode_arg = args.clone().mode;

--- a/server/src/tokens.rs
+++ b/server/src/tokens.rs
@@ -100,6 +100,9 @@ impl FromRequest for EdgeToken {
                     Some(v) => EdgeToken::try_from(v.clone()),
                     None => Err(EdgeError::AuthorizationDenied),
                 },
+                EdgeMode::Health(_) => {
+                    unreachable!("Trying to get token when running in healthcheck mode")
+                }
             };
             ready(key)
         } else {


### PR DESCRIPTION
We've had requests from users/customers that use Edge with docker-compose. Since our docker image does not contain any other binary besides the edge binary itself, they were not able to use the `healthcheck` directive for their compose service. This PR adds a `health` subcommand to the edge binary which will perform the needed health check to be used in a docker-compose service declaration.