### PR TITLE
perf: improve memory usage during request lifecycle

### DIFF
--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -1,4 +1,5 @@
 use crate::error::{EdgeError, FeatureError};
+use crate::filters::{name_prefix_filter, project_filter, FeatureFilterSet};
 use crate::http::feature_refresher::FeatureRefresher;
 use crate::metrics::client_metrics::MetricsCache;
 use crate::tokens::cache_key;
@@ -65,8 +66,29 @@ async fn resolve_features(
         .get(&edge_token.token)
         .map(|e| e.value().clone())
         .ok_or(EdgeError::AuthorizationDenied)?;
+
+    let filters = filter_query.into_inner();
+    let query = unleash_types::client_features::Query {
+        tags: None,
+        projects: Some(validated_token.projects.clone()),
+        name_prefix: filters.name_prefix.clone(),
+        environment: validated_token.environment.clone(),
+        inline_segment_constraints: Some(false),
+    };
+
+    let filter_set = if let Some(name_prefix) = filters.name_prefix {
+        FeatureFilterSet::from(Box::new(name_prefix_filter(name_prefix)))
+    } else {
+        FeatureFilterSet::default()
+    }
+    .with_filter(project_filter(&edge_token));
+
     let client_features = match req.app_data::<Data<FeatureRefresher>>() {
-        Some(refresher) => refresher.features_for_token(validated_token.clone()).await,
+        Some(refresher) => {
+            refresher
+                .features_for_filter(validated_token.clone(), filter_set)
+                .await
+        }
         None => features_cache
             .get(&cache_key(&edge_token))
             .map(|features| features.value().clone())
@@ -77,32 +99,12 @@ async fn resolve_features(
                 ..client_features
             })
             .ok_or(EdgeError::ClientFeaturesFetchError(FeatureError::Retriable)),
-    };
-    let filters = filter_query.into_inner();
-    let query = unleash_types::client_features::Query {
-        tags: None,
-        projects: Some(validated_token.projects),
-        name_prefix: filters.name_prefix.clone(),
-        environment: validated_token.environment,
-        inline_segment_constraints: Some(false),
-    };
-    client_features
-        .map(|f| ClientFeatures {
-            query: Some(query),
-            features: f
-                .features
-                .into_iter()
-                .filter(|f| {
-                    filters
-                        .name_prefix
-                        .as_ref()
-                        .map(|prefix| f.name.starts_with(prefix))
-                        .unwrap_or(true)
-                })
-                .collect(),
-            ..f
-        })
-        .map(Json)
+    }?;
+
+    Ok(Json(ClientFeatures {
+        query: Some(query),
+        ..client_features
+    }))
 }
 #[utoipa::path(
     context_path = "/api/client",

