### PR TITLE
fix: allow startup tokens to continue to validate against upstream

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -60,6 +60,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let lazy_feature_cache = features_cache.clone();
     let lazy_token_cache = token_cache.clone();
     let lazy_engine_cache = engine_cache.clone();
+    let lazy_feature_refresher = feature_refresher.clone();
 
     let metrics_cache = Arc::new(MetricsCache::default());
     let metrics_cache_clone = metrics_cache.clone();
@@ -156,6 +157,9 @@ async fn main() -> Result<(), anyhow::Error> {
                     tracing::info!("Persister was unexpectedly shut down");
                 }
                 _ = validator.schedule_validation_of_known_tokens(edge.token_revalidation_interval_seconds) => {
+                    tracing::info!("Token validator validator was unexpectedly shut down");
+                }
+                _ = validator.schedule_revalidation_of_startup_tokens(edge.tokens, lazy_feature_refresher) => {
                     tracing::info!("Token validator validator was unexpectedly shut down");
                 }
             }


### PR DESCRIPTION
Forces Edge to continue to validate startup tokens until they succeed. This fixes an issue where if Edge couldn't validate the startup tokens against Unleash, it would discard them and never try again. This does make the assumption that Edge should assume the startup tokens are valid and continue to check until it gets a response from Unleash. While the code looks a little icky, the loop becomes a no-op on a background thread once the tokens have been validated and no further calls will occur. If the tokens provided for startup are not valid, Edge will log that in the loop. I think that's correct, since the tokens _should_ be correct, or the user should get a strong warning that the config is broken. If the tokens can be validated during Edge's startup sequence, then the loop will never make HTTP calls