### PR TITLE
task: Added version header to client register response

### DIFF
--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -364,8 +364,8 @@ pub struct BuildInfo {
     pub build_os: String,
     pub build_target: String,
 }
-
 shadow!(build); // Get build information set to build placeholder
+pub const EDGE_VERSION: &str = build::PKG_VERSION;
 impl Default for BuildInfo {
     fn default() -> Self {
         BuildInfo {


### PR DESCRIPTION
Related to https://github.com/Unleash/unleash/pull/5774 - This adds an X-Edge-Version header to Edge's responses to `/api/client/register`. 
This will allow Edge to compare the version header with the known version where we added `/api/client/metrics/bulk` to decide where to post metrics. 