### PR TITLE
feat: added client authenticated bulk metrics

### DIFF
--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -144,7 +144,7 @@ async fn build_edge(args: &EdgeArgs) -> EdgeResult<EdgeInfo> {
                 args.upstream_certificate_file.clone(),
                 Duration::seconds(args.upstream_request_timeout),
                 Duration::seconds(args.upstream_socket_timeout),
-                args.token_header.token_header.clone()
+                args.token_header.token_header.clone(),
             )
         })
         .map(|c| c.with_custom_client_headers(args.custom_client_headers.clone()))

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -216,7 +216,6 @@ pub struct TokenHeader {
     /// Token header to use for edge authorization.
     #[clap(long, env, global = true, default_value = "Authorization")]
     pub token_header: String,
-
 }
 
 impl FromStr for TokenHeader {

--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -214,14 +214,15 @@ security(
 )]
 #[post("/metrics/bulk")]
 pub async fn post_bulk_metrics(
-    _edge_token: EdgeToken,
+    edge_token: EdgeToken,
     bulk_metrics: Json<BatchMetricsRequestBody>,
     connect_via: Data<ConnectVia>,
     metrics_cache: Data<MetricsCache>,
 ) -> EdgeResult<HttpResponse> {
     crate::metrics::client_metrics::register_bulk_metrics(
-        metrics_cache,
+        metrics_cache.get_ref(),
         connect_via.get_ref(),
+        &edge_token,
         bulk_metrics.into_inner(),
     );
     Ok(HttpResponse::Accepted().finish())

--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -5,7 +5,9 @@ use crate::filters::{
 use crate::http::feature_refresher::FeatureRefresher;
 use crate::metrics::client_metrics::MetricsCache;
 use crate::tokens::cache_key;
-use crate::types::{EdgeJsonResult, EdgeResult, EdgeToken, FeatureFilters};
+use crate::types::{
+    BatchMetricsRequestBody, EdgeJsonResult, EdgeResult, EdgeToken, FeatureFilters,
+};
 use actix_web::web::{self, Data, Json, Query};
 use actix_web::{get, post, HttpRequest, HttpResponse};
 use dashmap::DashMap;
@@ -199,6 +201,31 @@ pub async fn metrics(
     Ok(HttpResponse::Accepted().finish())
 }
 
+#[utoipa::path(
+context_path = "/api/client",
+responses(
+(status = 202, description = "Accepted bulk metrics"),
+(status = 403, description = "Was not allowed to post bulk metrics")
+),
+request_body = BatchMetricsRequestBody,
+security(
+("Authorization" = [])
+)
+)]
+#[post("/metrics/bulk")]
+pub async fn post_bulk_metrics(
+    _edge_token: EdgeToken,
+    bulk_metrics: Json<BatchMetricsRequestBody>,
+    connect_via: Data<ConnectVia>,
+    metrics_cache: Data<MetricsCache>,
+) -> EdgeResult<HttpResponse> {
+    crate::metrics::client_metrics::register_bulk_metrics(
+        metrics_cache,
+        connect_via.get_ref(),
+        bulk_metrics.into_inner(),
+    );
+    Ok(HttpResponse::Accepted().finish())
+}
 pub fn configure_client_api(cfg: &mut web::ServiceConfig) {
     cfg.service(
         web::scope("/client")
@@ -208,7 +235,8 @@ pub fn configure_client_api(cfg: &mut web::ServiceConfig) {
             .service(get_features)
             .service(get_feature)
             .service(register)
-            .service(metrics),
+            .service(metrics)
+            .service(post_bulk_metrics),
     );
 }
 
@@ -224,12 +252,12 @@ pub fn configure_experimental_post_features(
 #[cfg(test)]
 mod tests {
 
+    use crate::metrics::client_metrics::{ApplicationKey, MetricsBatch, MetricsKey};
+    use crate::types::{TokenType, TokenValidationStatus};
+    use std::collections::HashMap;
     use std::path::PathBuf;
     use std::str::FromStr;
-    use std::{collections::HashMap, sync::Arc};
-
-    use crate::metrics::client_metrics::{ApplicationKey, MetricsKey};
-    use crate::types::{TokenType, TokenValidationStatus};
+    use std::sync::Arc;
 
     use super::*;
 
@@ -243,14 +271,16 @@ mod tests {
         http::header::ContentType,
         test,
         web::{self, Data},
-        App,
+        App, ResponseError,
     };
     use chrono::{DateTime, Duration, TimeZone, Utc};
     use maplit::hashmap;
     use reqwest::StatusCode;
     use ulid::Ulid;
     use unleash_types::client_features::{ClientFeature, Constraint, Operator, Strategy};
-    use unleash_types::client_metrics::{ClientMetricsEnv, MetricBucket, ToggleStats};
+    use unleash_types::client_metrics::{
+        ClientMetricsEnv, ConnectViaBuilder, MetricBucket, ToggleStats,
+    };
     use unleash_yggdrasil::EngineState;
 
     async fn make_metrics_post_request() -> Request {
@@ -278,6 +308,38 @@ mod tests {
                 environment: Some("development".into()),
             }))
             .to_request()
+    }
+
+    async fn make_bulk_metrics_post_request(authorization: Option<String>) -> Request {
+        let mut req = test::TestRequest::post()
+            .uri("/api/client/metrics/bulk")
+            .insert_header(ContentType::json());
+        req = match authorization {
+            Some(auth) => req.insert_header(("Authorization", auth)),
+            None => req,
+        };
+        req.set_json(Json(BatchMetricsRequestBody {
+            applications: vec![ClientApplication {
+                app_name: "test_app".to_string(),
+                connect_via: None,
+                environment: None,
+                instance_id: None,
+                interval: 10,
+                sdk_version: None,
+                started: Default::default(),
+                strategies: vec![],
+            }],
+            metrics: vec![ClientMetricsEnv {
+                feature_name: "".to_string(),
+                app_name: "".to_string(),
+                environment: "".to_string(),
+                timestamp: Default::default(),
+                yes: 0,
+                no: 0,
+                variants: Default::default(),
+            }],
+        }))
+        .to_request()
     }
 
     async fn make_register_post_request(application: ClientApplication) -> Request {
@@ -476,6 +538,76 @@ mod tests {
         assert_eq!(saved_app.connect_via, Some(vec![our_app]));
     }
 
+    #[tokio::test]
+    async fn bulk_metrics_endpoint_correctly_accepts_data() {
+        let metrics_cache = MetricsCache::default();
+        let connect_via = ConnectViaBuilder::default()
+            .app_name("unleash-edge".into())
+            .instance_id("test".into())
+            .build()
+            .unwrap();
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(connect_via))
+                .app_data(web::Data::new(metrics_cache))
+                .service(web::scope("/api/client").service(post_bulk_metrics)),
+        )
+        .await;
+        let token = EdgeToken::from_str("*:development.somestring").unwrap();
+        let req = make_bulk_metrics_post_request(Some(token.token.clone())).await;
+        let call = test::call_service(&app, req).await;
+        assert_eq!(call.status(), StatusCode::ACCEPTED);
+    }
+    #[tokio::test]
+    async fn bulk_metrics_endpoint_correctly_refuses_metrics_without_auth_header() {
+        let mut token = EdgeToken::from_str("*:development.somestring").unwrap();
+        token.status = TokenValidationStatus::Validated;
+        token.token_type = Some(TokenType::Client);
+        let upstream_token_cache = Arc::new(DashMap::default());
+        let upstream_features_cache = Arc::new(DashMap::default());
+        let upstream_engine_cache = Arc::new(DashMap::default());
+        upstream_token_cache.insert(token.token.clone(), token.clone());
+        let srv = upstream_server(
+            upstream_token_cache,
+            upstream_features_cache,
+            upstream_engine_cache,
+        )
+        .await;
+        let client = UnleashClient::new(srv.url("/").as_str(), None).unwrap();
+        let status = client
+            .send_bulk_metrics_to_client_endpoint(MetricsBatch::default(), None)
+            .await;
+        assert_eq!(status.expect_err("").status_code(), StatusCode::FORBIDDEN);
+        let successful = client
+            .send_bulk_metrics_to_client_endpoint(MetricsBatch::default(), Some(token.clone()))
+            .await;
+        assert!(successful.is_ok());
+    }
+
+    #[tokio::test]
+    async fn bulk_metrics_endpoint_correctly_refuses_metrics_with_frontend_token() {
+        let mut frontend_token = EdgeToken::from_str("*:development.frontend").unwrap();
+        frontend_token.status = TokenValidationStatus::Validated;
+        frontend_token.token_type = Some(TokenType::Frontend);
+        let upstream_token_cache = Arc::new(DashMap::default());
+        let upstream_features_cache = Arc::new(DashMap::default());
+        let upstream_engine_cache = Arc::new(DashMap::default());
+        upstream_token_cache.insert(frontend_token.token.clone(), frontend_token.clone());
+        let srv = upstream_server(
+            upstream_token_cache,
+            upstream_features_cache,
+            upstream_engine_cache,
+        )
+        .await;
+        let client = UnleashClient::new(srv.url("/").as_str(), None).unwrap();
+        let status = client
+            .send_bulk_metrics_to_client_endpoint(
+                MetricsBatch::default(),
+                Some(frontend_token.clone()),
+            )
+            .await;
+        assert_eq!(status.expect_err("").status_code(), StatusCode::FORBIDDEN);
+    }
     #[tokio::test]
     async fn client_features_endpoint_correctly_returns_cached_features() {
         let features_cache: Arc<DashMap<String, ClientFeatures>> = Arc::new(DashMap::default());
@@ -1031,11 +1163,11 @@ mod tests {
         let res = test::call_service(&app, request).await;
         assert_eq!(res.status(), StatusCode::OK);
         let request = test::TestRequest::get()
-        .uri("/api/client/features")
-        .insert_header(ContentType::json())
-        .insert_header(("ShouldNotWork", production_token.token.clone()))
-        .to_request();
-    let res = test::call_service(&app, request).await;
-    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+            .uri("/api/client/features")
+            .insert_header(ContentType::json())
+            .insert_header(("ShouldNotWork", production_token.token.clone()))
+            .to_request();
+        let res = test::call_service(&app, request).await;
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
     }
 }

