### PR TITLE
DO NOT MERGE: Testing if organising features in ENV -> PROJECT -> FEATURES is easier

### DIFF
--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -160,6 +160,7 @@ async fn build_edge(args: &EdgeArgs) -> EdgeResult<EdgeInfo> {
     let feature_refresher = Arc::new(FeatureRefresher::new(
         unleash_client,
         feature_cache.clone(),
+        Arc::new(DashMap::default()),
         engine_cache.clone(),
         Duration::seconds(args.features_refresh_interval_seconds.try_into().unwrap()),
         persistence.clone(),


### PR DESCRIPTION
Testing if organising features in ENV -> PROJECT -> FEATURES is easier to work with, compared to ENV -> FEATURES.

I think it is, but it needs more work to be efficient. I think the old way of storing should be removed in favour of this way. The way of returning toggles should be changed to select by project and environment instead of selecting by environment and then filtering by projects.


This solves the problem of archived toggles not dissapearing from the features endpoint.

This is just an example to look at, nothing to merge here