### PR TITLE
feat: add disable-all-endpoint flag for disabling proxy /all endpoint

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -32,7 +32,7 @@ This document contains the help content for the `unleash-edge` command-line prog
   Default value: ``
 * `-w`, `--workers <WORKERS>` — How many workers should be started to handle requests. Defaults to number of physical cpus
 
-  Default value: `8`
+  Default value: `16`
 * `--enable-post-features` — Exposes the api/client/features endpoint for POST requests. This may be removed in a future release
 
   Default value: `false`
@@ -46,13 +46,16 @@ This document contains the help content for the `unleash-edge` command-line prog
   Default value: `3043`
 * `--instance-id <INSTANCE_ID>` — Instance id. Used for metrics reporting
 
-  Default value: `01H2G660P0FAGAVVVJXTNMRCW2`
+  Default value: `01H7SY1GR08PTQ1AJAMNKY413E`
 * `-a`, `--app-name <APP_NAME>` — App name. Used for metrics reporting
 
   Default value: `unleash-edge`
 * `--markdown-help`
 * `--trust-proxy` — By enabling the trust proxy option. Unleash Edge will have knowledge that it's sitting behind a proxy and that the X-Forward-\* header fields may be trusted, which otherwise may be easily spoofed. Edge will use this to populate its context's  remoteAddress field If you need to only trust specific ips or CIDR, enable this flag and then set `--proxy-trusted-servers`
 * `--proxy-trusted-servers <PROXY_TRUSTED_SERVERS>` — Tells Unleash Edge which servers to trust the X-Forwarded-For. Accepts explicit Ip addresses or Cidrs (127.0.0.1/16). Accepts a comma separated list or multiple instances of the flag. E.g `--proxy-trusted-servers "127.0.0.1,192.168.0.1"` and `--proxy-trusted-servers 127.0.0.1 --proxy-trusted-servers 192.168.0.1` are equivalent