--- a/server/src/http/feature_refresher.rs
+++ b/server/src/http/feature_refresher.rs
@@ -934,7 +934,14 @@ mod tests {
         server.stop().await;
         tokio::time::sleep(std::time::Duration::from_millis(5)).await; // To ensure our refresh is due
         feature_refresher.refresh_features().await;
-        assert_eq!(feature_refresher.tokens_to_refresh.get("*:development.secret123").unwrap().failure_count, 1);
+        assert_eq!(
+            feature_refresher
+                .tokens_to_refresh
+                .get("*:development.secret123")
+                .unwrap()
+                .failure_count,
+            1
+        );
         assert!(!feature_refresher.features_cache.is_empty());
         assert!(!feature_refresher.engine_cache.is_empty());
     }

--- a/server/src/metrics/client_metrics.rs
+++ b/server/src/metrics/client_metrics.rs
@@ -142,12 +142,31 @@ pub(crate) fn register_client_metrics(
     metrics_cache.sink_metrics(&metrics);
 }
 
+/***
+   Will filter out metrics that do not belong to the environment that edge_token has access to
+*/
 pub(crate) fn register_bulk_metrics(
-    metrics_cache: Data<MetricsCache>,
+    metrics_cache: &MetricsCache,
     connect_via: &ConnectVia,
+    edge_token: &EdgeToken,
     metrics: BatchMetricsRequestBody,
 ) {
-    metrics_cache.sink_bulk_metrics(metrics, connect_via);
+    let updated: BatchMetricsRequestBody = BatchMetricsRequestBody {
+        applications: metrics.applications.clone(),
+        metrics: metrics
+            .metrics
+            .iter()
+            .filter(|m| {
+                edge_token
+                    .environment
+                    .clone()
+                    .map(|e| e == m.environment)
+                    .unwrap_or(false)
+            })
+            .cloned()
+            .collect(),
+    };
+    metrics_cache.sink_bulk_metrics(updated, connect_via);
 }
 
 pub(crate) fn sendable(batch: &MetricsBatch) -> bool {
@@ -288,10 +307,12 @@ impl MetricsCache {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::types::{TokenType, TokenValidationStatus};
     use chrono::{DateTime, Utc};
     use std::collections::HashMap;
+    use std::str::FromStr;
     use test_case::test_case;
-    use unleash_types::client_metrics::{ClientMetricsEnv, ConnectVia};
+    use unleash_types::client_metrics::{ClientMetricsEnv, ConnectVia, ConnectViaBuilder};
 
     #[test]
     fn cache_aggregates_data_correctly() {
@@ -589,5 +610,49 @@ mod test {
         let metrics_batch = cache.get_appropriately_sized_batches();
         assert_eq!(metrics_batch.len(), 1);
         assert!(metrics_batch.get(0).unwrap().metrics.is_empty());
+    }
+
+    #[test]
+    pub fn register_bulk_metrics_filters_metrics_based_on_environment_in_token() {
+        let metrics_cache = MetricsCache::default();
+        let connect_via = ConnectViaBuilder::default()
+            .app_name("edge_bulk_metrics".into())
+            .instance_id("sometest".into())
+            .build()
+            .unwrap();
+        let mut edge_token_with_development =
+            EdgeToken::from_str("*:development.randomstring").unwrap();
+        edge_token_with_development.status = TokenValidationStatus::Validated;
+        edge_token_with_development.token_type = Some(TokenType::Client);
+        let metrics = BatchMetricsRequestBody {
+            applications: vec![],
+            metrics: vec![
+                ClientMetricsEnv {
+                    feature_name: "feature_one".into(),
+                    app_name: "my_app".into(),
+                    environment: "development".into(),
+                    timestamp: Utc::now(),
+                    yes: 50,
+                    no: 10,
+                    variants: Default::default(),
+                },
+                ClientMetricsEnv {
+                    feature_name: "feature_two".to_string(),
+                    app_name: "other_app".to_string(),
+                    environment: "production".to_string(),
+                    timestamp: Default::default(),
+                    yes: 50,
+                    no: 10,
+                    variants: Default::default(),
+                },
+            ],
+        };
+        register_bulk_metrics(
+            &metrics_cache,
+            &connect_via,
+            &edge_token_with_development,
+            metrics,
+        );
+        assert_eq!(metrics_cache.metrics.len(), 1);
     }
 }

--- a/server/src/tokens.rs
+++ b/server/src/tokens.rs
@@ -7,8 +7,8 @@ use std::collections::HashSet;
 use std::future::{ready, Ready};
 use std::str::FromStr;
 
-use crate::cli::TokenHeader;
 use crate::cli::EdgeMode;
+use crate::cli::TokenHeader;
 use crate::error::EdgeError;
 use crate::types::EdgeResult;
 use crate::types::EdgeToken;

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -1,6 +1,6 @@
 use std::cmp::min;
 use std::fmt;
-use std::fmt::{Display, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 use std::net::IpAddr;
 
 use std::sync::Arc;
@@ -69,7 +69,7 @@ pub struct ValidateTokensRequest {
     pub tokens: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, ToSchema)]
+#[derive(Clone, Serialize, Deserialize, Eq, ToSchema)]
 #[cfg_attr(test, derive(Default))]
 #[serde(rename_all = "camelCase")]
 pub struct EdgeToken {
@@ -80,6 +80,28 @@ pub struct EdgeToken {
     pub projects: Vec<String>,
     #[serde(default = "valid_status")]
     pub status: TokenValidationStatus,
+}
+
+impl Debug for EdgeToken {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EdgeToken")
+            .field(
+                "token",
+                &format!(
+                    "{}.[redacted]",
+                    &self
+                        .token
+                        .chars()
+                        .take_while(|p| p != &'.')
+                        .collect::<String>()
+                ),
+            )
+            .field("token_type", &self.token_type)
+            .field("environment", &self.environment)
+            .field("projects", &self.projects)
+            .field("status", &self.status)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/server/src/urls.rs
+++ b/server/src/urls.rs
@@ -12,6 +12,7 @@ pub struct UnleashUrls {
     pub client_features_url: Url,
     pub client_register_app_url: Url,
     pub client_metrics_url: Url,
+    pub client_bulk_metrics_url: Url,
     pub edge_api_url: Url,
     pub edge_validate_url: Url,
     pub edge_metrics_url: Url,
@@ -82,12 +83,18 @@ impl UnleashUrls {
             .push("admin")
             .push("api-tokens");
 
+        let mut client_bulk_metrics_url = client_metrics_url.clone();
+        client_bulk_metrics_url
+            .path_segments_mut()
+            .expect("Could not create /api/client/metrics/bulk")
+            .push("bulk");
         UnleashUrls {
             base_url,
             api_url,
             client_api_url,
             client_features_url,
             client_register_app_url,
+            client_bulk_metrics_url,
             client_metrics_url,
             edge_api_url,
             edge_validate_url,


### PR DESCRIPTION
So, reflecting what we're doing here: https://github.com/Unleash/unleash/pull/5779 this PR adds a client token authenticated endpoint for posting bulk metrics. We also filter the metrics by the environment the token used to POST metrics has access to.