### PR TITLE
chore: remove experimental post features endpoint

### DIFF
--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -239,13 +239,6 @@ pub struct TlsOptions {
 }
 
 #[derive(Args, Debug, Clone)]
-pub struct ExperimentalArgs {
-    /// Exposes the api/client/features endpoint for POST requests. This may be removed in a future release
-    #[clap(env, long, default_value_t = false)]
-    pub enable_post_features: bool,
-}
-
-#[derive(Args, Debug, Clone)]
 pub struct HttpServerArgs {
     /// Which port should this server listen for HTTP traffic on
     #[clap(short, long, env, default_value_t = 3063)]
@@ -261,9 +254,6 @@ pub struct HttpServerArgs {
     /// Defaults to number of physical cpus
     #[clap(short, long, env, global=true, default_value_t = num_cpus::get_physical())]
     pub workers: usize,
-
-    #[clap(flatten)]
-    pub experimental: ExperimentalArgs,
 
     #[clap(flatten)]
     pub tls: TlsOptions,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -60,7 +60,6 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let metrics_cache = Arc::new(MetricsCache::default());
     let metrics_cache_clone = metrics_cache.clone();
-    let experimental_post_enabled = http_args.experimental.enable_post_features;
 
     let openapi = openapi::ApiDoc::openapi();
     let refresher_for_app_data = feature_refresher.clone();
@@ -111,13 +110,7 @@ async fn main() -> Result<(), anyhow::Error> {
                         .configure(|cfg| {
                             frontend_api::configure_frontend_api(cfg, disable_all_endpoint)
                         })
-                        .configure(admin_api::configure_admin_api)
-                        .configure(|cfg| {
-                            client_api::configure_experimental_post_features(
-                                cfg,
-                                experimental_post_enabled,
-                            )
-                        }),
+                        .configure(admin_api::configure_admin_api),
                 )
                 .service(web::scope("/edge").configure(edge_api::configure_edge_api))
                 .service(


### PR DESCRIPTION
This removes the experimental post features endpoint, this was built for a very particular use case that didn't materialise and this serves no other purpose