### PR TITLE
fix: No longer return wrong feature toggle

### DIFF
--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -92,6 +92,7 @@ pub enum EdgeError {
     ClientCertificateError(CertificateError),
     ClientFeaturesFetchError(FeatureError),
     ClientFeaturesParseError(String),
+    ClientHydrationFailed(String),
     ClientRegisterError,
     FrontendNotYetHydrated(FrontendHydrationMissing),
     FeatureNotFound(String),
@@ -117,7 +118,7 @@ pub enum EdgeError {
 impl Error for EdgeError {}
 
 impl Display for EdgeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             EdgeError::InvalidBackupFile(path, why_invalid) => {
                 write!(f, "file at path: {path} was invalid due to {why_invalid}")
@@ -140,6 +141,7 @@ impl Display for EdgeError {
                     "Could not fetch features because upstream url was not found"
                 ),
             },
+
             EdgeError::FeatureNotFound(name) => {
                 write!(f, "Failed to find feature with name {name}")
             }
@@ -188,6 +190,12 @@ impl Display for EdgeError {
                     status_code
                 )
             }
+            EdgeError::ClientHydrationFailed(message) => {
+                write!(
+                    f,
+                    "Client hydration failed. Somehow we said [{message}] when it did"
+                )
+            }
         }
     }
 }
@@ -221,6 +229,7 @@ impl ResponseError for EdgeError {
             EdgeError::EdgeMetricsRequestError(status_code) => *status_code,
             EdgeError::HealthCheckError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             EdgeError::ReadyCheckError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            EdgeError::ClientHydrationFailed(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 

--- a/server/src/filters.rs
+++ b/server/src/filters.rs
@@ -29,7 +29,7 @@ impl FeatureFilterSet {
 
 fn filter_features(
     feature_cache: &Ref<'_, String, ClientFeatures>,
-    filters: FeatureFilterSet,
+    filters: &FeatureFilterSet,
 ) -> Vec<ClientFeature> {
     feature_cache
         .features
@@ -41,7 +41,7 @@ fn filter_features(
 
 pub(crate) fn filter_client_features(
     feature_cache: &Ref<'_, String, ClientFeatures>,
-    filters: FeatureFilterSet,
+    filters: &FeatureFilterSet,
 ) -> ClientFeatures {
     ClientFeatures {
         features: filter_features(feature_cache, filters),
@@ -97,11 +97,11 @@ mod tests {
 
         let features = map.get(&feature_name).unwrap();
         let filter_for_enabled = FeatureFilterSet::from(Box::new(|f| f.enabled));
-        let enabled_features = filter_features(&features, filter_for_enabled);
+        let enabled_features = filter_features(&features, &filter_for_enabled);
 
         let features = map.get(&feature_name).unwrap();
         let filter_for_disabled = FeatureFilterSet::from(Box::new(|f| !f.enabled));
-        let disabled_features = filter_features(&features, filter_for_disabled);
+        let disabled_features = filter_features(&features, &filter_for_disabled);
 
         assert_eq!(enabled_features[0].name, client_features.features[0].name);
 
@@ -144,7 +144,7 @@ mod tests {
 
         let chained_filter = FeatureFilterSet::from(Box::new(|f| f.enabled))
             .with_filter(Box::new(|f| f.impression_data.unwrap_or(false)));
-        let enabled_features = filter_features(&features, chained_filter);
+        let enabled_features = filter_features(&features, &chained_filter);
 
         assert_eq!(enabled_features[0].name, "feature-three".to_string());
     }
@@ -178,22 +178,22 @@ mod tests {
         let features = map.get(&map_key).unwrap();
 
         let filter = FeatureFilterSet::from(name_prefix_filter("feature-".to_string()));
-        let filtered_features = filter_features(&features, filter);
+        let filtered_features = filter_features(&features, &filter);
 
         assert_eq!(filtered_features.len(), 3);
 
         let filter = FeatureFilterSet::from(name_prefix_filter("feature-t".to_string()));
-        let filtered_features = filter_features(&features, filter);
+        let filtered_features = filter_features(&features, &filter);
 
         assert_eq!(filtered_features.len(), 2);
 
         let filter = FeatureFilterSet::from(name_prefix_filter("feature-o".to_string()));
-        let filtered_features = filter_features(&features, filter);
+        let filtered_features = filter_features(&features, &filter);
 
         assert_eq!(filtered_features.len(), 1);
 
         let filter = FeatureFilterSet::from(name_prefix_filter("feature-four".to_string()));
-        let filtered_features = filter_features(&features, filter);
+        let filtered_features = filter_features(&features, &filter);
 
         assert_eq!(filtered_features.len(), 0);
     }
@@ -235,7 +235,7 @@ mod tests {
         };
 
         let filter = FeatureFilterSet::from(project_filter(&token));
-        let filtered_features = filter_features(&features, filter);
+        let filtered_features = filter_features(&features, &filter);
 
         assert_eq!(filtered_features.len(), 2);
         assert_eq!(filtered_features[0].name, "feature-one".to_string());


### PR DESCRIPTION
Previously, upon first access with a new token which Edge hadn't seen before our rehydration code only filtered by project of the token, so once it had the data it would stupidly return the token that was available for the new token (in the wrong project).

After this refactor/fix we now apply all filters to all queries for feature toggles from the cache, which should reduce the combinations of possible filter mistakes.

fixes: #276