+* `--disable-all-endpoint` — Set this flag to true if you want to disable /api/proxy/all and /api/frontend/all Because returning all toggles regardless of their state is a potential security vulnerability, these endpoints can be disabled
+
+  Default value: `false`
 
 
 

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -215,6 +215,11 @@ pub struct CliArgs {
 
     #[clap(flatten)]
     pub trust_proxy: TrustProxy,
+
+    /// Set this flag to true if you want to disable /api/proxy/all and /api/frontend/all
+    /// Because returning all toggles regardless of their state is a potential security vulnerability, these endpoints can be disabled
+    #[clap(long, env, default_value_t = false, global = true)]
+    pub disable_all_endpoint: bool,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/server/src/frontend_api.rs
+++ b/server/src/frontend_api.rs
@@ -1,10 +1,13 @@
+use actix_http::body::MessageBody;
 use actix_http::HttpMessage;
+use actix_service::ServiceFactory;
 use std::collections::HashMap;
 
+use actix_web::dev::{ServiceRequest, ServiceResponse};
 use actix_web::{
     get, post,
     web::{self, Data, Json, Path},
-    HttpRequest, HttpResponse,
+    HttpRequest, HttpResponse, Scope,
 };
 use dashmap::DashMap;
 use serde_qs::actix::QsQuery;
@@ -564,40 +567,80 @@ pub async fn post_frontend_register(
     Ok(HttpResponse::Accepted().finish())
 }
 
-pub fn configure_frontend_api(cfg: &mut web::ServiceConfig) {
-    cfg.service(web::scope("/proxy")
+fn configure_frontend_endpoints(cfg: &mut web::ServiceConfig, disable_all_endpoint: bool) {
+    if !disable_all_endpoint {
+        cfg.service(
+            scope_with_auth("/frontend")
+                .service(get_frontend_all_features)
+                .service(post_frontend_all_features)
+                .service(get_enabled_frontend)
+                .service(post_frontend_metrics)
+                .service(post_frontend_enabled_features)
+                .service(post_frontend_register)
+                .service(post_frontend_evaluate_single_feature)
+                .service(get_frontend_evaluate_single_feature),
+        );
+    } else {
+        cfg.service(
+            scope_with_auth("/frontend")
+                .service(get_enabled_frontend)
+                .service(post_frontend_metrics)
+                .service(post_frontend_enabled_features)
+                .service(post_frontend_register)
+                .service(post_frontend_evaluate_single_feature)
+                .service(get_frontend_evaluate_single_feature),
+        );
+    }
+}
+
+fn scope_with_auth(
+    path: &str,
+) -> Scope<
+    impl ServiceFactory<
+        ServiceRequest,
+        Config = (),
+        Response = ServiceResponse<impl MessageBody>,
+        Error = actix_web::Error,
+        InitError = (),
+    >,
+> {
+    web::scope(path)
         .wrap(crate::middleware::as_async_middleware::as_async_middleware(
-            crate::middleware::enrich_with_client_ip::enrich_with_client_ip
+            crate::middleware::enrich_with_client_ip::enrich_with_client_ip,
         ))
         .wrap(crate::middleware::as_async_middleware::as_async_middleware(
-            crate::middleware::client_token_from_frontend_token::client_token_from_frontend_token, ))
+            crate::middleware::client_token_from_frontend_token::client_token_from_frontend_token,
+        ))
         .wrap(crate::middleware::as_async_middleware::as_async_middleware(
-        crate::middleware::validate_token::validate_token,
-    )).service(get_enabled_proxy)
-        .service(get_proxy_all_features)
-        .service(post_proxy_metrics)
-        .service(post_proxy_all_features)
-        .service(post_proxy_enabled_features)
-        .service(post_proxy_register)
-    ).service(
-        web::scope("/frontend")
-            .wrap(crate::middleware::as_async_middleware::as_async_middleware(
-                crate::middleware::enrich_with_client_ip::enrich_with_client_ip
-            ))
-            .wrap(crate::middleware::as_async_middleware::as_async_middleware(
-            crate::middleware::client_token_from_frontend_token::client_token_from_frontend_token))
-            .wrap(crate::middleware::as_async_middleware::as_async_middleware(
             crate::middleware::validate_token::validate_token,
         ))
+}
 
-        .service(get_enabled_frontend)
-        .service(get_frontend_all_features)
-        .service(post_frontend_metrics)
-        .service(post_frontend_all_features)
-        .service(post_frontend_enabled_features)
-        .service(post_frontend_register)
-        .service(post_frontend_evaluate_single_feature)
-        .service(get_frontend_evaluate_single_feature));
+fn configure_proxy_endpoints(cfg: &mut web::ServiceConfig, disable_all_endpoint: bool) {
+    if !disable_all_endpoint {
+        cfg.service(
+            scope_with_auth("/proxy")
+                .service(get_proxy_all_features)
+                .service(post_proxy_all_features)
+                .service(get_enabled_proxy)
+                .service(post_proxy_metrics)
+                .service(post_proxy_enabled_features)
+                .service(post_proxy_register),
+        );
+    } else {
+        cfg.service(
+            scope_with_auth("/proxy")
+                .service(get_enabled_proxy)
+                .service(post_proxy_metrics)
+                .service(post_proxy_enabled_features)
+                .service(post_proxy_register),
+        );
+    }
+}
+
+pub fn configure_frontend_api(cfg: &mut web::ServiceConfig, disable_all_endpoint: bool) {
+    configure_proxy_endpoints(cfg, disable_all_endpoint);
+    configure_frontend_endpoints(cfg, disable_all_endpoint);
 }
 
 pub fn frontend_from_yggdrasil(
@@ -1006,7 +1049,9 @@ mod tests {
                 .wrap(middleware::as_async_middleware::as_async_middleware(
                     middleware::validate_token::validate_token,
                 ))
-                .service(web::scope("/api").configure(super::configure_frontend_api)),
+                .service(
+                    web::scope("/api").configure(|cfg| super::configure_frontend_api(cfg, false)),
+                ),
         )
         .await;
 
@@ -1037,7 +1082,9 @@ mod tests {
                 .wrap(middleware::as_async_middleware::as_async_middleware(
                     middleware::validate_token::validate_token,
                 ))
-                .service(web::scope("/api").configure(super::configure_frontend_api)),
+                .service(
+                    web::scope("/api").configure(|cfg| super::configure_frontend_api(cfg, false)),
+                ),
         )
         .await;
         let req = test::TestRequest::get()
@@ -1062,7 +1109,9 @@ mod tests {
                 .app_data(Data::from(token_cache))
                 .app_data(Data::from(feature_cache))
                 .app_data(Data::from(engine_cache))
-                .service(web::scope("/api").configure(super::configure_frontend_api)),
+                .service(
+                    web::scope("/api").configure(|cfg| super::configure_frontend_api(cfg, false)),
+                ),
         )
         .await;
 
@@ -1089,7 +1138,9 @@ mod tests {
                 .app_data(Data::from(token_cache))
                 .app_data(Data::from(feature_cache))
                 .app_data(Data::from(engine_cache))
-                .service(web::scope("/api").configure(super::configure_frontend_api)),
+                .service(
+                    web::scope("/api").configure(|cfg| super::configure_frontend_api(cfg, false)),
+                ),
         )
         .await;
 
@@ -1121,7 +1172,9 @@ mod tests {
                 .app_data(Data::from(token_cache))
                 .app_data(Data::from(feature_cache))
                 .app_data(Data::from(engine_cache))
-                .service(web::scope("/api").configure(super::configure_frontend_api)),
+                .service(
+                    web::scope("/api").configure(|cfg| super::configure_frontend_api(cfg, false)),
+                ),
         )
         .await;
         let req = test::TestRequest::get()
@@ -1161,7 +1214,9 @@ mod tests {
                 .app_data(Data::from(token_cache))
                 .app_data(Data::from(feature_cache))
                 .app_data(Data::from(engine_cache))
-                .service(web::scope("/api").configure(super::configure_frontend_api)),
+                .service(
+                    web::scope("/api").configure(|cfg| super::configure_frontend_api(cfg, false)),
+                ),
         )
         .await;
         let req = test::TestRequest::post()
@@ -1204,7 +1259,9 @@ mod tests {
                 .app_data(Data::from(token_cache))
                 .app_data(Data::from(feature_cache))
                 .app_data(Data::from(engine_cache))
-                .service(web::scope("/api").configure(super::configure_frontend_api)),
+                .service(
+                    web::scope("/api").configure(|cfg| super::configure_frontend_api(cfg, false)),
+                ),
         )
         .await;
         let req = test::TestRequest::post()
@@ -1217,5 +1274,46 @@ mod tests {
         let result: FrontendResult = test::call_and_read_body_json(&app, req).await;
         let ip_addr_was_enabled = result.toggles.iter().any(|r| r.name == "ip_addr");
         assert!(ip_addr_was_enabled);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn disabling_all_endpoints_yields_404_when_trying_to_access_them() {
+        let client_features_with_custom_context_field =
+            crate::tests::features_from_disk("../examples/ip_address_feature.json");
+        let auth_key = "gard:development.secret123".to_string();
+        let (token_cache, feature_cache, engine_cache) = build_offline_mode(
+            client_features_with_custom_context_field.clone(),
+            vec![auth_key.clone()],
+        )
+        .unwrap();
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::from(token_cache))
+                .app_data(Data::from(feature_cache))
+                .app_data(Data::from(engine_cache))
+                .service(
+                    web::scope("/api").configure(|cfg| super::configure_frontend_api(cfg, true)),
+                ),
+        )
+        .await;
+        let frontend_req = test::TestRequest::post()
+            .uri("/api/frontend/all")
+            .peer_addr(SocketAddr::from_str("192.168.0.1:80").unwrap())
+            .insert_header(ContentType::json())
+            .insert_header(("Authorization", auth_key.clone()))
+            .set_json(json!({ "properties": {"companyId": "bricks"}}))
+            .to_request();
+        let result = test::call_service(&app, frontend_req).await;
+        assert_eq!(result.status(), StatusCode::NOT_FOUND);
+        let proxy_req = test::TestRequest::post()
+            .uri("/api/proxy/all")
+            .peer_addr(SocketAddr::from_str("192.168.0.1:80").unwrap())
+            .insert_header(ContentType::json())
+            .insert_header(("Authorization", auth_key.clone()))
+            .set_json(json!({ "properties": {"companyId": "bricks"}}))
+            .to_request();
+        let result = test::call_service(&app, proxy_req).await;
+        assert_eq!(result.status(), StatusCode::NOT_FOUND);
     }
 }

