### PR TITLE
chore: bump utoipa and unleash types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2219,9 +2219,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "6.8.1"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a36224c3276f8c4ebc8c20f158eca7ca4359c8db89991c4925132aaaf6702661"
+checksum = "b1e7d90385b59f0a6bf3d3b757f3ca4ece2048265d70db20a2016043d4509a40"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -2230,9 +2230,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "6.8.1"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b94b81e5b2c284684141a2fb9e2a31be90638caf040bf9afbc5a0416afe1ac"
+checksum = "3c3d8c6fd84090ae348e63a84336b112b5c3918b3bf0493a581f7bd8ee623c29"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2244,9 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "7.8.1"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d38ff6bf570dc3bb7100fce9f7b60c33fa71d80e88da3f2580df4ff2bdded74"
+checksum = "873feff8cb7bf86fdf0a71bb21c95159f4e4a37dd7a4bd1855a940909b583ada"
 dependencies = [
  "sha2",
  "walkdir",
@@ -3159,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "unleash-types"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8094986ab97242a6d5fc446b7c60c2d362bf3e206fd74d018160584ccb6a1fc3"
+checksum = "7caf216e78647316eeb2b671e59c47c3f6d17be242125593773231d06739d627"
 dependencies = [
  "base64",
  "chrono",
@@ -3224,9 +3224,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "utoipa"
-version = "3.5.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82b1bc5417102a73e8464c686eef947bdfb99fcdfc0a4f228e81afa9526470a"
+checksum = "6b208a50ff438dcdc887ea3f2db59530bd2f4bc3d2c70630e4d7ee7a281a1d1b"
 dependencies = [
  "indexmap 2.0.0",
  "serde",
@@ -3236,9 +3236,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "3.5.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d96dcd6fc96f3df9b3280ef480770af1b7c5d14bc55192baa9b067976d920c"
+checksum = "0bd516d8879043e081537690bc96c8f17b5a4602c336aecb8f1de89d9d9c7e72"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -3249,9 +3249,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-swagger-ui"
-version = "3.1.5"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84614caa239fb25b2bb373a52859ffd94605ceb256eeb1d63436325cf81e3653"
+checksum = "154517adf0d0b6e22e8e1f385628f14fcaa3db43531dc74303d3edef89d6dfe5"
 dependencies = [
  "actix-web",
  "mime_guess",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -54,8 +54,8 @@ tracing-subscriber = {version = "0.3.17", features = ["json", "env-filter"]}
 ulid = "1.1.0"
 unleash-types = { version = "0.10", features = ["openapi", "hashes"]}
 unleash-yggdrasil = { version = "0.6.0" }
-utoipa = {version = "3", features = ["actix_extras", "chrono"]}
-utoipa-swagger-ui = {version = "3", features = ["actix-web"]}
+utoipa = {version = "4", features = ["actix_extras", "chrono"]}
+utoipa-swagger-ui = {version = "4", features = ["actix-web"]}
 [dev-dependencies]
 actix-http = "3.4.0"
 actix-http-test = "3.1.0"

--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -358,6 +358,7 @@ mod tests {
                     feature_type: Some("release".into()),
                     description: Some("test feature".into()),
                     created_at: Some(Utc::now()),
+                    dependencies: None,
                     last_seen_at: None,
                     enabled: true,
                     stale: Some(false),
@@ -386,6 +387,7 @@ mod tests {
                 ClientFeature {
                     name: "feature_two_no_strats".into(),
                     feature_type: None,
+                    dependencies: None,
                     description: None,
                     created_at: Some(Utc.with_ymd_and_hms(2022, 12, 5, 12, 31, 0).unwrap()),
                     last_seen_at: None,
@@ -400,6 +402,7 @@ mod tests {
                     name: "feature_three".into(),
                     feature_type: Some("release".into()),
                     description: None,
+                    dependencies: None,
                     created_at: None,
                     last_seen_at: None,
                     enabled: true,
@@ -930,6 +933,7 @@ mod tests {
                 ClientFeature {
                     name: "edge-flag-1".into(),
                     feature_type: None,
+                    dependencies: None,
                     description: None,
                     created_at: None,
                     last_seen_at: None,
@@ -943,6 +947,7 @@ mod tests {
                 ClientFeature {
                     name: "edge-flag-3".into(),
                     feature_type: None,
+                    dependencies: None,
                     description: None,
                     created_at: None,
                     last_seen_at: None,

--- a/server/src/persistence/file.rs
+++ b/server/src/persistence/file.rs
@@ -215,6 +215,7 @@ mod tests {
                     last_seen_at: None,
                     stale: Some(false),
                     impression_data: Some(false),
+                    dependencies: None,
                 },
                 ClientFeature {
                     name: "test2".to_string(),


### PR DESCRIPTION
Does what it says on the tin, this doesn't alter any features but it does mean client SDKs that support dependent features work correctly against Edge