### PR TITLE
feat: added timing for client feature fetch operations

### DIFF
--- a/server/src/prom_metrics.rs
+++ b/server/src/prom_metrics.rs
@@ -102,4 +102,9 @@ fn register_custom_metrics(registry: &prometheus::Registry) {
             crate::http::unleash_client::TOKEN_VALIDATION_FAILURES.clone(),
         ))
         .unwrap();
+    registry
+        .register(Box::new(
+            crate::http::unleash_client::CLIENT_FEATURE_FETCH.clone(),
+        ))
+        .unwrap();
 }


### PR DESCRIPTION
Realised we were only logging fetch failures, not fetches that succeeded in any way. This PR adds a HistogramVec for timing all client feature fetch requests per http status.