### PR TITLE
feat: obey http status responses. backoff when 429 or 50x

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -51,6 +51,7 @@ opentelemetry_sdk = { version = "0.20.0", features = [
 ] }
 prometheus = { version = "0.13.3", features = ["process"] }
 prometheus-static-metric = "0.5.1"
+rand = "0.8.5"
 redis = { version = "0.23.3", features = ["tokio-comp", "tokio-rustls-comp"] }
 reqwest = { version = "0.11.22", default-features = false, features = [
   "rustls",

--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -1,4 +1,4 @@
-use crate::error::{EdgeError, FeatureError};
+use crate::error::EdgeError;
 use crate::filters::{
     filter_client_features, name_match_filter, name_prefix_filter, project_filter, FeatureFilterSet,
 };
@@ -94,7 +94,7 @@ async fn resolve_features(
         None => features_cache
             .get(&cache_key(&validated_token))
             .map(|client_features| filter_client_features(&client_features, &filter_set))
-            .ok_or(EdgeError::ClientFeaturesFetchError(FeatureError::Retriable)),
+            .ok_or(EdgeError::ClientCacheError),
     }?;
 
     Ok(Json(ClientFeatures {
@@ -140,7 +140,7 @@ pub async fn get_feature(
         None => features_cache
             .get(&cache_key(&validated_token))
             .map(|client_features| filter_client_features(&client_features, &filter_set))
-            .ok_or(EdgeError::ClientFeaturesFetchError(FeatureError::Retriable)),
+            .ok_or(EdgeError::ClientCacheError),
     }
     .map(|client_features| client_features.features.into_iter().next())?
     .ok_or(EdgeError::FeatureNotFound(feature_name.into_inner()))

--- a/server/src/persistence/file.rs
+++ b/server/src/persistence/file.rs
@@ -250,8 +250,10 @@ mod tests {
                     status: TokenValidationStatus::Validated,
                 },
                 etag: Some(EntityTag::new_weak("1234".into())),
+                next_refresh: None,
                 last_refreshed: Some(Utc::now()),
                 last_check: Some(Utc::now()),
+                failure_count: 0,
             },
             TokenRefresh {
                 token: EdgeToken {
@@ -259,8 +261,10 @@ mod tests {
                     ..EdgeToken::default()
                 },
                 etag: None,
+                next_refresh: None,
                 last_refreshed: None,
                 last_check: None,
+                failure_count: 0,
             },
         ];
 


### PR DESCRIPTION
Same thing here as in node and Java. In order to respect our upstream servers trying to tell us to chill out, this PR adds handling for 429, 500, 502, 503, 504. Edge already handled 401,403 and 404, so didn't need to change anything for that.