### PR TITLE
feat: Use Version-headers to decide where to post metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2298,9 +2298,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"
@@ -3003,6 +3003,7 @@ dependencies = [
  "reqwest",
  "rustls",
  "rustls-pemfile",
+ "semver",
  "serde",
  "serde_json",
  "serde_qs",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -59,6 +59,7 @@ reqwest = { version = "0.11.23", default-features = false, features = [
 ] }
 rustls = "0.21.8"
 rustls-pemfile = "1.0.4"
+semver = "1.0.21"
 serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "1.0.111"
 serde_qs = { version = "0.12.0", features = ["actix4", "tracing"] }

--- a/server/src/admin_api.rs
+++ b/server/src/admin_api.rs
@@ -59,7 +59,7 @@ mod tests {
             .collect::<String>();
         let project_token = match projects.len() {
             0 => "*",
-            1 => projects.get(0).unwrap(),
+            1 => projects.first().unwrap(),
             _ => {
                 if projects.contains(&"*".to_string()) {
                     "*"

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -389,7 +389,7 @@ mod tests {
             EdgeMode::Edge(args) => {
                 let client_headers = args.custom_client_headers;
                 assert_eq!(client_headers.len(), 2);
-                let auth = client_headers.get(0).unwrap();
+                let auth = client_headers.first().unwrap();
                 assert_eq!(auth.0, "Authorization");
                 assert_eq!(auth.1, "abc123");
                 let api_key = client_headers.get(1).unwrap();
@@ -413,7 +413,7 @@ mod tests {
             EdgeMode::Edge(args) => {
                 let client_headers = args.custom_client_headers;
                 assert_eq!(client_headers.len(), 2);
-                let auth = client_headers.get(0).unwrap();
+                let auth = client_headers.first().unwrap();
                 assert_eq!(auth.0, "Authorization");
                 assert_eq!(auth.1, "abc123");
                 let api_key = client_headers.get(1).unwrap();
@@ -437,7 +437,7 @@ mod tests {
             EdgeMode::Edge(args) => {
                 let client_headers = args.custom_client_headers;
                 assert_eq!(client_headers.len(), 1);
-                let auth = client_headers.get(0).unwrap();
+                let auth = client_headers.first().unwrap();
                 assert_eq!(auth.0, "Authorization");
                 assert_eq!(auth.1, "test:test.secret");
             }
@@ -642,7 +642,7 @@ mod tests {
         assert!(args.trust_proxy.trust_proxy);
         info!("{:?}", args.trust_proxy.proxy_trusted_servers);
         assert_eq!(args.trust_proxy.proxy_trusted_servers.len(), 2);
-        let first = args.trust_proxy.proxy_trusted_servers.get(0).unwrap();
+        let first = args.trust_proxy.proxy_trusted_servers.first().unwrap();
         if let NetworkAddr::Ip(ip_addr) = first {
             assert!(ip_addr.is_ipv4());
         } else {
@@ -671,7 +671,7 @@ mod tests {
         let args = CliArgs::parse_from(args);
         info!("{:?}", args.trust_proxy.proxy_trusted_servers);
         assert_eq!(args.trust_proxy.proxy_trusted_servers.len(), 2);
-        let first = args.trust_proxy.proxy_trusted_servers.get(0).unwrap();
+        let first = args.trust_proxy.proxy_trusted_servers.first().unwrap();
         if let NetworkAddr::CidrIpv4(cidr) = first {
             assert_eq!(cidr.network_length(), 16);
         } else {

--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -588,10 +588,8 @@ mod tests {
             )
             .send()
             .await;
-        assert_eq!(
-            status.expect_err("").status(),
-            Some(reqwest::StatusCode::FORBIDDEN)
-        );
+        assert!(status.is_ok());
+        assert_eq!(status.unwrap().status(), StatusCode::FORBIDDEN);
         let client = UnleashClient::new(srv.url("/").as_str(), None).unwrap();
         let successful = client
             .send_bulk_metrics_to_client_endpoint(MetricsBatch::default(), &token.token)

--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -576,13 +576,25 @@ mod tests {
             upstream_engine_cache,
         )
         .await;
-        let client = UnleashClient::new(srv.url("/").as_str(), None).unwrap();
-        let status = client
-            .send_bulk_metrics_to_client_endpoint(MetricsBatch::default(), None)
+        let req = reqwest::Client::new();
+        let status = req
+            .post(srv.url("/api/client/metrics/bulk").as_str())
+            .body(
+                serde_json::to_string(&crate::types::BatchMetricsRequestBody {
+                    applications: vec![],
+                    metrics: vec![],
+                })
+                .unwrap(),
+            )
+            .send()
             .await;
-        assert_eq!(status.expect_err("").status_code(), StatusCode::FORBIDDEN);
+        assert_eq!(
+            status.expect_err("").status(),
+            Some(reqwest::StatusCode::FORBIDDEN)
+        );
+        let client = UnleashClient::new(srv.url("/").as_str(), None).unwrap();
         let successful = client
-            .send_bulk_metrics_to_client_endpoint(MetricsBatch::default(), Some(token.clone()))
+            .send_bulk_metrics_to_client_endpoint(MetricsBatch::default(), &token.token)
             .await;
         assert!(successful.is_ok());
     }
@@ -604,10 +616,7 @@ mod tests {
         .await;
         let client = UnleashClient::new(srv.url("/").as_str(), None).unwrap();
         let status = client
-            .send_bulk_metrics_to_client_endpoint(
-                MetricsBatch::default(),
-                Some(frontend_token.clone()),
-            )
+            .send_bulk_metrics_to_client_endpoint(MetricsBatch::default(), &frontend_token.token)
             .await;
         assert_eq!(status.expect_err("").status_code(), StatusCode::FORBIDDEN);
     }

--- a/server/src/frontend_api.rs
+++ b/server/src/frontend_api.rs
@@ -854,7 +854,7 @@ mod tests {
         let _result: FrontendResult = test::call_and_read_body_json(&app, req).await;
         let result: FrontendResult = test::call_and_read_body_json(&app, second_req).await;
         assert_eq!(result.toggles.len(), 1);
-        assert!(result.toggles.get(0).unwrap().enabled)
+        assert!(result.toggles.first().unwrap().enabled)
     }
 
     #[actix_web::test]

--- a/server/src/http/background_send_metrics.rs
+++ b/server/src/http/background_send_metrics.rs
@@ -2,7 +2,7 @@ use actix_web::http::StatusCode;
 use std::cmp::max;
 use tracing::{error, info, trace, warn};
 
-use super::unleash_client::UnleashClient;
+use super::feature_refresher::FeatureRefresher;
 
 use crate::{
     error::EdgeError,
@@ -25,76 +25,135 @@ lazy_static! {
     .unwrap();
     pub static ref METRICS_UNEXPECTED_ERRORS: IntGauge =
         register_int_gauge!(Opts::new("metrics_send_error", "Failures to send metrics")).unwrap();
+    pub static ref METRICS_UPSTREAM_OUTDATED: IntGaugeVec = register_int_gauge_vec!(
+        Opts::new(
+            "metrics_upstream_outdated",
+            "Number of times we have tried to send metrics to an outdated endpoint"
+        ),
+        &["environment"]
+    )
+    .unwrap();
+    pub static ref METRICS_UPSTREAM_CLIENT_BULK: IntGaugeVec = register_int_gauge_vec!(
+        Opts::new(
+            "metrics_upstream_client_bulk",
+            "Number of times we have tried to send metrics to the client bulk endpoint"
+        ),
+        &["environment"]
+    )
+    .unwrap();
+}
+
+fn decide_where_to_post(
+    environment: &String,
+    feature_refresher: Arc<FeatureRefresher>,
+) -> (bool, String) {
+    if let Some(token_refresh) = feature_refresher
+        .tokens_to_refresh
+        .iter()
+        .find(|t| t.token.environment == Some(environment.to_string()))
+    {
+        if token_refresh.use_client_bulk_endpoint {
+            info!("Sending metrics to client bulk endpoint");
+            METRICS_UPSTREAM_CLIENT_BULK
+                .with_label_values(&[environment])
+                .inc();
+            (true, token_refresh.token.token.clone())
+        } else {
+            warn!("Your upstream is outdated. Please upgrade to at least Unleash version 5.9.0 or Edge Version 17.0.0");
+            METRICS_UPSTREAM_OUTDATED
+                .with_label_values(&[environment])
+                .inc();
+            (false, "".into())
+        }
+    } else {
+        (false, "".into())
+    }
 }
 
 pub async fn send_metrics_task(
     metrics_cache: Arc<MetricsCache>,
-    unleash_client: Arc<UnleashClient>,
+    feature_refresher: Arc<FeatureRefresher>,
     send_interval: i64,
 ) {
     let mut failures = 0;
     let mut interval = Duration::seconds(send_interval);
     loop {
-        let batches = metrics_cache.get_appropriately_sized_batches();
-        trace!("Posting {} batches", batches.len());
-        for batch in batches {
-            if !batch.applications.is_empty() || !batch.metrics.is_empty() {
-                if let Err(edge_error) = unleash_client.send_batch_metrics(batch.clone()).await {
-                    match edge_error {
-                        EdgeError::EdgeMetricsRequestError(status_code, message) => {
-                            METRICS_UPSTREAM_HTTP_ERRORS
-                                .with_label_values(&[status_code.as_str()])
-                                .inc();
-                            match status_code {
-                                StatusCode::PAYLOAD_TOO_LARGE => error!(
-                                    "Metrics were too large. They were {}",
-                                    size_of_batch(&batch)
-                                ),
-                                StatusCode::BAD_REQUEST => {
-                                    error!("Unleash said [{message:?}]. Dropping this metric bucket to avoid consuming too much memory");
-                                }
-                                StatusCode::NOT_FOUND => {
-                                    failures = 10;
-                                    interval = new_interval(interval, failures, 5);
-                                    error!("Upstream said we are trying to post to an endpoint that doesn't exist. backing off to {} seconds", interval.num_seconds());
-                                }
-                                StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED => {
-                                    failures = 10;
-                                    interval = new_interval(interval, failures, 5);
-                                    error!("Upstream said we were not allowed to post metrics, backing off to {} seconds", interval.num_seconds());
-                                }
-                                StatusCode::TOO_MANY_REQUESTS => {
-                                    failures = max(10, failures + 1);
-                                    interval = new_interval(interval, failures, 5);
-                                    info!(
-                                        "Upstream said it was too busy, backing off to {} seconds",
-                                        interval.num_seconds()
-                                    );
-                                    metrics_cache.reinsert_batch(batch);
-                                }
-                                StatusCode::INTERNAL_SERVER_ERROR
-                                | StatusCode::BAD_GATEWAY
-                                | StatusCode::SERVICE_UNAVAILABLE
-                                | StatusCode::GATEWAY_TIMEOUT => {
-                                    failures = max(10, failures + 1);
-                                    interval = new_interval(interval, failures, 5);
-                                    info!("Upstream said it is struggling. It returned Http status {}. Backing off to {} seconds", status_code, interval.num_seconds());
-                                    metrics_cache.reinsert_batch(batch);
-                                }
-                                _ => {
-                                    warn!("Failed to send metrics. Status code was {status_code}. Will reinsert metrics for next attempt");
-                                    metrics_cache.reinsert_batch(batch);
+        trace!("Looping metrics");
+        let envs = metrics_cache.get_metrics_by_environment();
+        for (env, batch) in envs.iter() {
+            let (use_new_endpoint, token) = decide_where_to_post(env, feature_refresher.clone());
+            let batches = metrics_cache.get_appropriately_sized_env_batches(batch);
+            trace!("Posting {} batches for {env}", batches.len());
+            for batch in batches {
+                if !batch.applications.is_empty() || !batch.metrics.is_empty() {
+                    let result = if use_new_endpoint {
+                        feature_refresher
+                            .unleash_client
+                            .send_bulk_metrics_to_client_endpoint(batch.clone(), &token)
+                            .await
+                    } else {
+                        feature_refresher
+                            .unleash_client
+                            .send_batch_metrics(batch.clone())
+                            .await
+                    };
+                    if let Err(edge_error) = result {
+                        match edge_error {
+                            EdgeError::EdgeMetricsRequestError(status_code, message) => {
+                                METRICS_UPSTREAM_HTTP_ERRORS
+                                    .with_label_values(&[status_code.as_str()])
+                                    .inc();
+                                match status_code {
+                                    StatusCode::PAYLOAD_TOO_LARGE => error!(
+                                        "Metrics were too large. They were {}",
+                                        size_of_batch(&batch)
+                                    ),
+                                    StatusCode::BAD_REQUEST => {
+                                        error!("Unleash said [{message:?}]. Dropping this metric bucket to avoid consuming too much memory");
+                                    }
+                                    StatusCode::NOT_FOUND => {
+                                        failures = 10;
+                                        interval = new_interval(interval, failures, 5);
+                                        error!("Upstream said we are trying to post to an endpoint that doesn't exist. backing off to {} seconds", interval.num_seconds());
+                                    }
+                                    StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED => {
+                                        failures = 10;
+                                        interval = new_interval(interval, failures, 5);
+                                        error!("Upstream said we were not allowed to post metrics, backing off to {} seconds", interval.num_seconds());
+                                    }
+                                    StatusCode::TOO_MANY_REQUESTS => {
+                                        failures = max(10, failures + 1);
+                                        interval = new_interval(interval, failures, 5);
+                                        info!(
+                                            "Upstream said it was too busy, backing off to {} seconds",
+                                            interval.num_seconds()
+                                        );
+                                        metrics_cache.reinsert_batch(batch);
+                                    }
+                                    StatusCode::INTERNAL_SERVER_ERROR
+                                    | StatusCode::BAD_GATEWAY
+                                    | StatusCode::SERVICE_UNAVAILABLE
+                                    | StatusCode::GATEWAY_TIMEOUT => {
+                                        failures = max(10, failures + 1);
+                                        interval = new_interval(interval, failures, 5);
+                                        info!("Upstream said it is struggling. It returned Http status {}. Backing off to {} seconds", status_code, interval.num_seconds());
+                                        metrics_cache.reinsert_batch(batch);
+                                    }
+                                    _ => {
+                                        warn!("Failed to send metrics. Status code was {status_code}. Will reinsert metrics for next attempt");
+                                        metrics_cache.reinsert_batch(batch);
+                                    }
                                 }
                             }
+                            _ => {
+                                warn!("Failed to send metrics: {edge_error:?}");
+                                METRICS_UNEXPECTED_ERRORS.inc();
+                            }
                         }
-                        _ => {
-                            warn!("Failed to send metrics: {edge_error:?}");
-                            METRICS_UNEXPECTED_ERRORS.inc();
-                        }
+                    } else {
+                        failures = max(0, failures - 1);
+                        interval = new_interval(interval, failures, 5);
                     }
-                } else {
-                    failures = max(0, failures - 1);
-                    interval = new_interval(interval, failures, 5);
                 }
             }
         }

--- a/server/src/http/unleash_client.rs
+++ b/server/src/http/unleash_client.rs
@@ -860,7 +860,7 @@ mod tests {
         match validate_result {
             Ok(token_status) => {
                 assert_eq!(token_status.len(), 1);
-                let validated_token = token_status.get(0).unwrap();
+                let validated_token = token_status.first().unwrap();
                 assert_eq!(validated_token.status, TokenValidationStatus::Validated);
                 assert_eq!(validated_token.environment, Some("development".into()))
             }

--- a/server/src/http/unleash_client.rs
+++ b/server/src/http/unleash_client.rs
@@ -203,6 +203,7 @@ impl UnleashClient {
             token_header,
         }
     }
+    #[allow(clippy::too_many_arguments)]
     pub fn from_url_with_service_account_token(
         server_url: Url,
         skip_ssl_verification: bool,
@@ -478,13 +479,13 @@ impl UnleashClient {
     pub async fn send_bulk_metrics_to_client_endpoint(
         &self,
         request: MetricsBatch,
-        token: &String,
+        token: &str,
     ) -> EdgeResult<()> {
         trace!("Sending metrics to bulk endpoint");
         let result = self
             .backing_client
             .post(self.urls.client_bulk_metrics_url.to_string())
-            .headers(self.header_map(Some(token.clone())))
+            .headers(self.header_map(Some(token.to_string())))
             .json(&request)
             .send()
             .await

--- a/server/src/http/unleash_client.rs
+++ b/server/src/http/unleash_client.rs
@@ -12,7 +12,7 @@ use reqwest::header::{HeaderMap, HeaderName};
 use reqwest::{header, Client};
 use reqwest::{ClientBuilder, Identity, RequestBuilder, StatusCode, Url};
 use serde::{Deserialize, Serialize};
-use tracing::{debug, info, warn};
+use tracing::{debug, info, trace, warn};
 use unleash_types::client_features::ClientFeatures;
 use unleash_types::client_metrics::ClientApplication;
 
@@ -62,6 +62,14 @@ lazy_static! {
             "Why we failed to validate tokens"
         ),
         &["status_code"]
+    )
+    .unwrap();
+    pub static ref UPSTREAM_VERSION: IntGaugeVec = register_int_gauge_vec!(
+        Opts::new(
+            "upstream_version",
+            "The server type (Unleash or Edge) and version of the upstream we're connected to"
+        ),
+        &["server", "version"]
     )
     .unwrap();
 }
@@ -328,7 +336,7 @@ impl UnleashClient {
         &self,
         api_key: String,
         application: ClientApplication,
-    ) -> EdgeResult<()> {
+    ) -> EdgeResult<bool> {
         self.backing_client
             .post(self.urls.client_register_app_url.to_string())
             .headers(self.header_map(Some(api_key)))
@@ -343,7 +351,23 @@ impl UnleashClient {
                 if !r.status().is_success() {
                     CLIENT_REGISTER_FAILURES
                         .with_label_values(&[r.status().as_str()])
-                        .inc()
+                        .inc();
+                }
+                if let Some(edge_version) = r.headers().get("X-Edge-Version") {
+                    let version = edge_version.to_str().unwrap_or("pre-16.2.0");
+                    UPSTREAM_VERSION
+                        .with_label_values(&["edge", version])
+                        .inc();
+                    crate::metrics::version_is_new_enough_for_client_bulk("edge", version)
+                } else if let Some(unleash_version) = r.headers().get("X-Unleash-Version") {
+                    let version = unleash_version.to_str().unwrap_or("pre-5.9.0");
+                    UPSTREAM_VERSION
+                        .with_label_values(&["unleash", version])
+                        .inc();
+                    crate::metrics::version_is_new_enough_for_client_bulk("unleash", version)
+                } else {
+                    warn!("Connected to an old version of Unleash or Edge. Please upgrade your server to Unleash 5.9 or Edge 17.0");
+                    false
                 }
             })
     }
@@ -426,6 +450,7 @@ impl UnleashClient {
     }
 
     pub async fn send_batch_metrics(&self, request: MetricsBatch) -> EdgeResult<()> {
+        trace!("Sending metrics to old /edge/metrics endpoint");
         let result = self
             .backing_client
             .post(self.urls.edge_metrics_url.to_string())
@@ -453,12 +478,13 @@ impl UnleashClient {
     pub async fn send_bulk_metrics_to_client_endpoint(
         &self,
         request: MetricsBatch,
-        token: Option<EdgeToken>,
+        token: &String,
     ) -> EdgeResult<()> {
+        trace!("Sending metrics to bulk endpoint");
         let result = self
             .backing_client
             .post(self.urls.client_bulk_metrics_url.to_string())
-            .headers(self.header_map(token.map(|t| t.token)))
+            .headers(self.header_map(Some(token.clone())))
             .json(&request)
             .send()
             .await

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -156,7 +156,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 _ = refresher.start_refresh_features_background_task() => {
                     tracing::info!("Feature refresher unexpectedly shut down");
                 }
-                _ = unleash_edge::http::background_send_metrics::send_metrics_task(metrics_cache_clone.clone(), refresher.unleash_client.clone(), edge.metrics_interval_seconds.try_into().unwrap()) => {
+                _ = unleash_edge::http::background_send_metrics::send_metrics_task(metrics_cache_clone.clone(), refresher.clone(), edge.metrics_interval_seconds.try_into().unwrap()) => {
                     tracing::info!("Metrics poster unexpectedly shut down");
                 }
                 _ = persist_data(persistence.clone(), lazy_token_cache.clone(), lazy_feature_cache.clone(), refresher.tokens_to_refresh.clone()) => {

--- a/server/src/metrics/client_metrics.rs
+++ b/server/src/metrics/client_metrics.rs
@@ -252,7 +252,7 @@ impl MetricsCache {
         for metric in batch.metrics.clone() {
             self.metrics.remove(&MetricsKey::from(metric.clone()));
         }
-        METRICS_SIZE_HISTOGRAM.observe(size_of_batch(&batch) as f64);
+        METRICS_SIZE_HISTOGRAM.observe(size_of_batch(batch) as f64);
         if sendable(batch) {
             vec![batch.clone()]
         } else {
@@ -658,7 +658,7 @@ mod test {
         cache.sink_metrics(&metrics);
         let metrics_batch = cache.get_appropriately_sized_batches();
         assert_eq!(metrics_batch.len(), 1);
-        assert!(metrics_batch.get(0).unwrap().metrics.is_empty());
+        assert!(metrics_batch.first().unwrap().metrics.is_empty());
     }
 
     #[test]

--- a/server/src/metrics/client_metrics.rs
+++ b/server/src/metrics/client_metrics.rs
@@ -2,10 +2,14 @@ use crate::types::{BatchMetricsRequestBody, EdgeToken};
 use actix_web::web::Data;
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
+use iter_tools::Itertools;
 use lazy_static::lazy_static;
 use prometheus::{register_histogram, Histogram};
 use serde::{Deserialize, Serialize};
-use std::hash::{Hash, Hasher};
+use std::{
+    collections::HashMap,
+    hash::{Hash, Hasher},
+};
 use tracing::{debug, instrument};
 use unleash_types::client_metrics::{
     ClientApplication, ClientMetrics, ClientMetricsEnv, ConnectVia,
@@ -215,6 +219,51 @@ pub(crate) fn cut_into_sendable_batches(batch: MetricsBatch) -> Vec<MetricsBatch
 }
 
 impl MetricsCache {
+    pub fn get_metrics_by_environment(&self) -> HashMap<String, MetricsBatch> {
+        let mut batches_by_environment = HashMap::new();
+
+        let applications = self
+            .applications
+            .iter()
+            .map(|e| e.value().clone())
+            .collect::<Vec<ClientApplication>>();
+        let data = self
+            .metrics
+            .iter()
+            .map(|e| e.value().clone())
+            .collect::<Vec<ClientMetricsEnv>>();
+        let map: HashMap<String, Vec<ClientMetricsEnv>> = data
+            .into_iter()
+            .into_group_map_by(|metric| metric.environment.clone());
+        for (environment, metrics) in map {
+            let batch = MetricsBatch {
+                applications: applications.clone(),
+                metrics,
+            };
+            batches_by_environment.insert(environment, batch);
+        }
+        batches_by_environment
+    }
+
+    pub fn get_appropriately_sized_env_batches(&self, batch: &MetricsBatch) -> Vec<MetricsBatch> {
+        for app in batch.applications.clone() {
+            self.applications.remove(&ApplicationKey::from(app.clone()));
+        }
+        for metric in batch.metrics.clone() {
+            self.metrics.remove(&MetricsKey::from(metric.clone()));
+        }
+        METRICS_SIZE_HISTOGRAM.observe(size_of_batch(&batch) as f64);
+        if sendable(batch) {
+            vec![batch.clone()]
+        } else {
+            debug!(
+                "We have {} applications and {} metrics",
+                batch.applications.len(),
+                batch.metrics.len()
+            );
+            cut_into_sendable_batches(batch.clone())
+        }
+    }
     /// This is a destructive call. We'll remove all metrics that is due for posting
     /// Called from [crate::http::background_send_metrics::send_metrics_task] which will reinsert on 5xx server failures, but leave 413 and 400 failures on the floor
     pub fn get_appropriately_sized_batches(&self) -> Vec<MetricsBatch> {
@@ -654,5 +703,35 @@ mod test {
             metrics,
         );
         assert_eq!(metrics_cache.metrics.len(), 1);
+    }
+
+    #[test]
+    pub fn metrics_will_be_gathered_per_environment() {
+        let metrics = vec![
+            ClientMetricsEnv {
+                feature_name: "feature_one".into(),
+                app_name: "my_app".into(),
+                environment: "development".into(),
+                timestamp: Utc::now(),
+                yes: 50,
+                no: 10,
+                variants: Default::default(),
+            },
+            ClientMetricsEnv {
+                feature_name: "feature_two".to_string(),
+                app_name: "other_app".to_string(),
+                environment: "production".to_string(),
+                timestamp: Default::default(),
+                yes: 50,
+                no: 10,
+                variants: Default::default(),
+            },
+        ];
+        let cache = MetricsCache::default();
+        cache.sink_metrics(&metrics);
+        let metrics_by_env_map = cache.get_metrics_by_environment();
+        assert_eq!(metrics_by_env_map.len(), 2);
+        assert!(metrics_by_env_map.contains_key("development"));
+        assert!(metrics_by_env_map.contains_key("production"));
     }
 }

--- a/server/src/metrics/mod.rs
+++ b/server/src/metrics/mod.rs
@@ -1,5 +1,72 @@
+use semver::{Version, VersionReq};
+use tracing::trace;
+
 #[cfg(not(tarpaulin_include))]
 pub mod actix_web_metrics;
 
 pub mod client_metrics;
 pub mod route_formatter;
+
+const EDGE_REQUIREMENT: &str = ">=17.0.0";
+const UNLEASH_REQUIREMENT: &str = ">=5.9.0";
+
+pub fn version_is_new_enough_for_client_bulk(upstream: &str, version: &str) -> bool {
+    match upstream {
+        "edge" => {
+            let v_req = VersionReq::parse(EDGE_REQUIREMENT).unwrap();
+            let edge_version = Version::parse(version).unwrap();
+            trace!("Comparing version {version} against Edge requirement of {EDGE_REQUIREMENT}");
+            v_req.matches(&edge_version)
+        }
+        "unleash" => {
+            trace!(
+                "Comparing version {version} against Unleash requirement of {UNLEASH_REQUIREMENT}"
+            );
+            let v_req = VersionReq::parse(UNLEASH_REQUIREMENT).unwrap();
+            let unleash_version = Version::parse(version).unwrap();
+            v_req.matches(&unleash_version)
+                || (unleash_version.major == 5
+                    && unleash_version.minor == 8
+                    && unleash_version.patch == 0
+                    && unleash_version.build.contains("main"))
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test_case::test_case;
+    use tracing_test::traced_test;
+
+    #[test_case("unleash", "5.8.0+main", true)]
+    #[test_case("unleash", "5.9.0", true)]
+    #[test_case("unleash", "5.9.1", true)]
+    #[test_case("unleash", "5.10.0", true)]
+    #[test_case("unleash", "6.0.0", true)]
+    #[test_case("unleash", "5.9.0+main", true)]
+    #[test_case("unleash", "5.8.0", false)]
+    #[test_case("unleash", "5.8.1", false)]
+    #[traced_test]
+    pub fn unleash_version_is_new_enough_for_client_bulk(
+        upstream: &str,
+        version: &str,
+        expected: bool,
+    ) {
+        let result = super::version_is_new_enough_for_client_bulk(upstream, version);
+        assert_eq!(result, expected);
+    }
+
+    #[test_case("edge", "17.0.0", true)]
+    #[test_case("edge", "17.1.0", true)]
+    #[test_case("edge", "16.1.0", false)]
+    #[test_case("edge", "16.0.0", false)]
+    pub fn edge_version_is_new_enough_for_client_bulk(
+        upstream: &str,
+        version: &str,
+        expected: bool,
+    ) {
+        let result = super::version_is_new_enough_for_client_bulk(upstream, version);
+        assert_eq!(result, expected);
+    }
+}

--- a/server/src/metrics/mod.rs
+++ b/server/src/metrics/mod.rs
@@ -1,3 +1,4 @@
+use lazy_static::lazy_static;
 use semver::{Version, VersionReq};
 use tracing::trace;
 
@@ -10,21 +11,25 @@ pub mod route_formatter;
 const EDGE_REQUIREMENT: &str = ">=17.0.0";
 const UNLEASH_REQUIREMENT: &str = ">=5.9.0";
 
+lazy_static! {
+    pub static ref EDGE_VERSION_REQ: VersionReq = VersionReq::parse(EDGE_REQUIREMENT).unwrap();
+    pub static ref UNLEASH_VERSION_REQ: VersionReq =
+        VersionReq::parse(UNLEASH_REQUIREMENT).unwrap();
+}
+
 pub fn version_is_new_enough_for_client_bulk(upstream: &str, version: &str) -> bool {
     match upstream {
         "edge" => {
-            let v_req = VersionReq::parse(EDGE_REQUIREMENT).unwrap();
             let edge_version = Version::parse(version).unwrap();
             trace!("Comparing version {version} against Edge requirement of {EDGE_REQUIREMENT}");
-            v_req.matches(&edge_version)
+            EDGE_VERSION_REQ.matches(&edge_version)
         }
         "unleash" => {
             trace!(
                 "Comparing version {version} against Unleash requirement of {UNLEASH_REQUIREMENT}"
             );
-            let v_req = VersionReq::parse(UNLEASH_REQUIREMENT).unwrap();
             let unleash_version = Version::parse(version).unwrap();
-            v_req.matches(&unleash_version)
+            UNLEASH_VERSION_REQ.matches(&unleash_version)
                 || (unleash_version.major == 5
                     && unleash_version.minor == 8
                     && unleash_version.patch == 0

--- a/server/src/persistence/file.rs
+++ b/server/src/persistence/file.rs
@@ -325,6 +325,6 @@ mod tests {
 
         let token_refresh: TokenRefresh = serde_json::from_str(json).unwrap();
 
-        assert_eq!(token_refresh.use_client_bulk_endpoint, false);
+        assert!(!token_refresh.use_client_bulk_endpoint);
     }
 }

--- a/server/src/persistence/file.rs
+++ b/server/src/persistence/file.rs
@@ -254,6 +254,7 @@ mod tests {
                 last_refreshed: Some(Utc::now()),
                 last_check: Some(Utc::now()),
                 failure_count: 0,
+                use_client_bulk_endpoint: false,
             },
             TokenRefresh {
                 token: EdgeToken {
@@ -265,6 +266,7 @@ mod tests {
                 last_refreshed: None,
                 last_check: None,
                 failure_count: 0,
+                use_client_bulk_endpoint: false,
             },
         ];
 
@@ -300,5 +302,29 @@ mod tests {
         let reloaded = persister.load_tokens().await.unwrap();
 
         assert_eq!(reloaded, tokens);
+    }
+
+    #[test]
+    fn can_read_token_refresh_without_use_client_bulk_field() {
+        let json = r#"{
+            "token": {
+                "token": "default:development:ajsdkajnsdlsan",
+                "token_type": "client",
+                "environment": "development",
+                "projects": [
+                    "default"
+                ],
+                "status": "Validated"
+            },
+            "etag": "W/\"1234\"",
+            "next_refresh": null,
+            "last_refreshed": "2021-03-09T13:00:00Z",
+            "last_check": "2021-03-09T13:00:00Z",
+            "failure_count": 0
+        }"#;
+
+        let token_refresh: TokenRefresh = serde_json::from_str(json).unwrap();
+
+        assert_eq!(token_refresh.use_client_bulk_endpoint, false);
     }
 }

--- a/server/src/prom_metrics.rs
+++ b/server/src/prom_metrics.rs
@@ -100,6 +100,16 @@ fn register_custom_metrics(registry: &prometheus::Registry) {
         .unwrap();
     registry
         .register(Box::new(
+            background_send_metrics::METRICS_UPSTREAM_CLIENT_BULK.clone(),
+        ))
+        .unwrap();
+    registry
+        .register(Box::new(
+            background_send_metrics::METRICS_UPSTREAM_OUTDATED.clone(),
+        ))
+        .unwrap();
+    registry
+        .register(Box::new(
             crate::http::unleash_client::CLIENT_FEATURE_FETCH_FAILURES.clone(),
         ))
         .unwrap();
@@ -116,6 +126,11 @@ fn register_custom_metrics(registry: &prometheus::Registry) {
     registry
         .register(Box::new(
             crate::http::unleash_client::CLIENT_FEATURE_FETCH.clone(),
+        ))
+        .unwrap();
+    registry
+        .register(Box::new(
+            crate::http::unleash_client::UPSTREAM_VERSION.clone(),
         ))
         .unwrap();
 }

--- a/server/src/tokens.rs
+++ b/server/src/tokens.rs
@@ -169,7 +169,7 @@ impl FromStr for EdgeToken {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.contains(':') && s.contains('.') {
             let token_parts: Vec<String> = s.split(':').take(2).map(|s| s.to_string()).collect();
-            let token_projects = if let Some(projects) = token_parts.get(0) {
+            let token_projects = if let Some(projects) = token_parts.first() {
                 if projects == "[]" {
                     vec![]
                 } else {
@@ -188,7 +188,7 @@ impl FromStr for EdgeToken {
                     return Err(EdgeError::TokenParseError(s.into()));
                 }
                 Ok(EdgeToken {
-                    environment: e_a_k.get(0).cloned(),
+                    environment: e_a_k.first().cloned(),
                     projects: token_projects,
                     token_type: None,
                     token: s.into(),

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -176,6 +176,17 @@ impl EdgeToken {
             projects: vec!["*".into()],
         }
     }
+
+    #[cfg(test)]
+    pub fn validated_client_token(token: &str) -> Self {
+        EdgeToken::from_str(token)
+            .map(|mut t| {
+                t.status = TokenValidationStatus::Validated;
+                t.token_type = Some(TokenType::Client);
+                t
+            })
+            .unwrap()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, utoipa::ToSchema)]

--- a/server/tests/redis_test.rs
+++ b/server/tests/redis_test.rs
@@ -80,5 +80,5 @@ async fn redis_saves_and_restores_token_refreshes_correctly() {
         .unwrap();
     let saved_refreshes = redis_persister.load_refresh_targets().await.unwrap();
     assert_eq!(saved_refreshes.len(), 1);
-    assert_eq!(saved_refreshes.get(0).unwrap().token, edge_token);
+    assert_eq!(saved_refreshes.first().unwrap().token, edge_token);
 }


### PR DESCRIPTION
Will now post to /api/client/metrics/bulk if upstream returns 

- Edge version 17.0.0 or newer.
- Unleash version 5.9.0 or newer (or actually 5.8.0+main, our tip of main).