### PR TITLE
chore: Removed shadow-rs to reduce our dependencies tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,32 +637,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
-
-[[package]]
-name = "const_format"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,19 +1099,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
-name = "git2"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf97ba92db08df386e10c8ede66a2a0369bd277090afd8710e19e38de9ec0cd"
-dependencies = [
- "bitflags 2.4.1",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
-
-[[package]]
 name = "h2"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,12 +1342,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_debug"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d198e9919d9822d5f7083ba8530e04de87841eaf21ead9af8f2304efd57c89"
-
-[[package]]
 name = "iter_tools"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,30 +1400,6 @@ name = "libc"
 version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
-
-[[package]]
-name = "libgit2-sys"
-version = "0.16.1+1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1623,15 +1554,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
  "libc",
 ]
 
@@ -2477,19 +2399,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shadow-rs"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9198caff1c94f1a5df6664bddbc379896b51b98a55b0b3fedcb23078fe00c77"
-dependencies = [
- "const_format",
- "git2",
- "is_debug",
- "time",
- "tzdb",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2745,8 +2654,6 @@ checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
  "itoa",
- "libc",
- "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -2976,25 +2883,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
-name = "tz-rs"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
-dependencies = [
- "const_fn",
-]
-
-[[package]]
-name = "tzdb"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec758958f2fb5069cd7fae385be95cc8eceb8cdfd270c7d14de6034f0108d99e"
-dependencies = [
- "iana-time-zone",
- "tz-rs",
-]
-
-[[package]]
 name = "ucd-trie"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3046,12 +2934,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
 name = "unleash-edge"
 version = "14.0.0"
 dependencies = [
@@ -3091,7 +2973,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
- "shadow-rs",
  "test-case",
  "testcontainers",
  "testcontainers-modules",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -48,7 +48,6 @@ rustls-pemfile = "1.0.3"
 serde = {version = "1.0.189", features = ["derive"]}
 serde_json = "1.0.107"
 serde_qs = { version = "0.12.0", features = ["actix4", "tracing"] }
-shadow-rs = "0.24.1"
 tokio = {version = "1.33.0", features = ["macros", "rt-multi-thread", "tracing", "fs"]}
 tracing = {version = "0.1.40", features = ["log"]}
 tracing-subscriber = {version = "0.3.17", features = ["json", "env-filter"]}
@@ -68,6 +67,3 @@ test-case = "3.2.1"
 testcontainers = "0.15.0"
 testcontainers-modules = { version = "0.1.3", features = ["redis"]}
 tracing-test = "0.2.4"
-
-[build-dependencies]
-shadow-rs = "0.24.1"

--- a/server/build.rs
+++ b/server/build.rs
@@ -1,3 +1,0 @@
-fn main() -> shadow_rs::SdResult<()> {
-    shadow_rs::new()
-}

--- a/server/src/http/feature_refresher.rs
+++ b/server/src/http/feature_refresher.rs
@@ -18,7 +18,7 @@ use super::unleash_client::UnleashClient;
 use crate::error::{EdgeError, FeatureError};
 use crate::filters::{filter_client_features, FeatureFilterSet};
 use crate::types::{
-    build, ClientTokenRequest, ClientTokenResponse, EdgeResult, TokenType, TokenValidationStatus,
+    self, ClientTokenRequest, ClientTokenResponse, EdgeResult, TokenType, TokenValidationStatus,
 };
 use crate::{
     persistence::EdgePersistence,
@@ -120,7 +120,7 @@ fn client_application_from_token(token: EdgeToken, refresh_interval: i64) -> Cli
         environment: token.environment,
         instance_id: None,
         interval: refresh_interval as u32,
-        sdk_version: Some(format!("unleash-edge:{}", build::PKG_VERSION)),
+        sdk_version: Some(format!("unleash-edge:{}", types::CARGO_PKG_VERSION)),
         started: Utc::now(),
         strategies: vec![],
     }

--- a/server/src/http/unleash_client.rs
+++ b/server/src/http/unleash_client.rs
@@ -153,7 +153,7 @@ fn new_reqwest_client(
             );
 
             client
-                .user_agent(format!("unleash-edge-{}", crate::types::build::PKG_VERSION))
+                .user_agent(format!("unleash-edge-{}", crate::types::CARGO_PKG_VERSION))
                 .default_headers(header_map)
                 .danger_accept_invalid_certs(skip_ssl_verification)
                 .timeout(socket_timeout.to_std().unwrap())

--- a/server/src/prom_metrics.rs
+++ b/server/src/prom_metrics.rs
@@ -31,11 +31,10 @@ pub fn instantiate(
 fn instantiate_prometheus_metrics_handler(
     registry: prometheus::Registry,
 ) -> (PrometheusMetricsHandler, RequestMetrics) {
-    let resource = opentelemetry::sdk::Resource::new(vec![
-        opentelemetry::KeyValue::new("service.name", "unleash-edge"),
-        opentelemetry::KeyValue::new("edge.version", crate::types::build::PKG_VERSION),
-        opentelemetry::KeyValue::new("edge.githash", crate::types::build::SHORT_COMMIT),
-    ]);
+    let resource = opentelemetry::sdk::Resource::new(vec![opentelemetry::KeyValue::new(
+        "service.name",
+        "unleash-edge",
+    )]);
     let provider = MeterProvider::builder().with_resource(resource).build();
     (
         PrometheusMetricsHandler::new(registry),

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -13,7 +13,6 @@ use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use dashmap::DashMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use shadow_rs::shadow;
 use unleash_types::client_features::ClientFeatures;
 use unleash_types::client_metrics::{ClientApplication, ClientMetricsEnv};
 use unleash_yggdrasil::EngineState;
@@ -273,60 +272,13 @@ pub struct ClientTokenRequest {
     pub environment: String,
     pub expires_at: DateTime<Utc>,
 }
+pub const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[async_trait]
 pub trait TokenValidator {
     /// Will validate upstream, and add tokens with status from upstream to token cache.
     /// Will block until verified with upstream
     async fn register_tokens(&mut self, tokens: Vec<String>) -> EdgeResult<Vec<EdgeToken>>;
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct BuildInfo {
-    pub package_version: String,
-    pub app_name: String,
-    pub git_commit_date: DateTime<Utc>,
-    pub package_major: String,
-    pub package_minor: String,
-    pub package_patch: String,
-    pub package_version_pre: Option<String>,
-    pub branch: String,
-    pub tag: String,
-    pub rust_version: String,
-    pub rust_channel: String,
-    pub short_commit_hash: String,
-    pub full_commit_hash: String,
-    pub build_os: String,
-    pub build_target: String,
-}
-
-shadow!(build); // Get build information set to build placeholder
-impl Default for BuildInfo {
-    fn default() -> Self {
-        BuildInfo {
-            package_version: build::PKG_VERSION.into(),
-            app_name: build::PROJECT_NAME.into(),
-            package_major: build::PKG_VERSION_MAJOR.into(),
-            package_minor: build::PKG_VERSION_MINOR.into(),
-            package_patch: build::PKG_VERSION_PATCH.into(),
-            package_version_pre: if build::PKG_VERSION_PRE.is_empty() {
-                None
-            } else {
-                Some(build::PKG_VERSION_PRE.into())
-            },
-            branch: build::BRANCH.into(),
-            tag: build::TAG.into(),
-            rust_version: build::RUST_VERSION.into(),
-            rust_channel: build::RUST_CHANNEL.into(),
-            short_commit_hash: build::SHORT_COMMIT.into(),
-            full_commit_hash: build::COMMIT_HASH.into(),
-            git_commit_date: DateTime::parse_from_rfc3339(build::COMMIT_DATE_3339)
-                .expect("shadow-rs did not give proper date")
-                .into(),
-            build_os: build::BUILD_OS.into(),
-            build_target: build::BUILD_TARGET.into(),
-        }
-    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, IntoParams)]

--- a/server/tests/base_path_test.rs
+++ b/server/tests/base_path_test.rs
@@ -2,7 +2,6 @@
 mod base_path_tests {
     use reqwest::Client;
     use std::process::{Command, Stdio};
-    use unleash_edge::types::BuildInfo;
 
     #[actix_web::test]
     async fn test_base_path() {
@@ -29,7 +28,7 @@ mod base_path_tests {
         // Send a request to the app
         let client = Client::new();
         let base_url = "http://localhost:3063";
-        let endpoint = "/internal-backstage/info";
+        let endpoint = "/internal-backstage/health";
         let url = format!("{}{}{}", base_url, base_path, endpoint);
         let resp = client
             .get(&url)
@@ -39,18 +38,6 @@ mod base_path_tests {
 
         // Assert that the response status is 200 OK
         assert!(resp.status().is_success());
-
-        let body = resp
-            .bytes()
-            .await
-            .expect("Failed to retrieve response body as bytes");
-
-        // Deserialize the response body into BuildInfo struct
-        let info: BuildInfo =
-            serde_json::from_slice(&body).expect("Failed to deserialize response body");
-
-        // Assert that the app_name field matches the expected value
-        assert_eq!(info.app_name, "unleash-edge");
 
         // Test a different endpoint
         let url = format!("{}{}{}", base_url, base_path, "/api/client/features");


### PR DESCRIPTION
We did some build timings and found that libgit2 was taking the most time to build, since we weren't using the info endpoint much, and we could find the pkg version using the env! macro instead it felt like a good trade off.