### PR TITLE
feat: more information in error logs

### DIFF
--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -91,7 +91,7 @@ pub enum EdgeError {
     ClientBuildError(String),
     ClientCertificateError(CertificateError),
     ClientFeaturesFetchError(FeatureError),
-    ClientFeaturesParseError,
+    ClientFeaturesParseError(String),
     ClientRegisterError,
     FrontendNotYetHydrated(FrontendHydrationMissing),
     FeatureNotFound(String),
@@ -142,8 +142,8 @@ impl Display for EdgeError {
             EdgeError::FeatureNotFound(name) => {
                 write!(f, "Failed to find feature with name {name}")
             }
-            EdgeError::ClientFeaturesParseError => {
-                write!(f, "Failed to parse client features")
+            EdgeError::ClientFeaturesParseError(error) => {
+                write!(f, "Failed to parse client features: [{error}]")
             }
             EdgeError::ClientRegisterError => {
                 write!(f, "Failed to register client")
@@ -198,7 +198,7 @@ impl ResponseError for EdgeError {
             EdgeError::NoTokenProvider => StatusCode::INTERNAL_SERVER_ERROR,
             EdgeError::TokenParseError(_) => StatusCode::FORBIDDEN,
             EdgeError::ClientBuildError(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            EdgeError::ClientFeaturesParseError => StatusCode::INTERNAL_SERVER_ERROR,
+            EdgeError::ClientFeaturesParseError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             EdgeError::ClientFeaturesFetchError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             EdgeError::InvalidServerUrl(_) => StatusCode::INTERNAL_SERVER_ERROR,
             EdgeError::PersistenceError(_) => StatusCode::INTERNAL_SERVER_ERROR,

--- a/server/src/http/feature_refresher.rs
+++ b/server/src/http/feature_refresher.rs
@@ -321,6 +321,18 @@ impl FeatureRefresher {
                                     self.engine_cache.remove(&cache_key);
                                 }
                             }
+                            FeatureError::NotFound => {
+                                warn!("Had a bad URL when trying to fetch features. Removing ourselves");
+                                self.tokens_to_refresh.remove(&refresh.token.token);
+                                if !self.tokens_to_refresh.iter().any(|e| {
+                                    e.value().token.environment == refresh.token.environment
+                                }) {
+                                    let cache_key = cache_key(&refresh.token);
+                                    // No tokens left that access the environment of our current refresh. Deleting client features and engine cache
+                                    self.features_cache.remove(&cache_key);
+                                    self.engine_cache.remove(&cache_key);
+                                }
+                            }
                         }
                     }
                     _ => warn!("Couldn't refresh features: {e:?}. Will retry next pass"),

--- a/server/src/http/unleash_client.rs
+++ b/server/src/http/unleash_client.rs
@@ -334,9 +334,9 @@ impl UnleashClient {
                 .get("ETag")
                 .or_else(|| response.headers().get("etag"))
                 .and_then(|etag| EntityTag::from_str(etag.to_str().unwrap()).ok());
-            let features = response.json::<ClientFeatures>().await.map_err(|_e| {
+            let features = response.json::<ClientFeatures>().await.map_err(|e| {
                 warn!("Could not parse features response to internal representation");
-                EdgeError::ClientFeaturesParseError
+                EdgeError::ClientFeaturesParseError(e.to_string())
             })?;
             Ok(ClientFeaturesResponse::Updated(features, etag))
         } else if response.status() == StatusCode::FORBIDDEN {

--- a/server/src/http/unleash_client.rs
+++ b/server/src/http/unleash_client.rs
@@ -473,7 +473,7 @@ impl UnleashClient {
                 TOKEN_VALIDATION_FAILURES
                     .with_label_values(&[result.status().as_str()])
                     .inc();
-                info!(
+                warn!(
                     "Failed to validate tokens. Requested url: [{}]. Got status: {:?}",
                     self.urls.edge_validate_url.to_string(),
                     s

--- a/server/src/middleware/client_token_from_frontend_token.rs
+++ b/server/src/middleware/client_token_from_frontend_token.rs
@@ -8,6 +8,7 @@ use tracing::{debug, instrument};
 
 use crate::{
     http::feature_refresher::FeatureRefresher,
+    tokens,
     types::{EdgeResult, EdgeToken, TokenValidationStatus},
 };
 
@@ -32,7 +33,10 @@ pub async fn client_token_from_frontend_token(
 ) -> Result<ServiceResponse<impl MessageBody>, actix_web::Error> {
     if let Some(token_cache) = req.app_data::<Data<DashMap<String, EdgeToken>>>() {
         if let Some(fe_token) = token_cache.get(&token.token) {
-            debug!("Token got extracted to {:#?}", fe_token.value().clone());
+            debug!(
+                "Token got extracted to {:#?}",
+                tokens::anonymize_token(fe_token.value())
+            );
             if fe_token.status == TokenValidationStatus::Validated {
                 create_client_token_for_fe_token(&req, &fe_token).await?;
             }

--- a/server/src/persistence/mod.rs
+++ b/server/src/persistence/mod.rs
@@ -31,21 +31,23 @@ pub async fn persist_data(
         tokio::select! {
             _ = tokio::time::sleep(Duration::from_secs(60)) => {
                 if let Some(persister) = persistence.clone() {
-                    if persister.save_tokens(token_cache.iter().filter(|t| t.value().status == TokenValidationStatus::Validated).map(|e| e.value().clone()).collect()).await.is_ok() {
-                        debug!("Persisted tokens");
-                    } else {
-                        warn!("Could not persist tokens");
+                    match persister.save_tokens(token_cache.iter().filter(|t| t.value().status == TokenValidationStatus::Validated).map(|e| e.value().clone()).collect()).await {
+                        Ok(()) => debug!("Persisted tokens"),
+                        Err(save_error) =>
+                            warn!("Could not persist tokens: {save_error:?}")
+
+
                     }
-                    if persister.save_features(features_cache.iter().map(|e| (e.key().clone(), e.value().clone())).collect()).await.is_ok() {
-                        debug!("Persisted features");
-                    } else {
-                        warn!("Could not persist features");
+                    match persister.save_features(features_cache.iter().map(|e| (e.key().clone(), e.value().clone())).collect()).await {
+                        Ok(()) => debug!("Persisted features"),
+                        Err(save_error) =>
+                            warn!("Could not persist features: {save_error:?}")
+
                     }
 
-                    if persister.save_refresh_targets(refresh_targets_cache.iter().map(|e| e.value().clone()).collect()).await.is_ok() {
-                        debug!("Persisted refresh targets");
-                    } else {
-                        warn!("Could not persist refresh targets");
+                    match persister.save_refresh_targets(refresh_targets_cache.iter().map(|e| e.value().clone()).collect()).await {
+                        Ok(()) => debug!("Persisted refresh targets"),
+                        Err(save_error) => warn!("Could not persist refresh targets: {save_error:?}")
                     }
                 } else {
                     debug!("Had no persister. Nothing was persisted");

--- a/server/src/persistence/redis.rs
+++ b/server/src/persistence/redis.rs
@@ -70,7 +70,7 @@ impl EdgePersistence for RedisPersister {
         let mut client = self.redis_client.write().await;
         let raw_features: String = client.get(FEATURES_KEY)?;
         let raw_features = serde_json::from_str::<Vec<(String, ClientFeatures)>>(&raw_features)
-            .map_err(|_| EdgeError::ClientFeaturesParseError)?;
+            .map_err(|e| EdgeError::ClientFeaturesParseError(e.to_string()))?;
         Ok(raw_features.into_iter().collect())
     }
 


### PR DESCRIPTION
This adds more output to our error messages when we fail to validate tokens as well as when we receive 401 or 404 from client features endpoints.