### PR TITLE
chore: bumps yggdrasil and unleash-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3140,9 +3140,9 @@ dependencies = [
 
 [[package]]
 name = "unleash-types"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1486a9668923725b2c79a0eae4809f5ea61e8c5d0c7f6bedeb8f8da6afe4cec9"
+checksum = "8094986ab97242a6d5fc446b7c60c2d362bf3e206fd74d018160584ccb6a1fc3"
 dependencies = [
  "base64",
  "chrono",
@@ -3155,9 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "unleash-yggdrasil"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219b9e90b40c842a58cf7bce1e408e53e1740ae33bb4b923e830a6470acd3dfd"
+checksum = "b7c95c91eb4777c16d5885aa1cf628c83f46cfdfd4d0b11ee9ba78fe248faab0"
 dependencies = [
  "chrono",
  "convert_case 0.6.0",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -53,7 +53,7 @@ tracing = {version = "0.1.37", features = ["log"]}
 tracing-subscriber = {version = "0.3.17", features = ["json", "env-filter"]}
 ulid = "1.0.0"
 unleash-types = { version = "0.10", features = ["openapi", "hashes"]}
-unleash-yggdrasil = { version = "0.5.8" }
+unleash-yggdrasil = { version = "0.5.9" }
 utoipa = {version = "3", features = ["actix_extras", "chrono"]}
 utoipa-swagger-ui = {version = "3", features = ["actix-web"]}
 [dev-dependencies]

--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -365,6 +365,7 @@ mod tests {
                     project: Some("default".into()),
                     strategies: Some(vec![
                         Strategy {
+                            variants: None,
                             name: "standard".into(),
                             sort_order: Some(500),
                             segments: None,
@@ -372,6 +373,7 @@ mod tests {
                             parameters: None,
                         },
                         Strategy {
+                            variants: None,
                             name: "gradualRollout".into(),
                             sort_order: Some(100),
                             segments: None,
@@ -409,6 +411,7 @@ mod tests {
                             name: "gradualRollout".to_string(),
                             sort_order: None,
                             segments: None,
+                            variants: None,
                             constraints: Some(vec![Constraint {
                                 context_name: "version".to_string(),
                                 operator: Operator::SemverGt,
@@ -425,6 +428,7 @@ mod tests {
                             segments: None,
                             constraints: None,
                             parameters: None,
+                            variants: None,
                         },
                     ]),
                     variants: None,

--- a/server/src/frontend_api.rs
+++ b/server/src/frontend_api.rs
@@ -723,6 +723,7 @@ mod tests {
                     name: "default".into(),
                     sort_order: None,
                     segments: None,
+                    variants: None,
                     constraints: Some(vec![Constraint {
                         context_name: "userId".into(),
                         operator: Operator::In,


### PR DESCRIPTION
This bumps Yggdrasil and UnleashTypes to support strategy variants. This doesn't include test since this is covered by tests in the underlying libraries.

If you're looking for the tests to confirm that metrics work correctly, they're also not here. This is actually handled by the proxy sdks, all Edge does is forward on metrics it receives to Unleash so it's up to the proxy sdk to do this correctly.