### PR TITLE
fix: move etag middleware to last in chain to ensure it gets added in…

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -100,9 +100,9 @@ async fn main() -> Result<(), anyhow::Error> {
         };
         app.service(
             web::scope(&base_path)
+                .wrap(Etag)
                 .wrap(actix_web::middleware::Compress::default())
                 .wrap(actix_web::middleware::NormalizePath::default())
-                .wrap(Etag)
                 .wrap(cors_middleware)
                 .wrap(RequestTracing::new())
                 .wrap(request_metrics.clone())


### PR DESCRIPTION
## About the changes

fix: move etag middleware to last in chain to ensure it gets added In gziped responses 

<!-- Does it close an issue? Multiple? -->
Closes #
https://github.com/Unleash/unleash-client-dotnet/issues/165


