### PR TITLE
fix(#274): use the validated token to calculate flags to return

### DIFF
--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -635,7 +635,6 @@ mod tests {
         token_a.projects = vec!["dx".into(), "eg".into()];
         token_a.status = TokenValidationStatus::Validated;
         token_a.token_type = Some(TokenType::Client);
-        println!("Created token A: {:?}", token_a);
         token_cache.insert(token_a.token.clone(), token_a.clone());
 
         let mut token_b =

--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -129,7 +129,7 @@ pub async fn get_feature(
         .ok_or(EdgeError::AuthorizationDenied)?;
 
     let filter_set = FeatureFilterSet::from(Box::new(name_match_filter(feature_name.clone())))
-        .with_filter(project_filter(&edge_token));
+        .with_filter(project_filter(&validated_token));
 
     match req.app_data::<Data<FeatureRefresher>>() {
         Some(refresher) => {
@@ -138,7 +138,7 @@ pub async fn get_feature(
                 .await
         }
         None => features_cache
-            .get(&cache_key(&edge_token))
+            .get(&cache_key(&validated_token))
             .map(|client_features| filter_client_features(&client_features, filter_set))
             .ok_or(EdgeError::ClientFeaturesFetchError(FeatureError::Retriable)),
     }


### PR DESCRIPTION
This change fixes a bug where the client API would return all flags
that existed in the cache, even if the api token did not have access
to those flags. Crucially, the API token had to have access to
multiple (but not all) projects for this to happen.

The root cause is that we used the incoming edge token to check which
flags to return. Before it gets validated, its `projects` property is
just an empty list. In the filtering, this causes edge to return all
available. Features.

The solution was to instead use the validated edge token that we
create further up.

There is also a test that confirms this behavior is what we expect.

## Discussion point

Could we make it so that the `with_filter` function can only take
validated edge tokens or would that break something else? Might be a
good way to future proof it.

---

Closes #274 