### PR TITLE
feat: Add support for setting log format at startup

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -45,7 +45,7 @@ This document contains the help content for the `unleash-edge` command-line prog
   Default value: `3043`
 * `--instance-id <INSTANCE_ID>` — Instance id. Used for metrics reporting
 
-  Default value: `01HAM0JMKDMZZP0HXNT8K1J6FW`
+  Default value: `01HE51VN5SQBAWR5Q93NAESEPW`
 * `-a`, `--app-name <APP_NAME>` — App name. Used for metrics reporting
 
   Default value: `unleash-edge`
@@ -58,6 +58,12 @@ This document contains the help content for the `unleash-edge` command-line prog
 * `--edge-request-timeout <EDGE_REQUEST_TIMEOUT>` — Timeout for requests to Edge
 
   Default value: `5`
+* `-l`, `--log-format <LOG_FORMAT>` — Which log format should Edge use
+
+  Default value: `plain`
+
+  Possible values: `plain`, `json`, `pretty`
+
 
 
 

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -218,6 +218,13 @@ pub struct ReadyCheckArgs {
     pub ca_certificate_file: Option<PathBuf>,
 }
 
+#[derive(Debug, Clone, ValueEnum)]
+pub enum LogFormat {
+    Plain,
+    Json,
+    Pretty,
+}
+
 #[derive(Parser, Debug, Clone)]
 pub struct CliArgs {
     #[clap(flatten)]
@@ -248,6 +255,10 @@ pub struct CliArgs {
     /// Timeout for requests to Edge
     #[clap(long, env, default_value_t = 5)]
     pub edge_request_timeout: u64,
+
+    /// Which log format should Edge use
+    #[clap(short, long, env, global = true, value_enum, default_value_t = LogFormat::Plain)]
+    pub log_format: LogFormat,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/server/src/http/feature_refresher.rs
+++ b/server/src/http/feature_refresher.rs
@@ -1163,7 +1163,6 @@ mod tests {
         upstream_features_cache.insert(cache_key.clone(), empty_features);
 
         feature_refresher.refresh_features().await;
-        println!("{:#?}", features_cache.get(&cache_key).unwrap().features);
         // Since our response was empty, our theory is that there should be no features here now.
         assert!(!features_cache
             .get(&cache_key)

--- a/server/src/http/unleash_client.rs
+++ b/server/src/http/unleash_client.rs
@@ -949,24 +949,4 @@ mod tests {
         );
         assert!(client.is_ok());
     }
-
-    /* #[tokio::test]
-    pub async fn can_make_ssl_request() {
-        let root_cert = "./testdata/tls/certs/cacert.pem";
-        let key = "./testdata/client_certs/client.key.pem";
-        let cert = "./testdata/client_certs/client.cert.pem";
-        let identity = ClientTls {
-            pkcs8_client_certificate_file: Some(cert.into()),
-            pkcs8_client_key_file: Some(key.into()),
-            pkcs12_identity_file: None,
-            pkcs12_passphrase: None,
-            upstream_certificate_file: Some(root_cert.into()),
-        };
-        let client = new_reqwest_client("test_pkcs8".into(), false, Some(identity));
-        assert!(client.is_ok());
-        let actual_client = client.unwrap();
-        let res = actual_client.get("https://localhost:4433").send().await;
-        println!("{res:?}");
-        assert!(res.is_ok());
-    }*/
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let request_timeout = args.edge_request_timeout;
     let trust_proxy = args.clone().trust_proxy;
     let base_path = http_args.base_path.clone();
-    let (metrics_handler, request_metrics) = prom_metrics::instantiate(None);
+    let (metrics_handler, request_metrics) = prom_metrics::instantiate(None, &args.log_format);
     let connect_via = ConnectVia {
         app_name: args.clone().app_name,
         instance_id: args.clone().instance_id,

--- a/server/src/ready_checker.rs
+++ b/server/src/ready_checker.rs
@@ -44,10 +44,7 @@ pub async fn check_ready(ready_check_args: ReadyCheckArgs) -> Result<(), EdgeErr
             ))
         })?;
         match ready_check_result.status {
-            Status::Ready => {
-                println!("OK");
-                Ok(())
-            }
+            Status::Ready => Ok(()),
             _ => Err(EdgeError::ReadyCheckError(format!(
                 "Ready check returned a different status than READY. It returned {:?}",
                 ready_check_result


### PR DESCRIPTION
We've had a customer request to be able to change log formatting. This PR adds support for plain (what we currently have), pretty (a bit friendlier format) and json 
```json
{"timestamp":"2023-11-01T09:00:16.007926Z","level":"DEBUG","fields":{"message":"No update needed. Will update last check time with \"537b2ba0:127766\""},"target":"unleash_edge::http::feature_refresher"}
```