--- a/server/src/http/unleash_client.rs
+++ b/server/src/http/unleash_client.rs
@@ -562,7 +562,7 @@ mod tests {
         test_server(move || {
             HttpService::new(map_config(
                 App::new()
-                    .wrap(Etag::default())
+                    .wrap(Etag)
                     .service(
                         web::resource("/api/client/features")
                             .route(web::get().to(return_client_features)),
@@ -606,7 +606,7 @@ mod tests {
                 TlsAcceptorConfig::default().handshake_timeout(Duration::from_secs(5));
             HttpService::new(map_config(
                 App::new()
-                    .wrap(Etag::default())
+                    .wrap(Etag)
                     .service(
                         web::resource("/api/client/features")
                             .route(web::get().to(return_client_features)),
@@ -644,7 +644,7 @@ mod tests {
         test_server(move || {
             HttpService::new(map_config(
                 App::new()
-                    .wrap(Etag::default())
+                    .wrap(Etag)
                     .wrap(as_async_middleware(validate_api_key_middleware))
                     .service(
                         web::resource("/api/client/features")

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -76,7 +76,9 @@ mod tests {
                     .service(
                         web::scope("/api")
                             .configure(crate::client_api::configure_client_api)
-                            .configure(crate::frontend_api::configure_frontend_api)
+                            .configure(|cfg| {
+                                crate::frontend_api::configure_frontend_api(cfg, false)
+                            })
                             .configure(crate::admin_api::configure_admin_api),
                     )
                     .service(web::scope("/edge").configure(crate::edge_api::configure_edge_api)),

--- a/server/src/middleware/client_token_from_frontend_token.rs
+++ b/server/src/middleware/client_token_from_frontend_token.rs
@@ -101,7 +101,9 @@ mod tests {
                     .service(
                         web::scope("/api")
                             .configure(crate::client_api::configure_client_api)
-                            .configure(crate::frontend_api::configure_frontend_api)
+                            .configure(|cfg| {
+                                crate::frontend_api::configure_frontend_api(cfg, false)
+                            })
                             .configure(crate::admin_api::configure_admin_api),
                     )
                     .service(web::scope("/edge").configure(crate::edge_api::configure_edge_api)),

--- a/server/tests/redis_test.rs
+++ b/server/tests/redis_test.rs
@@ -12,7 +12,7 @@ use unleash_edge::{
 use unleash_types::client_features::{ClientFeature, ClientFeatures};
 
 fn setup_redis(docker: &Cli) -> (Client, String, Container<Redis>) {
-    let node: Container<Redis> = docker.run(Redis::default());
+    let node: Container<Redis> = docker.run(Redis);
     let host_port = node.get_host_port_ipv4(6379);
     let url = format!("redis://127.0.0.1:{host_port}");
 


### PR DESCRIPTION
So, since the proxy allows you to enable this, to bring Edge to feature parity, this PR allows users to disable the `/api/frontend/all` and `/api/proxy/all` endpoints.