### PR TITLE
small clean ups of unreachable branches

### DIFF
--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -201,7 +201,6 @@ pub async fn build_caches_and_refreshers(args: CliArgs) -> EdgeResult<EdgeInfo> 
             build_offline(offline_args).map(|cache| (cache, None, None, None))
         }
         EdgeMode::Edge(edge_args) => build_edge(&edge_args).await,
-        EdgeMode::Health(_) => unreachable!("Trying to build caches for health check"),
-        EdgeMode::Ready(_) => unreachable!("Trying to build caches for ready check"),
+        _ => unreachable!(),
     }
 }

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -361,9 +361,7 @@ mod tests {
                 assert_eq!(api_key.0, "X-Api-Key");
                 assert_eq!(api_key.1, "mysecret")
             }
-            EdgeMode::Offline(_) => unreachable!(),
-            EdgeMode::Health(_) => unreachable!(),
-            EdgeMode::Ready(_) => unreachable!(),
+            _ => unreachable!(),
         }
     }
 
@@ -387,9 +385,7 @@ mod tests {
                 assert_eq!(api_key.0, "X-Api-Key");
                 assert_eq!(api_key.1, "mysecret")
             }
-            EdgeMode::Offline(_) => unreachable!(),
-            EdgeMode::Health(_) => unreachable!(),
-            EdgeMode::Ready(_) => unreachable!(),
+            _ => unreachable!(),
         }
     }
 
@@ -410,9 +406,7 @@ mod tests {
                 assert_eq!(auth.0, "Authorization");
                 assert_eq!(auth.1, "test:test.secret");
             }
-            EdgeMode::Offline(_) => unreachable!(),
-            EdgeMode::Health(_) => unreachable!(),
-            EdgeMode::Ready(_) => unreachable!(),
+            _ => unreachable!(),
         }
     }
 

--- a/server/src/tokens.rs
+++ b/server/src/tokens.rs
@@ -126,12 +126,7 @@ impl FromRequest for EdgeToken {
                     Some(v) => EdgeToken::try_from(v.clone()),
                     None => Err(EdgeError::AuthorizationDenied),
                 },
-                EdgeMode::Health(_) => {
-                    unreachable!("Trying to get token when running in healthcheck mode")
-                }
-                EdgeMode::Ready(_) => {
-                    unreachable!("Trying to get token when running in ready check mode")
-                }
+                _ => unreachable!(),
             };
             ready(key)
         } else {


### PR DESCRIPTION
Our unreachable code is getting a bit noisy. If we trust rustc and the tests, we should be able to do this without trouble