### PR TITLE
chore: allows resolving a single toggle to do that directly instead of iterating the whole map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,9 +1890,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
+checksum = "f73935e4d55e2abf7f130186537b19e7a4abc886a0252380b59248af473a3fc9"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1900,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
+checksum = "aef623c9bbfa0eedf5a0efba11a5ee83209c326653ca31ff019bec3a95bfff2b"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1910,9 +1910,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
+checksum = "b3e8cba4ec22bada7fc55ffe51e2deb6a0e0db2d0b7ab0b103acc80d2510c190"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1923,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
+checksum = "a01f71cb40bd8bb94232df14b946909e14660e33fc05db3e50ae2a82d7ea0ca0"
 dependencies = [
  "once_cell",
  "pest",
@@ -3167,9 +3167,9 @@ dependencies = [
 
 [[package]]
 name = "unleash-yggdrasil"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b2e100fd30db3032d3683bcccad0954e89881176694b610a2a5b7ea602e52a"
+checksum = "219b9e90b40c842a58cf7bce1e408e53e1740ae33bb4b923e830a6470acd3dfd"
 dependencies = [
  "chrono",
  "convert_case 0.6.0",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -53,7 +53,7 @@ tracing = {version = "0.1.37", features = ["log"]}
 tracing-subscriber = {version = "0.3.17", features = ["json", "env-filter"]}
 ulid = "1.0.0"
 unleash-types = { version = "0.10.1", features = ["openapi", "hashes"]}
-unleash-yggdrasil = { version = "0.5.7" }
+unleash-yggdrasil = { version = "0.5.8" }
 utoipa = {version = "3", features = ["actix_extras", "chrono"]}
 utoipa-swagger-ui = {version = "3", features = ["actix-web"]}
 [dev-dependencies]

--- a/server/src/frontend_api.rs
+++ b/server/src/frontend_api.rs
@@ -402,8 +402,7 @@ pub fn evaluate_feature(
         .clone();
     engine_cache
         .get(&cache_key(&validated_token))
-        .and_then(|engine| engine.resolve_all(&context_with_ip))
-        .and_then(|toggles| toggles.get(&feature_name).cloned())
+        .and_then(|engine| engine.resolve(&feature_name, &context_with_ip))
         .and_then(|resolved_toggle| {
             if validated_token.projects.contains(&"*".into())
                 || validated_token.projects.contains(&resolved_toggle.project)


### PR DESCRIPTION
Allows Edge to tap into `resolve` in Yggdrasil rather than `resolve_all` when checking a single toggle. This means Edge doesn't have to walk the entire hashmap of state to resolve a single toggle. This provides a modest performance improvement when working with thousands of toggles