--- a/server/src/filters.rs
+++ b/server/src/filters.rs
@@ -127,7 +127,7 @@ mod tests {
         let map = DashMap::default();
         let map_key = "some-key".to_string();
 
-        map.insert(map_key.clone(), client_features.clone());
+        map.insert(map_key.clone(), client_features);
         let features = map.get(&map_key).unwrap();
 
         let chained_filter = FeatureFilterSet::from(Box::new(|f| f.enabled))
@@ -162,7 +162,7 @@ mod tests {
         let map = DashMap::default();
         let map_key = "some-feature".to_string();
 
-        map.insert(map_key.clone(), client_features.clone());
+        map.insert(map_key.clone(), client_features);
         let features = map.get(&map_key).unwrap();
 
         let filter = FeatureFilterSet::from(name_prefix_filter(Some("feature-".to_string())));
@@ -209,7 +209,7 @@ mod tests {
         let map = DashMap::default();
         let map_key = "some-key".to_string();
 
-        map.insert(map_key.clone(), client_features.clone());
+        map.insert(map_key.clone(), client_features);
         let features = map.get(&map_key).unwrap();
 
         let token = EdgeToken {

--- a/server/src/filters.rs
+++ b/server/src/filters.rs
@@ -170,17 +170,7 @@ mod tests {
 
         assert_eq!(filtered_features.len(), 3);
 
-        let filter = FeatureFilterSet::from(name_prefix_filter(Some("feature-one".to_string())));
-        let filtered_features = filter_features(&features, filter);
-
-        assert_eq!(filtered_features.len(), 1);
-
-        let filter = FeatureFilterSet::from(name_prefix_filter(Some("feature-two".to_string())));
-        let filtered_features = filter_features(&features, filter);
-
-        assert_eq!(filtered_features.len(), 1);
-
-        let filter = FeatureFilterSet::from(name_prefix_filter(Some("feature-three".to_string())));
+        let filter = FeatureFilterSet::from(name_prefix_filter(Some("feature-o".to_string())));
         let filtered_features = filter_features(&features, filter);
 
         assert_eq!(filtered_features.len(), 1);

--- a/server/src/filters.rs
+++ b/server/src/filters.rs
@@ -27,7 +27,7 @@ impl FeatureFilterSet {
     }
 }
 
-pub fn filter_features(
+fn filter_features(
     feature_cache: &Ref<'_, String, ClientFeatures>,
     filters: FeatureFilterSet,
 ) -> Vec<ClientFeature> {
@@ -37,6 +37,18 @@ pub fn filter_features(
         .filter(|feature| filters.apply(feature))
         .cloned()
         .collect::<Vec<ClientFeature>>()
+}
+
+pub fn filter_client_features(
+    feature_cache: &Ref<'_, String, ClientFeatures>,
+    filters: FeatureFilterSet,
+) -> ClientFeatures {
+    ClientFeatures {
+        features: filter_features(feature_cache, filters),
+        segments: feature_cache.segments.clone(),
+        query: feature_cache.query.clone(),
+        version: feature_cache.version,
+    }
 }
 
 pub fn name_prefix_filter(name_prefix: String) -> FeatureFilter {

--- a/server/src/filters.rs
+++ b/server/src/filters.rs
@@ -1,4 +1,51 @@
-use crate::{http::feature_refresher::FeatureFilter, types::EdgeToken};
+use dashmap::mapref::one::Ref;
+use unleash_types::client_features::{ClientFeature, ClientFeatures};
+
+use crate::types::EdgeToken;
+
+pub type FeatureFilter = Box<dyn Fn(&ClientFeature) -> bool>;
+
+pub struct FeatureFilterSet {
+    filters: Vec<FeatureFilter>,
+}
+
+impl FeatureFilterSet {
+    pub fn from(filter: FeatureFilter) -> Self {
+        Self {
+            filters: vec![filter],
+        }
+    }
+
+    pub fn with_filter(mut self, filter: FeatureFilter) -> Self {
+        self.filters.push(filter);
+        self
+    }
+
+    pub fn apply(&self, feature: &ClientFeature) -> bool {
+        self.filters.iter().all(|filter| filter(feature))
+    }
+}
+
+pub fn filter_features(
+    feature_cache: &Ref<'_, String, ClientFeatures>,
+    filters: FeatureFilterSet,
+) -> Vec<ClientFeature> {
+    feature_cache
+        .features
+        .iter()
+        .filter(|feature| filters.apply(feature))
+        .cloned()
+        .collect::<Vec<ClientFeature>>()
+}
+
+pub fn name_prefix_filter(name_prefix: Option<String>) -> FeatureFilter {
+    Box::new(move |f| {
+        name_prefix
+            .as_ref()
+            .map(|prefix| f.name.starts_with(prefix))
+            .unwrap_or(true)
+    })
+}
 
 pub fn project_filter(token: &EdgeToken) -> FeatureFilter {
     let token = token.clone();
@@ -11,4 +58,180 @@ pub fn project_filter(token: &EdgeToken) -> FeatureFilter {
             false
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dashmap::DashMap;
+    use unleash_types::client_features::{ClientFeature, ClientFeatures};
+
+    #[test]
+    pub fn filter_features_applies_filters() {
+        let feature_name = "some-feature".to_string();
+
+        let client_features = ClientFeatures {
+            version: 0,
+            features: vec![ClientFeature {
+                enabled: true,
+                ..ClientFeature::default()
+            }],
+            query: None,
+            segments: None,
+        };
+
+        let map = DashMap::default();
+        map.insert(feature_name.clone(), client_features.clone());
+
+        let features = map.get(&feature_name).unwrap();
+        let filter_for_enabled = FeatureFilterSet::from(Box::new(|f| f.enabled));
+        let enabled_features = filter_features(&features, filter_for_enabled);
+
+        let features = map.get(&feature_name).unwrap();
+        let filter_for_disabled = FeatureFilterSet::from(Box::new(|f| !f.enabled));
+        let disabled_features = filter_features(&features, filter_for_disabled);
+
+        assert_eq!(enabled_features[0].name, client_features.features[0].name);
+
+        assert!(disabled_features.is_empty());
+    }
+
+    #[test]
+    pub fn chaining_filters_applies_all_filters() {
+        let client_features = ClientFeatures {
+            version: 0,
+            features: vec![
+                ClientFeature {
+                    name: "feature-one".to_string(),
+                    enabled: true,
+                    impression_data: Some(false),
+                    ..ClientFeature::default()
+                },
+                ClientFeature {
+                    name: "feature-two".to_string(),
+                    enabled: false,
+                    impression_data: Some(true),
+                    ..ClientFeature::default()
+                },
+                ClientFeature {
+                    name: "feature-three".to_string(),
+                    enabled: true,
+                    impression_data: Some(true),
+                    ..ClientFeature::default()
+                },
+            ],
+            query: None,
+            segments: None,
+        };
+
+        let map = DashMap::default();
+        let map_key = "some-key".to_string();
+
+        map.insert(map_key.clone(), client_features.clone());
+        let features = map.get(&map_key).unwrap();
+
+        let chained_filter = FeatureFilterSet::from(Box::new(|f| f.enabled))
+            .with_filter(Box::new(|f| f.impression_data.unwrap_or(false)));
+        let enabled_features = filter_features(&features, chained_filter);
+
+        assert_eq!(enabled_features[0].name, "feature-three".to_string());
+    }
+
+    #[test]
+    fn name_prefix_filter_filters_by_prefix() {
+        let client_features = ClientFeatures {
+            version: 0,
+            features: vec![
+                ClientFeature {
+                    name: "feature-one".to_string(),
+                    ..ClientFeature::default()
+                },
+                ClientFeature {
+                    name: "feature-two".to_string(),
+                    ..ClientFeature::default()
+                },
+                ClientFeature {
+                    name: "feature-three".to_string(),
+                    ..ClientFeature::default()
+                },
+            ],
+            query: None,
+            segments: None,
+        };
+
+        let map = DashMap::default();
+        let map_key = "some-feature".to_string();
+
+        map.insert(map_key.clone(), client_features.clone());
+        let features = map.get(&map_key).unwrap();
+
+        let filter = FeatureFilterSet::from(name_prefix_filter(Some("feature-".to_string())));
+        let filtered_features = filter_features(&features, filter);
+
+        assert_eq!(filtered_features.len(), 3);
+
+        let filter = FeatureFilterSet::from(name_prefix_filter(Some("feature-one".to_string())));
+        let filtered_features = filter_features(&features, filter);
+
+        assert_eq!(filtered_features.len(), 1);
+
+        let filter = FeatureFilterSet::from(name_prefix_filter(Some("feature-two".to_string())));
+        let filtered_features = filter_features(&features, filter);
+
+        assert_eq!(filtered_features.len(), 1);
+
+        let filter = FeatureFilterSet::from(name_prefix_filter(Some("feature-three".to_string())));
+        let filtered_features = filter_features(&features, filter);
+
+        assert_eq!(filtered_features.len(), 1);
+
+        let filter = FeatureFilterSet::from(name_prefix_filter(Some("feature-four".to_string())));
+        let filtered_features = filter_features(&features, filter);
+
+        assert_eq!(filtered_features.len(), 0);
+    }
+
+    #[test]
+    fn project_filter_filters_on_project_tokens() {
+        let client_features = ClientFeatures {
+            version: 0,
+            features: vec![
+                ClientFeature {
+                    name: "feature-one".to_string(),
+                    project: Some("default".to_string()),
+                    ..ClientFeature::default()
+                },
+                ClientFeature {
+                    name: "feature-two".to_string(),
+                    project: Some("default".to_string()),
+                    ..ClientFeature::default()
+                },
+                ClientFeature {
+                    name: "feature-three".to_string(),
+                    project: Some("not-default".to_string()),
+                    ..ClientFeature::default()
+                },
+            ],
+            query: None,
+            segments: None,
+        };
+
+        let map = DashMap::default();
+        let map_key = "some-key".to_string();
+
+        map.insert(map_key.clone(), client_features.clone());
+        let features = map.get(&map_key).unwrap();
+
+        let token = EdgeToken {
+            projects: vec!["default".to_string()],
+            ..Default::default()
+        };
+
+        let filter = FeatureFilterSet::from(project_filter(&token));
+        let filtered_features = filter_features(&features, filter);
+
+        assert_eq!(filtered_features.len(), 2);
+        assert_eq!(filtered_features[0].name, "feature-one".to_string());
+        assert_eq!(filtered_features[1].name, "feature-two".to_string());
+    }
 }

--- a/server/src/filters.rs
+++ b/server/src/filters.rs
@@ -1,0 +1,14 @@
+use crate::{http::feature_refresher::FeatureFilter, types::EdgeToken};
+
+pub fn project_filter(token: &EdgeToken) -> FeatureFilter {
+    let token = token.clone();
+    Box::new(move |feature| {
+        if let Some(feature_project) = &feature.project {
+            token.projects.is_empty()
+                || token.projects.contains(&"*".to_string())
+                || token.projects.contains(feature_project)
+        } else {
+            false
+        }
+    })
+}

--- a/server/src/filters.rs
+++ b/server/src/filters.rs
@@ -55,6 +55,10 @@ pub fn name_prefix_filter(name_prefix: String) -> FeatureFilter {
     Box::new(move |f| f.name.starts_with(&name_prefix))
 }
 
+pub fn name_match_filter(name_prefix: String) -> FeatureFilter {
+    Box::new(move |f| f.name.starts_with(&name_prefix))
+}
+
 pub fn project_filter(token: &EdgeToken) -> FeatureFilter {
     let token = token.clone();
     Box::new(move |feature| {

--- a/server/src/http/feature_refresher.rs
+++ b/server/src/http/feature_refresher.rs
@@ -12,7 +12,7 @@ use unleash_yggdrasil::EngineState;
 
 use super::unleash_client::UnleashClient;
 use crate::error::{EdgeError, FeatureError};
-use crate::filters::{filter_features, project_filter, FeatureFilterSet};
+use crate::filters::{filter_client_features, FeatureFilterSet};
 use crate::types::{
     build, ClientTokenRequest, ClientTokenResponse, EdgeResult, ProjectFilter, TokenType,
     TokenValidationStatus,
@@ -209,15 +209,9 @@ impl FeatureRefresher {
         token: &EdgeToken,
         filters: FeatureFilterSet,
     ) -> Option<ClientFeatures> {
-        let client_features = self.features_cache.get(&cache_key(token))?;
-        let features = filter_features(&client_features, filters);
-
-        Some(ClientFeatures {
-            features,
-            query: client_features.query.clone(),
-            segments: client_features.segments.clone(),
-            version: client_features.version,
-        })
+        self.features_cache
+            .get(&cache_key(token))
+            .map(|client_features| filter_client_features(&client_features, filters))
     }
 
     ///

--- a/server/src/http/feature_refresher.rs
+++ b/server/src/http/feature_refresher.rs
@@ -3,17 +3,16 @@ use std::{sync::Arc, time::Duration};
 
 use actix_web::http::header::EntityTag;
 use chrono::Utc;
-use dashmap::mapref::one::Ref;
 use dashmap::DashMap;
 use tracing::log::trace;
 use tracing::{debug, warn};
-use unleash_types::client_features::ClientFeature;
 use unleash_types::client_metrics::ClientApplication;
 use unleash_types::{client_features::ClientFeatures, Upsert};
 use unleash_yggdrasil::EngineState;
 
 use super::unleash_client::UnleashClient;
 use crate::error::{EdgeError, FeatureError};
+use crate::filters::{filter_features, FeatureFilterSet};
 use crate::types::{
     build, ClientTokenRequest, ClientTokenResponse, EdgeResult, ProjectFilter, TokenType,
     TokenValidationStatus,
@@ -58,41 +57,6 @@ fn client_application_from_token(token: EdgeToken, refresh_interval: i64) -> Cli
         started: Utc::now(),
         strategies: vec![],
     }
-}
-
-pub type FeatureFilter = Box<dyn Fn(&ClientFeature) -> bool>;
-
-pub struct FeatureFilterSet {
-    filters: Vec<FeatureFilter>,
-}
-
-impl FeatureFilterSet {
-    pub fn from(filter: FeatureFilter) -> Self {
-        Self {
-            filters: vec![filter],
-        }
-    }
-
-    pub fn with_filter(mut self, filter: FeatureFilter) -> Self {
-        self.filters.push(filter);
-        self
-    }
-
-    pub fn apply(&self, feature: &ClientFeature) -> bool {
-        self.filters.iter().all(|filter| filter(feature))
-    }
-}
-
-pub fn filter_features(
-    feature_cache: &Ref<'_, String, ClientFeatures>,
-    filters: FeatureFilterSet,
-) -> Vec<ClientFeature> {
-    feature_cache
-        .features
-        .iter()
-        .filter(|feature| filters.apply(feature))
-        .cloned()
-        .collect::<Vec<ClientFeature>>()
 }
 
 impl FeatureRefresher {
@@ -224,7 +188,6 @@ impl FeatureRefresher {
         token: &EdgeToken,
         filters: FeatureFilterSet,
     ) -> Option<ClientFeatures> {
-
         let client_features = self.features_cache.get(&cache_key(token))?;
         let features = filter_features(&client_features, filters);
 
@@ -232,7 +195,7 @@ impl FeatureRefresher {
             features,
             query: client_features.query.clone(),
             segments: client_features.segments.clone(),
-            version: client_features.version.clone(),
+            version: client_features.version,
         })
     }
 
@@ -391,10 +354,9 @@ mod tests {
     use chrono::{Duration, Utc};
     use dashmap::DashMap;
     use reqwest::Url;
-    use unleash_types::client_features::{ClientFeature, ClientFeatures};
+    use unleash_types::client_features::ClientFeatures;
     use unleash_yggdrasil::EngineState;
 
-    use crate::http::feature_refresher::FeatureFilterSet;
     use crate::tests::features_from_disk;
     use crate::tokens::cache_key;
     use crate::types::TokenType;
@@ -404,7 +366,7 @@ mod tests {
         types::{EdgeToken, TokenRefresh},
     };
 
-    use super::{filter_features, FeatureRefresher};
+    use super::FeatureRefresher;
 
     impl PartialEq for TokenRefresh {
         fn eq(&self, other: &Self) -> bool {
@@ -413,45 +375,6 @@ mod tests {
                 && self.last_refreshed == other.last_refreshed
                 && self.last_check == other.last_check
         }
-    }
-
-    #[test]
-    pub fn filter_features_applies_filters() {
-        let feature_name = "some-feature".to_string();
-
-        let client_features = ClientFeatures {
-            version: 0,
-            features: vec![ClientFeature {
-                enabled: true,
-                created_at: None,
-                description: None,
-                feature_type: None,
-                project: Some("default".into()),
-                stale: None,
-                strategies: None,
-                impression_data: Some(false),
-                last_seen_at: None,
-                name: feature_name.clone(),
-                variants: None,
-            }],
-            query: None,
-            segments: None,
-        };
-
-        let map = DashMap::default();
-        map.insert(feature_name.clone(), client_features.clone());
-
-        let features = map.get(&feature_name).unwrap();
-        let filter_for_enabled = FeatureFilterSet::from(Box::new(|f| f.enabled));
-        let enabled_features = filter_features(&features, filter_for_enabled);
-
-        let features = map.get(&feature_name).unwrap();
-        let filter_for_disabled = FeatureFilterSet::from(Box::new(|f| !f.enabled));
-        let disabled_features = filter_features(&features, filter_for_disabled);
-
-        assert_eq!(enabled_features[0].name, client_features.features[0].name);
-
-        assert!(disabled_features.is_empty());
     }
 
     #[tokio::test]

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -8,6 +8,7 @@ pub mod client_api;
 pub mod edge_api;
 #[cfg(not(tarpaulin_include))]
 pub mod error;
+pub mod filters;
 pub mod frontend_api;
 pub mod health_checker;
 pub mod http;

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -14,9 +14,9 @@ use chrono::{DateTime, Duration, Utc};
 use dashmap::DashMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use shadow_rs::shadow;
-use unleash_types::client_features::{ClientFeature, ClientFeatures};
+use unleash_types::client_features::ClientFeatures;
 use unleash_types::client_metrics::{ClientApplication, ClientMetricsEnv};
-use unleash_yggdrasil::{EngineState, ResolvedToggle};
+use unleash_yggdrasil::EngineState;
 use utoipa::{IntoParams, ToSchema};
 
 pub type EdgeJsonResult<T> = Result<Json<T>, EdgeError>;
@@ -247,39 +247,6 @@ pub struct BatchMetricsRequest {
 pub struct BatchMetricsRequestBody {
     pub applications: Vec<ClientApplication>,
     pub metrics: Vec<ClientMetricsEnv>,
-}
-pub trait ProjectFilter<T> {
-    fn filter_by_projects(&self, token: &EdgeToken) -> Vec<T>;
-}
-
-impl ProjectFilter<ClientFeature> for Vec<ClientFeature> {
-    fn filter_by_projects(&self, token: &EdgeToken) -> Vec<ClientFeature> {
-        self.iter()
-            .filter(|feature| {
-                if let Some(feature_project) = &feature.project {
-                    token.projects.is_empty()
-                        || token.projects.contains(&"*".to_string())
-                        || token.projects.contains(feature_project)
-                } else {
-                    false
-                }
-            })
-            .cloned()
-            .collect::<Vec<ClientFeature>>()
-    }
-}
-
-impl ProjectFilter<ResolvedToggle> for Vec<ResolvedToggle> {
-    fn filter_by_projects(&self, token: &EdgeToken) -> Vec<ResolvedToggle> {
-        self.iter()
-            .filter(|toggle| {
-                token.projects.is_empty()
-                    || token.projects.contains(&"*".to_string())
-                    || token.projects.contains(&toggle.project)
-            })
-            .cloned()
-            .collect()
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
## What

This inverts the way we do filtering of the feature toggles when resolving data out of our cache. Previously we'd materialise the entire response, cloning each. Now we build the filtering at a higher layer and pass the filter in to the method that resolves the toggles. This means that the filter is applied **before** the cloning.

## Why

We're a little inefficient with the number of clones we apply when resolving a toggle. This means we stack allocate a **lot** of unnecessary memory. This reduces this to one clone (two on one cold path of retrieving toggles when they're not present in the cache). 

All in all, this doubles the response speed when working with a large number of toggles and halves the memory usage to achieve that.

## Benchmarks

### Baseline benchmark

Summary:
  Total:	14.3805 secs
  Slowest:	10.0794 secs
  Fastest:	0.9730 secs
  Average:	5.5344 secs
  Requests/sec:	7.8579
  

Response time histogram:
  0.973 [1]	|■
  1.884 [4]	|■■■■
  2.794 [7]	|■■■■■■■
  3.705 [7]	|■■■■■■■
  4.616 [9]	|■■■■■■■■■
  5.526 [18]	|■■■■■■■■■■■■■■■■■■
  6.437 [39]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  7.347 [10]	|■■■■■■■■■■
  8.258 [13]	|■■■■■■■■■■■■■
  9.169 [1]	|■
  10.079 [4]	|■■■■


Latency distribution:
  10% in 2.8589 secs
  25% in 4.7205 secs
  50% in 5.8351 secs
  75% in 6.4597 secs
  90% in 7.4248 secs
  95% in 8.9751 secs
  99% in 10.0794 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0015 secs, 0.9730 secs, 10.0794 secs
  DNS-lookup:	0.0004 secs, 0.0000 secs, 0.0016 secs
  req write:	0.0001 secs, 0.0000 secs, 0.0003 secs
  resp wait:	3.2266 secs, 0.0585 secs, 7.3207 secs
  resp read:	1.8054 secs, 0.0001 secs, 6.3262 secs

Status code distribution:
  [200]	107 responses
  [408]	6 responses

### Baseline memory usage:

After 1 prewarm up strike and benchmarks run: 4.0 GB

### Benchmark after patch
Summary:
  Total:	12.3002 secs
  Slowest:	6.2325 secs
  Fastest:	1.0501 secs
  Average:	2.9045 secs
  Requests/sec:	15.6909
  

Response time histogram:
  1.050 [1]	|■
  1.568 [1]	|■
  2.087 [5]	|■■■
  2.605 [65]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  3.123 [73]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  3.641 [30]	|■■■■■■■■■■■■■■■■
  4.160 [7]	|■■■■
  4.678 [5]	|■■■
  5.196 [3]	|■■
  5.714 [2]	|■
  6.232 [1]	|■


Latency distribution:
  10% in 2.3857 secs
  25% in 2.4603 secs
  50% in 2.8073 secs
  75% in 3.1863 secs
  90% in 3.5532 secs
  95% in 4.3718 secs
  99% in 6.2325 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0003 secs, 1.0501 secs, 6.2325 secs
  DNS-lookup:	0.0001 secs, 0.0000 secs, 0.0009 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0004 secs
  resp wait:	1.7042 secs, 0.3664 secs, 3.4124 secs
  resp read:	1.1997 secs, 0.1047 secs, 3.1137 secs

Status code distribution:
  [200]	193 responses


### Memory usage after patch

After 1 prewarm up strike and benchmarks run: 2.2GB

