### PR TITLE
feat: add hot reloading and an optional, simpler file format to offline mode

### DIFF
--- a/examples/simple-bootstrap.json
+++ b/examples/simple-bootstrap.json
@@ -1,0 +1,13 @@
+{
+  "featureOne": {
+    "enabled": true,
+    "variant": "variantOne"
+  },
+  "featureTwo": {
+    "enabled": false,
+    "variant": "variantTwo"
+  },
+  "featureThree": {
+    "enabled": true
+  }
+}

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -181,6 +181,9 @@ pub struct OfflineArgs {
     /// Tokens that should be allowed to connect to Edge. Supports a comma separated list or multiple instances of the `--tokens` argument
     #[clap(short, long, env, value_delimiter = ',')]
     pub tokens: Vec<String>,
+    /// The interval in seconds between reloading the bootstrap file. Disabled if unset or 0
+    #[clap(short, long, env, default_value_t = 0)]
+    pub reload_interval: u64,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -628,6 +628,7 @@ mod tests {
                 .app_data(Data::new(crate::cli::EdgeMode::Offline(OfflineArgs {
                     bootstrap_file: Some(PathBuf::from("../examples/features.json")),
                     tokens: vec!["secret_123".into()],
+                    reload_interval: 0,
                 })))
                 .service(web::scope("/api/client").service(get_features)),
         )

--- a/server/src/frontend_api.rs
+++ b/server/src/frontend_api.rs
@@ -994,6 +994,7 @@ mod tests {
                 .app_data(Data::new(EdgeMode::Offline(OfflineArgs {
                     bootstrap_file: None,
                     tokens: vec!["secret-123".into()],
+                    reload_interval: 0,
                 })))
                 .service(web::scope("/api/frontend").service(super::get_frontend_all_features)),
         )

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -15,6 +15,7 @@ pub mod http;
 pub mod internal_backstage;
 pub mod metrics;
 pub mod middleware;
+pub mod offline;
 #[cfg(not(tarpaulin_include))]
 pub mod openapi;
 pub mod persistence;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -158,7 +158,7 @@ async fn main() -> Result<(), anyhow::Error> {
         }
         cli::EdgeMode::Offline(offline_args) if offline_args.reload_interval > 0 => {
             tokio::select! {
-                _ = offline_hotload::start_hotload_loop(offline_args.bootstrap_file ,lazy_feature_cache, lazy_engine_cache, offline_args.tokens, offline_args.reload_interval) => {
+                _ = offline_hotload::start_hotload_loop(lazy_feature_cache, lazy_engine_cache, offline_args) => {
                     tracing::info!("Hotloader unexpectedly shut down.");
                 },
                 _ = server.run() => {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -156,9 +156,9 @@ async fn main() -> Result<(), anyhow::Error> {
                 }
             }
         }
-        cli::EdgeMode::Offline(offline_args) => {
+        cli::EdgeMode::Offline(offline_args) if offline_args.reload_interval > 0 => {
             tokio::select! {
-                _ = offline_hotload::start_hotload_loop(offline_args.bootstrap_file ,lazy_feature_cache, lazy_engine_cache, offline_args.tokens) => {
+                _ = offline_hotload::start_hotload_loop(offline_args.bootstrap_file ,lazy_feature_cache, lazy_engine_cache, offline_args.tokens, offline_args.reload_interval) => {
                     tracing::info!("Hotloader unexpectedly shut down.");
                 },
                 _ = server.run() => {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -16,6 +16,7 @@ use unleash_edge::builder::build_caches_and_refreshers;
 use unleash_edge::cli::{CliArgs, EdgeMode};
 use unleash_edge::metrics::client_metrics::MetricsCache;
 use unleash_edge::middleware::request_tracing::RequestTracing;
+use unleash_edge::offline::offline_hotload;
 use unleash_edge::persistence::{persist_data, EdgePersistence};
 use unleash_edge::types::{EdgeToken, TokenRefresh, TokenValidationStatus};
 use unleash_edge::{admin_api, cli, client_api, frontend_api, health_checker, openapi};
@@ -57,6 +58,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let token_validator_schedule = token_validator.clone();
     let lazy_feature_cache = features_cache.clone();
     let lazy_token_cache = token_cache.clone();
+    let lazy_engine_cache = engine_cache.clone();
 
     let metrics_cache = Arc::new(MetricsCache::default());
     let metrics_cache_clone = metrics_cache.clone();
@@ -152,6 +154,16 @@ async fn main() -> Result<(), anyhow::Error> {
                 _ = validator.schedule_validation_of_known_tokens(edge.token_revalidation_interval_seconds) => {
                     tracing::info!("Token validator validator was unexpectedly shut down");
                 }
+            }
+        }
+        cli::EdgeMode::Offline(offline_args) => {
+            tokio::select! {
+                _ = offline_hotload::start_hotload_loop(offline_args.bootstrap_file ,lazy_feature_cache, lazy_engine_cache, offline_args.tokens) => {
+                    tracing::info!("Hotloader unexpectedly shut down.");
+                },
+                _ = server.run() => {
+                    tracing::info!("Actix is shutting down. No pending tasks.");
+                },
             }
         }
         _ => tokio::select! {

--- a/server/src/offline/mod.rs
+++ b/server/src/offline/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(not(tarpaulin_include))]
+pub mod offline_hotload;

--- a/server/src/offline/offline_hotload.rs
+++ b/server/src/offline/offline_hotload.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     fs::File,
     io::{BufReader, Read},
-    path::{Path, PathBuf},
+    path::Path,
     str::FromStr,
     sync::Arc,
     time::Duration,
@@ -15,18 +15,19 @@ use unleash_types::client_features::{
 };
 use unleash_yggdrasil::EngineState;
 
-use crate::{error::EdgeError, types::EdgeToken};
+use crate::{cli::OfflineArgs, error::EdgeError, types::EdgeToken};
 
 pub async fn start_hotload_loop(
-    bootstrap_path: Option<PathBuf>,
     features_cache: Arc<DashMap<std::string::String, ClientFeatures>>,
     engine_cache: Arc<DashMap<std::string::String, EngineState>>,
-    known_tokens: Vec<String>,
-    interval: u64,
+    offline_args: OfflineArgs,
 ) {
+    let known_tokens = offline_args.tokens;
+    let bootstrap_path = offline_args.bootstrap_file;
+
     loop {
         tokio::select! {
-            _ = tokio::time::sleep(Duration::from_secs(interval)) => {
+            _ = tokio::time::sleep(Duration::from_secs(offline_args.reload_interval)) => {
                 let bootstrap = bootstrap_path.as_ref().map(|bootstrap_path|load_bootstrap(bootstrap_path));
                 match bootstrap {
                     Some(Ok(bootstrap)) => {

--- a/server/src/offline/offline_hotload.rs
+++ b/server/src/offline/offline_hotload.rs
@@ -94,11 +94,11 @@ fn make_simple_bootstrap(simple_bootstrap: HashMap<String, SimpleFeature>) -> Cl
                 variants,
                 strategies: Some(vec![Strategy {
                     name: "default".into(),
-                    parameters: None,
+                    parameters: Some(HashMap::new()),
                     sort_order: None,
                     segments: None,
-                    constraints: None,
-                    variants: None,
+                    constraints: Some(vec![]),
+                    variants: Some(vec![]),
                 }]),
                 project: Some("default".into()),
                 ..Default::default()

--- a/server/src/offline/offline_hotload.rs
+++ b/server/src/offline/offline_hotload.rs
@@ -22,10 +22,11 @@ pub async fn start_hotload_loop(
     features_cache: Arc<DashMap<std::string::String, ClientFeatures>>,
     engine_cache: Arc<DashMap<std::string::String, EngineState>>,
     known_tokens: Vec<String>,
+    interval: u64,
 ) {
     loop {
         tokio::select! {
-            _ = tokio::time::sleep(Duration::from_secs(1)) => {
+            _ = tokio::time::sleep(Duration::from_secs(interval)) => {
                 let bootstrap = bootstrap_path.as_ref().map(|bootstrap_path|load_bootstrap(bootstrap_path));
                 match bootstrap {
                     Some(Ok(bootstrap)) => {

--- a/server/src/offline/offline_hotload.rs
+++ b/server/src/offline/offline_hotload.rs
@@ -1,0 +1,216 @@
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{BufReader, Read},
+    path::{Path, PathBuf},
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
+
+use dashmap::DashMap;
+use serde::Deserialize;
+use unleash_types::client_features::{
+    ClientFeature, ClientFeatures, Strategy, Variant, WeightType,
+};
+use unleash_yggdrasil::EngineState;
+
+use crate::{error::EdgeError, types::EdgeToken};
+
+pub async fn start_hotload_loop(
+    bootstrap_path: Option<PathBuf>,
+    features_cache: Arc<DashMap<std::string::String, ClientFeatures>>,
+    engine_cache: Arc<DashMap<std::string::String, EngineState>>,
+    known_tokens: Vec<String>,
+) {
+    loop {
+        tokio::select! {
+            _ = tokio::time::sleep(Duration::from_secs(1)) => {
+                let bootstrap = bootstrap_path.as_ref().map(|bootstrap_path|load_bootstrap(bootstrap_path));
+                match bootstrap {
+                    Some(Ok(bootstrap)) => {
+                        let edge_tokens: Vec<EdgeToken> = known_tokens
+                        .iter()
+                        .map(|token| EdgeToken::from_str(token).unwrap_or_else(|_| EdgeToken::offline_token(token)))
+                        .collect();
+
+                        for edge_token in edge_tokens {
+                            load_offline_engine_cache(&edge_token, features_cache.clone(), engine_cache.clone(), bootstrap.clone());
+                        }
+                    },
+                    Some(Err(e)) => {
+                        tracing::error!("Error loading bootstrap file: {:?}", e);
+                    }
+                    None => {
+                        tracing::debug!("No bootstrap file provided");
+                    }
+                };
+            }
+        }
+    }
+}
+
+pub(crate) fn load_offline_engine_cache(
+    edge_token: &EdgeToken,
+    features_cache: Arc<DashMap<String, ClientFeatures>>,
+    engine_cache: Arc<DashMap<String, EngineState>>,
+    client_features: ClientFeatures,
+) {
+    features_cache.insert(
+        crate::tokens::cache_key(edge_token),
+        client_features.clone(),
+    );
+    let mut engine_state = EngineState::default();
+    engine_state.take_state(client_features);
+    engine_cache.insert(crate::tokens::cache_key(edge_token), engine_state);
+}
+
+#[derive(Deserialize)]
+struct SimpleFeature {
+    enabled: bool,
+    variant: Option<String>,
+}
+
+fn make_simple_bootstrap(simple_bootstrap: HashMap<String, SimpleFeature>) -> ClientFeatures {
+    let features = simple_bootstrap
+        .iter()
+        .map(|(feature_name, simple_feat)| {
+            let variants = simple_feat.variant.as_ref().map(|variant_name| {
+                vec![Variant {
+                    name: variant_name.clone(),
+                    weight: 1000,
+                    weight_type: Some(WeightType::Fix),
+                    stickiness: Some("default".into()),
+                    payload: None,
+                    overrides: None,
+                }]
+            });
+
+            ClientFeature {
+                name: feature_name.clone(),
+                enabled: simple_feat.enabled,
+                variants,
+                strategies: Some(vec![Strategy {
+                    name: "default".into(),
+                    parameters: None,
+                    sort_order: None,
+                    segments: None,
+                    constraints: None,
+                    variants: None,
+                }]),
+                project: Some("default".into()),
+                ..Default::default()
+            }
+        })
+        .collect();
+    ClientFeatures {
+        version: 2,
+        features,
+        segments: None,
+        query: None,
+    }
+}
+
+pub(crate) fn load_bootstrap(bootstrap_path: &Path) -> Result<ClientFeatures, EdgeError> {
+    let file = File::open(bootstrap_path).map_err(|_| EdgeError::NoFeaturesFile)?;
+
+    let mut reader = BufReader::new(file);
+    let mut content = String::new();
+
+    reader
+        .read_to_string(&mut content)
+        .map_err(|_| EdgeError::NoFeaturesFile)?;
+
+    parse_bootstrap(content).map_err(|e| {
+        let path = format!("{}", bootstrap_path.to_path_buf().display());
+        EdgeError::InvalidBackupFile(path, e.to_string())
+    })
+}
+
+fn parse_bootstrap(content: String) -> Result<ClientFeatures, serde_json::Error> {
+    let client_features: Result<ClientFeatures, serde_json::Error> =
+        serde_json::from_str::<HashMap<String, SimpleFeature>>(&content)
+            .map(make_simple_bootstrap)
+            .or_else(|_| serde_json::from_str(&content));
+
+    client_features
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_bootstrap;
+
+    #[test]
+    fn loads_simple_bootstrap_format() {
+        let simple_bootstrap = r#"
+        {
+            "feature1": {
+                "enabled": true,
+                "variant": "variant1"
+            }
+        }"#;
+        parse_bootstrap(simple_bootstrap.to_string()).unwrap();
+    }
+
+    #[test]
+    fn simple_bootstrap_parses_to_client_features_correctly() {
+        let simple_bootstrap = r#"
+        {
+            "feature1": {
+                "enabled": true,
+                "variant": "variant1"
+            }
+        }"#;
+        let client_features = parse_bootstrap(simple_bootstrap.to_string()).unwrap();
+        assert_eq!(client_features.features.len(), 1);
+        assert_eq!(client_features.features[0].name, "feature1");
+        assert!(client_features.features[0].enabled);
+        assert_eq!(
+            client_features.features[0].variants.as_ref().unwrap()[0].name,
+            "variant1"
+        );
+    }
+
+    #[test]
+    fn simple_bootstrap_does_not_require_variants() {
+        let simple_bootstrap = r#"
+        {
+            "feature1": {
+                "enabled": true
+            }
+        }"#;
+        parse_bootstrap(simple_bootstrap.to_string()).unwrap();
+    }
+
+    #[test]
+    fn falls_back_to_standard_unleash_format() {
+        let simple_bootstrap = r#"
+        {
+            "version": 2,
+            "features": [
+              {
+                "strategies": [
+                  {
+                    "name": "default",
+                    "constraints": [],
+                    "parameters": {}
+                  }
+                ],
+                "impressionData": false,
+                "enabled": true,
+                "name": "custom.constraint",
+                "description": "",
+                "project": "default",
+                "stale": false,
+                "type": "release",
+                "variants": []
+              }
+            ],
+            "query": {
+              "environment": "development",
+              "inlineSegmentConstraints": true
+            }
+          }"#;
+        parse_bootstrap(simple_bootstrap.to_string()).unwrap();
+    }
+}


### PR DESCRIPTION
This adds some nice tooling for local development in offline mode. That's two things, firstly the user can now specify a reload interval, which will cause Edge to reload the offline file every X seconds. The second is a simpler format to specify the offline bootstrap in. That's a very, very simplified format, which Edge maps into a full ClientFeatures response matching the expected set properties. Together these allow the user to fiddle with toggles when in offline mode easily so that they can force their SDKs into the states that they want

Almost all of this code does not touch `edge` mode, which is primarily what production environments use. It's also all opt in. So I think this is relatively safe to merge