### PR TITLE
Document that tokens cli arg allows multiple comma-separated values

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -85,7 +85,7 @@ Run in edge mode
 * `--token-revalidation-interval-seconds <TOKEN_REVALIDATION_INTERVAL_SECONDS>` — How long between each revalidation of a token
 
   Default value: `3600`
-* `-t`, `--tokens <TOKENS>` — Get data for these client tokens at startup. Hot starts your feature cache
+* `-t`, `--tokens <TOKENS>` — Get data for these client tokens at startup. Accepts comma-separated list of tokens. Hot starts your feature cache
 * `-H`, `--custom-client-headers <CUSTOM_CLIENT_HEADERS>` — Expects curl header format (-H <HEADERNAME>: <HEADERVALUE>) for instance `-H X-Api-Key: mysecretapikey`
 * `-s`, `--skip-ssl-verification` — If set to true, we will skip SSL verification when connecting to the upstream Unleash server
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Unleash Edge is distributed as a binary and as a docker image.
   - If running in `edge` mode your command should be
     - `docker run -p 3063:3063 -e UPSTREAM_URL=<YOUR_UNLEASH_INSTANCE> unleashorg/unleash-edge:v2.0.1 edge`
   - If running in `offline` mode you will need to provide a volume containing your feature toggles file. An example is available inside the examples folder. To use this, you can use the command
-    - `docker run -v ./examples:/edge/data -p 3063:3063 -e BOOTSTRAP_FILE=/edge/data/features.json -e TOKENS='my-secret-123' unleashorg/unleash-edge:v2.0.1 offline`
+    - `docker run -v ./examples:/edge/data -p 3063:3063 -e BOOTSTRAP_FILE=/edge/data/features.json -e TOKENS='my-secret-123,another-secret-789' unleashorg/unleash-edge:v2.0.1 offline`
 
 ### Cargo/Rust
 
@@ -157,7 +157,7 @@ Options:
       --token-revalidation-interval-seconds <TOKEN_REVALIDATION_INTERVAL_SECONDS>
           How long between each revalidation of a token [env: TOKEN_REVALIDATION_INTERVAL_SECONDS=] [default: 3600]
   -t, --tokens <TOKENS>
-          Get data for these client tokens at startup. Hot starts your feature cache [env: TOKENS=]
+          Get data for these client tokens at startup. Accepts comma-separated list of tokens. Hot starts your feature cache [env: TOKENS=]
   -H, --custom-client-headers <CUSTOM_CLIENT_HEADERS>
           Expects curl header format (-H <HEADERNAME>: <HEADERVALUE>) for instance `-H X-Api-Key: mysecretapikey` [env: CUSTOM_CLIENT_HEADERS=]
   -s, --skip-ssl-verification

--- a/server/README.md
+++ b/server/README.md
@@ -157,7 +157,7 @@ Options:
       --token-revalidation-interval-seconds <TOKEN_REVALIDATION_INTERVAL_SECONDS>
           How long between each revalidation of a token [env: TOKEN_REVALIDATION_INTERVAL_SECONDS=] [default: 3600]
   -t, --tokens <TOKENS>
-          Get data for these client tokens at startup. Hot starts your feature cache [env: TOKENS=]
+          Get data for these client tokens at startup. Accepts comma-separated list of tokens. Hot starts your feature cache [env: TOKENS=]
   -H, --custom-client-headers <CUSTOM_CLIENT_HEADERS>
           Expects curl header format (-H <HEADERNAME>: <HEADERVALUE>) for instance `-H X-Api-Key: mysecretapikey` [env: CUSTOM_CLIENT_HEADERS=]
   -s, --skip-ssl-verification

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -122,7 +122,7 @@ pub struct EdgeArgs {
     #[clap(long, env, default_value_t = 3600)]
     pub token_revalidation_interval_seconds: u64,
 
-    /// Get data for these client tokens at startup. Hot starts your feature cache
+    /// Get data for these client tokens at startup. Accepts comma-separated list of tokens. Hot starts your feature cache
     #[clap(short, long, env, value_delimiter = ',')]
     pub tokens: Vec<String>,
 


### PR DESCRIPTION
Nowhere in the docs it was previously stated how to pass multiple tokens. This documents explicitly that the tokens should be comma separated.