### PR TITLE
Quote angle brackets; fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Options:
 
 ##### Environments in offline mode
 Currently, Edge does not support multiple environments in offline mode. All tokens added at startup will receive the same list of features passed in as the bootstrap argument. 
-However, tokens in <project>:<environment>.<secret> format will still filter by project.
+However, tokens in `<project>:<environment>.<secret>` format will still filter by project.
 
 ## [Metrics](https://docs.getunleash.io/reference/api/unleash/metrics)
 


### PR DESCRIPTION
This surrounds angle bracketed content in backticks, so that markdown renders it as expected instead of parsing it as html tags. The wrong parsing also causes our doc build to fail.

It currently renders as nothing on github too:
![image](https://github.com/Unleash/unleash-edge/assets/17786332/6a501402-1d99-4a36-82c9-1b33ff4e5c6b)
