### PR TITLE
chore: reduce unnecessary public api surface

### DIFF
--- a/server/src/filters.rs
+++ b/server/src/filters.rs
@@ -6,7 +6,7 @@ use crate::types::EdgeToken;
 pub type FeatureFilter = Box<dyn Fn(&ClientFeature) -> bool>;
 
 #[derive(Default)]
-pub struct FeatureFilterSet {
+pub(crate) struct FeatureFilterSet {
     filters: Vec<FeatureFilter>,
 }
 
@@ -39,7 +39,7 @@ fn filter_features(
         .collect::<Vec<ClientFeature>>()
 }
 
-pub fn filter_client_features(
+pub(crate) fn filter_client_features(
     feature_cache: &Ref<'_, String, ClientFeatures>,
     filters: FeatureFilterSet,
 ) -> ClientFeatures {
@@ -51,15 +51,15 @@ pub fn filter_client_features(
     }
 }
 
-pub fn name_prefix_filter(name_prefix: String) -> FeatureFilter {
+pub(crate) fn name_prefix_filter(name_prefix: String) -> FeatureFilter {
     Box::new(move |f| f.name.starts_with(&name_prefix))
 }
 
-pub fn name_match_filter(name_prefix: String) -> FeatureFilter {
+pub(crate) fn name_match_filter(name_prefix: String) -> FeatureFilter {
     Box::new(move |f| f.name.starts_with(&name_prefix))
 }
 
-pub fn project_filter(token: &EdgeToken) -> FeatureFilter {
+pub(crate) fn project_filter(token: &EdgeToken) -> FeatureFilter {
     let token = token.clone();
     Box::new(move |feature| {
         if let Some(feature_project) = &feature.project {

--- a/server/src/http/feature_refresher.rs
+++ b/server/src/http/feature_refresher.rs
@@ -87,7 +87,7 @@ impl FeatureRefresher {
         }
     }
 
-    pub fn get_tokens_due_for_refresh(&self) -> Vec<TokenRefresh> {
+    pub(crate) fn get_tokens_due_for_refresh(&self) -> Vec<TokenRefresh> {
         self.tokens_to_refresh
             .iter()
             .map(|e| e.value().clone())
@@ -100,7 +100,7 @@ impl FeatureRefresher {
             .collect()
     }
 
-    pub fn get_tokens_never_refreshed(&self) -> Vec<TokenRefresh> {
+    pub(crate) fn get_tokens_never_refreshed(&self) -> Vec<TokenRefresh> {
         self.tokens_to_refresh
             .iter()
             .map(|e| e.value().clone())
@@ -108,20 +108,26 @@ impl FeatureRefresher {
             .collect()
     }
 
-    pub fn token_is_subsumed(&self, token: &EdgeToken) -> bool {
+    pub(crate) fn token_is_subsumed(&self, token: &EdgeToken) -> bool {
         self.tokens_to_refresh
             .iter()
             .filter(|r| r.token.environment == token.environment)
             .any(|t| t.token.subsumes(token))
     }
 
-    pub fn frontend_token_is_covered_by_client_token(&self, frontend_token: &EdgeToken) -> bool {
+    pub(crate) fn frontend_token_is_covered_by_client_token(
+        &self,
+        frontend_token: &EdgeToken,
+    ) -> bool {
         self.tokens_to_refresh.iter().any(|client_token| {
             frontend_token.same_environment_and_broader_or_equal_project_access(&client_token.token)
         })
     }
 
-    async fn register_and_hydrate_token(&self, token: &EdgeToken) -> EdgeResult<ClientFeatures> {
+    pub(crate) async fn register_and_hydrate_token(
+        &self,
+        token: &EdgeToken,
+    ) -> EdgeResult<ClientFeatures> {
         let filter = FeatureFilterSet::from(project_filter(token));
         self.register_token_for_refresh(token.clone(), None).await;
         self.hydrate_new_tokens().await;
@@ -129,7 +135,7 @@ impl FeatureRefresher {
             .ok_or(EdgeError::ClientFeaturesFetchError(FeatureError::Retriable))
     }
 
-    pub async fn forward_request_for_client_token(
+    pub(crate) async fn forward_request_for_client_token(
         &self,
         client_token_request: ClientTokenRequest,
     ) -> EdgeResult<ClientTokenResponse> {
@@ -138,7 +144,10 @@ impl FeatureRefresher {
             .await
     }
 
-    pub async fn create_client_token_for_fe_token(&self, token: EdgeToken) -> EdgeResult<()> {
+    pub(crate) async fn create_client_token_for_fe_token(
+        &self,
+        token: EdgeToken,
+    ) -> EdgeResult<()> {
         if token.status == TokenValidationStatus::Validated
             && token.token_type == Some(TokenType::Frontend)
         {
@@ -156,7 +165,7 @@ impl FeatureRefresher {
         Ok(())
     }
 
-    pub async fn features_for_filter(
+    pub(crate) async fn features_for_filter(
         &self,
         token: EdgeToken,
         filters: FeatureFilterSet,

--- a/server/src/http/unleash_client.rs
+++ b/server/src/http/unleash_client.rs
@@ -476,6 +476,15 @@ mod tests {
 
     use super::{EdgeTokens, UnleashClient};
 
+    impl ClientFeaturesRequest {
+        pub(crate) fn new(api_key: String, etag: Option<String>) -> Self {
+            Self {
+                api_key,
+                etag: etag.map(EntityTag::new_weak),
+            }
+        }
+    }
+
     const TEST_TOKEN: &str = "[]:development.08bce4267a3b1aa";
     const TEST_SERVICE_ACCOUNT_TOKEN: &str = "*:*.service-account-token";
     fn two_client_features() -> ClientFeatures {

--- a/server/src/middleware/client_token_from_frontend_token.rs
+++ b/server/src/middleware/client_token_from_frontend_token.rs
@@ -5,23 +5,13 @@ use actix_web::{
 };
 use dashmap::DashMap;
 use tracing::{debug, instrument};
-use unleash_yggdrasil::EngineState;
 
 use crate::{
     http::feature_refresher::FeatureRefresher,
-    tokens::cache_key,
     types::{EdgeResult, EdgeToken, TokenValidationStatus},
 };
 
-pub fn have_data_for_fe_token(req: &ServiceRequest, token: &EdgeToken) -> bool {
-    if let Some(engine_cache) = req.app_data::<Data<DashMap<String, EngineState>>>() {
-        engine_cache.contains_key(&cache_key(token))
-    } else {
-        false
-    }
-}
-
-pub async fn create_client_token_for_fe_token(
+pub(crate) async fn create_client_token_for_fe_token(
     req: &ServiceRequest,
     token: &EdgeToken,
 ) -> EdgeResult<()> {

--- a/server/src/tls.rs
+++ b/server/src/tls.rs
@@ -8,7 +8,7 @@ use crate::cli::TlsOptions;
 use crate::error::{CertificateError, EdgeError};
 use crate::types::EdgeResult;
 
-pub fn build_upstream_certificate(
+pub(crate) fn build_upstream_certificate(
     upstream_certificate: Option<PathBuf>,
 ) -> EdgeResult<Option<reqwest::tls::Certificate>> {
     upstream_certificate

--- a/server/src/tokens.rs
+++ b/server/src/tokens.rs
@@ -71,12 +71,15 @@ impl EdgeToken {
         }
     }
 
-    pub fn subsumes(&self, other: &EdgeToken) -> bool {
+    pub(crate) fn subsumes(&self, other: &EdgeToken) -> bool {
         self.token_type == other.token_type
             && self.same_environment_and_broader_or_equal_project_access(other)
     }
 
-    pub fn same_environment_and_broader_or_equal_project_access(&self, other: &EdgeToken) -> bool {
+    pub(crate) fn same_environment_and_broader_or_equal_project_access(
+        &self,
+        other: &EdgeToken,
+    ) -> bool {
         self.environment == other.environment
             && (self.projects.contains(&"*".into())
                 || (self.projects.len() >= other.projects.len()

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -59,15 +59,6 @@ pub struct ValidateTokensRequest {
     pub tokens: Vec<String>,
 }
 
-impl ClientFeaturesRequest {
-    pub fn new(api_key: String, etag: Option<String>) -> Self {
-        Self {
-            api_key,
-            etag: etag.map(EntityTag::new_weak),
-        }
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, ToSchema)]
 #[cfg_attr(test, derive(Default))]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
This narrows the access modifiers for a number of functions and structs that make no sense to be public. This is a nuisance because internal changes become major/minor version changes for no good reason 