### PR TITLE
Feat/use etag from upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ debug/
 *.ipr
 *.iws
 .vscode
+mutants.out
 
 .project
 .classpath

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "actix-cors"
-version = "0.6.5"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0346d8c1f762b41b458ed3145eea914966bb9ad20b9be0d6d463b20d45586370"
+checksum = "f9e772b3bcafe335042b5db010ab7c09013dad6eac4915c91d8d50902769f331"
 dependencies = [
  "actix-utils",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "actix-cors"
-version = "0.7.0"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e772b3bcafe335042b5db010ab7c09013dad6eac4915c91d8d50902769f331"
+checksum = "0346d8c1f762b41b458ed3145eea914966bb9ad20b9be0d6d463b20d45586370"
 dependencies = [
  "actix-utils",
  "actix-web",
@@ -447,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.5"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bitflags"
@@ -2979,6 +2979,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "async-trait",
+ "base64",
  "chrono",
  "cidr",
  "clap",
@@ -3008,6 +3009,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "shadow-rs",
+ "str-buf",
  "test-case",
  "testcontainers",
  "testcontainers-modules",
@@ -3020,6 +3022,7 @@ dependencies = [
  "unleash-yggdrasil",
  "utoipa",
  "utoipa-swagger-ui",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -3503,9 +3506,9 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9828b178da53440fa9c766a3d2f73f7cf5d0ac1fe3980c1e5018d899fd19e07b"
+checksum = "53be06678ed9e83edb1745eb72efc0bbcd7b5c3c35711a860906aed827a13d61"
 
 [[package]]
 name = "zerocopy"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -21,7 +21,7 @@ license = false
 eula = false
 
 [dependencies]
-actix-cors = "0.6.5"
+actix-cors = "0.7.0"
 actix-http = { version = "3.5.1", features = ["compress-zstd", "rustls-0_21"] }
 actix-middleware-etag = "0.3.0"
 actix-service = "2.0.2"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -87,7 +87,7 @@ utoipa = { version = "4.2.0", features = ["actix_extras", "chrono"] }
 utoipa-swagger-ui = { version = "6", features = ["actix-web"] }
 xxhash-rust = { version = "0.8.8", features = ["xxh3"] }
 [dev-dependencies]
-actix-http = "3.4.0"
+actix-http = "3.5.1"
 actix-http-test = "3.1.0"
 actix-service = "2.0.2"
 env_logger = "0.10.1"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -21,7 +21,7 @@ license = false
 eula = false
 
 [dependencies]
-actix-cors = "0.7.0"
+actix-cors = "0.6.5"
 actix-http = { version = "3.5.1", features = ["compress-zstd", "rustls-0_21"] }
 actix-middleware-etag = "0.3.0"
 actix-service = "2.0.2"
@@ -30,6 +30,7 @@ ahash = "0.8.7"
 
 anyhow = "1.0.79"
 async-trait = "0.1.77"
+base64 = "0.21.7"
 chrono = { version = "0.4.31", features = ["serde"] }
 cidr = "0.2.2"
 clap = { version = "4.4.16", features = ["derive", "env"] }
@@ -70,6 +71,7 @@ serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "1.0.111"
 serde_qs = { version = "0.12.0", features = ["actix4", "tracing"] }
 shadow-rs = { version = "0.26.0" }
+str-buf = "3.0.2"
 tokio = { version = "1.35.1", features = [
   "macros",
   "rt-multi-thread",
@@ -83,8 +85,9 @@ unleash-types = { version = "0.10", features = ["openapi", "hashes"] }
 unleash-yggdrasil = { version = "0.8.0" }
 utoipa = { version = "4.2.0", features = ["actix_extras", "chrono"] }
 utoipa-swagger-ui = { version = "6", features = ["actix-web"] }
+xxhash-rust = { version = "0.8.8", features = ["xxh3"] }
 [dev-dependencies]
-actix-http = "3.5.1"
+actix-http = "3.4.0"
 actix-http-test = "3.1.0"
 actix-service = "2.0.2"
 env_logger = "0.10.1"

--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -270,6 +270,7 @@ mod tests {
     use crate::middleware;
     use crate::tests::{features_from_disk, upstream_server};
     use actix_http::Request;
+    use actix_web::http::header::EntityTag;
     use actix_web::{
         http::header::ContentType,
         test,
@@ -870,10 +871,12 @@ mod tests {
             Arc::new(DashMap::default());
         let upstream_token_cache: Arc<DashMap<String, EdgeToken>> = Arc::new(DashMap::default());
         let upstream_engine_cache: Arc<DashMap<String, EngineState>> = Arc::new(DashMap::default());
+        let upstream_etag_cache: Arc<DashMap<EdgeToken, EntityTag>> = Arc::new(DashMap::default());
         let server = upstream_server(
             upstream_token_cache.clone(),
             upstream_features_cache.clone(),
             upstream_engine_cache.clone(),
+            upstream_etag_cache.clone(),
         )
         .await;
         let upstream_features = features_from_disk("../examples/hostedexample.json");
@@ -889,11 +892,13 @@ mod tests {
         let features_cache: Arc<DashMap<String, ClientFeatures>> = Arc::new(DashMap::default());
         let token_cache: Arc<DashMap<String, EdgeToken>> = Arc::new(DashMap::default());
         let engine_cache: Arc<DashMap<String, EngineState>> = Arc::new(DashMap::default());
+        let etag_cache: Arc<DashMap<EdgeToken, EntityTag>> = Arc::new(DashMap::default());
         let feature_refresher = Arc::new(FeatureRefresher {
             unleash_client: unleash_client.clone(),
             tokens_to_refresh: Arc::new(Default::default()),
             features_cache: features_cache.clone(),
             engine_cache: engine_cache.clone(),
+            etag_cache: etag_cache.clone(),
             refresh_interval: Duration::seconds(6000),
             persistence: None,
         });
@@ -993,10 +998,13 @@ mod tests {
             Arc::new(DashMap::default());
         let upstream_token_cache: Arc<DashMap<String, EdgeToken>> = Arc::new(DashMap::default());
         let upstream_engine_cache: Arc<DashMap<String, EngineState>> = Arc::new(DashMap::default());
+        let upstream_etag_cache: Arc<DashMap<EdgeToken, EntityTag>> = Arc::new(DashMap::default());
+
         let server = upstream_server(
             upstream_token_cache.clone(),
             upstream_features_cache.clone(),
             upstream_engine_cache.clone(),
+            upstream_etag_cache.clone(),
         )
         .await;
         let upstream_features = features_from_disk("../examples/hostedexample.json");
@@ -1013,10 +1021,13 @@ mod tests {
         let features_cache: Arc<DashMap<String, ClientFeatures>> = Arc::new(DashMap::default());
         let token_cache: Arc<DashMap<String, EdgeToken>> = Arc::new(DashMap::default());
         let engine_cache: Arc<DashMap<String, EngineState>> = Arc::new(DashMap::default());
+        let etag_cache = Arc::new(DashMap::default());
+
         let feature_refresher = Arc::new(FeatureRefresher::new(
             unleash_client.clone(),
             features_cache.clone(),
             engine_cache.clone(),
+            etag_cache.clone(),
             Duration::seconds(6000),
             None,
         ));

--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -570,11 +570,14 @@ mod tests {
         let upstream_token_cache = Arc::new(DashMap::default());
         let upstream_features_cache = Arc::new(DashMap::default());
         let upstream_engine_cache = Arc::new(DashMap::default());
+        let upstream_etag_cache = Arc::new(DashMap::default());
+
         upstream_token_cache.insert(token.token.clone(), token.clone());
         let srv = upstream_server(
             upstream_token_cache,
             upstream_features_cache,
             upstream_engine_cache,
+            upstream_etag_cache,
         )
         .await;
         let req = reqwest::Client::new();
@@ -606,11 +609,13 @@ mod tests {
         let upstream_token_cache = Arc::new(DashMap::default());
         let upstream_features_cache = Arc::new(DashMap::default());
         let upstream_engine_cache = Arc::new(DashMap::default());
+        let upstream_etag_cache = Arc::new(DashMap::default());
         upstream_token_cache.insert(frontend_token.token.clone(), frontend_token.clone());
         let srv = upstream_server(
             upstream_token_cache,
             upstream_features_cache,
             upstream_engine_cache,
+            upstream_etag_cache,
         )
         .await;
         let client = UnleashClient::new(srv.url("/").as_str(), None).unwrap();

--- a/server/src/filters.rs
+++ b/server/src/filters.rs
@@ -39,6 +39,20 @@ fn filter_features(
         .collect::<Vec<ClientFeature>>()
 }
 
+pub fn filter_features_for_token(features: &ClientFeatures, token: &EdgeToken) -> ClientFeatures {
+    let f = FeatureFilterSet::from(project_filter(&token));
+    let filtered = features
+        .features
+        .iter()
+        .filter(|feature| f.apply(feature))
+        .cloned()
+        .collect::<Vec<ClientFeature>>();
+    ClientFeatures {
+        features: filtered,
+        ..features.clone()
+    }
+}
+
 pub(crate) fn filter_client_features(
     feature_cache: &Ref<'_, String, ClientFeatures>,
     filters: &FeatureFilterSet,

--- a/server/src/filters.rs
+++ b/server/src/filters.rs
@@ -40,7 +40,7 @@ fn filter_features(
 }
 
 pub fn filter_features_for_token(features: &ClientFeatures, token: &EdgeToken) -> ClientFeatures {
-    let f = FeatureFilterSet::from(project_filter(&token));
+    let f = FeatureFilterSet::from(project_filter(token));
     let filtered = features
         .features
         .iter()

--- a/server/src/hashing.rs
+++ b/server/src/hashing.rs
@@ -1,4 +1,4 @@
-use actix_http::header::{Header, HeaderName, HeaderValue, TryIntoHeaderPair};
+use actix_http::header::{HeaderName, HeaderValue, TryIntoHeaderPair};
 use actix_web::http::header::{ETag, EntityTag};
 use base64::Engine;
 use unleash_types::client_features::ClientFeatures;

--- a/server/src/hashing.rs
+++ b/server/src/hashing.rs
@@ -1,0 +1,30 @@
+use actix_http::header::{Header, HeaderName, HeaderValue, TryIntoHeaderPair};
+use actix_web::http::header::{ETag, EntityTag};
+use base64::Engine;
+use unleash_types::client_features::ClientFeatures;
+use xxhash_rust::xxh3;
+
+use crate::error::EdgeError;
+
+pub fn bytes_to_etag(bytes: &[u8]) -> EntityTag {
+    let hash = xxh3::xxh3_128(bytes);
+    let base64 = base64::prelude::BASE64_URL_SAFE.encode(hash.to_le_bytes());
+    let hash = format!("{:x}-{}", bytes.len(), base64);
+    EntityTag::new_weak(hash)
+}
+
+pub fn bytes_to_etag_header(bytes: &[u8]) -> Result<(HeaderName, HeaderValue), EdgeError> {
+    let etag = bytes_to_etag(bytes);
+    entity_tag_to_etag_header(&etag)
+}
+
+pub fn entity_tag_to_etag_header(etag: &EntityTag) -> Result<(HeaderName, HeaderValue), EdgeError> {
+    ETag(etag.clone())
+        .try_into_pair()
+        .map_err(|_| EdgeError::EdgeTokenError)
+}
+
+pub fn client_features_to_etag(features: &ClientFeatures) -> EntityTag {
+    let bytes = serde_json::to_vec(features).unwrap();
+    bytes_to_etag(&bytes)
+}

--- a/server/src/http/feature_refresher.rs
+++ b/server/src/http/feature_refresher.rs
@@ -533,12 +533,14 @@ mod tests {
         );
         let features_cache = Arc::new(DashMap::default());
         let engines_cache = Arc::new(DashMap::default());
+        let etag_cache = Arc::new(DashMap::default());
 
         let duration = Duration::seconds(5);
         let feature_refresher = FeatureRefresher::new(
             Arc::new(unleash_client),
             features_cache,
             engines_cache,
+            etag_cache,
             duration,
             None,
         );
@@ -565,12 +567,14 @@ mod tests {
         );
         let features_cache = Arc::new(DashMap::default());
         let engines_cache = Arc::new(DashMap::default());
+        let etag_cache = Arc::new(DashMap::default());
 
         let duration = Duration::seconds(5);
         let feature_refresher = FeatureRefresher::new(
             Arc::new(unleash_client),
             features_cache,
             engines_cache,
+            etag_cache,
             duration,
             None,
         );
@@ -601,11 +605,13 @@ mod tests {
         );
         let features_cache = Arc::new(DashMap::default());
         let engines_cache = Arc::new(DashMap::default());
+        let etag_cache = Arc::new(DashMap::default());
         let duration = Duration::seconds(5);
         let feature_refresher = FeatureRefresher::new(
             Arc::new(unleash_client),
             features_cache,
             engines_cache,
+            etag_cache,
             duration,
             None,
         );
@@ -644,11 +650,13 @@ mod tests {
         );
         let features_cache = Arc::new(DashMap::default());
         let engines_cache = Arc::new(DashMap::default());
+        let etag_cache = Arc::new(DashMap::default());
         let duration = Duration::seconds(5);
         let feature_refresher = FeatureRefresher::new(
             Arc::new(unleash_client),
             features_cache,
             engines_cache,
+            etag_cache,
             duration,
             None,
         );
@@ -696,11 +704,13 @@ mod tests {
         );
         let features_cache = Arc::new(DashMap::default());
         let engines_cache = Arc::new(DashMap::default());
+        let etag_cache = Arc::new(DashMap::default());
         let duration = Duration::seconds(5);
         let feature_refresher = FeatureRefresher::new(
             Arc::new(unleash_client),
             features_cache,
             engines_cache,
+            etag_cache,
             duration,
             None,
         );
@@ -752,12 +762,13 @@ mod tests {
         );
         let features_cache = Arc::new(DashMap::default());
         let engines_cache = Arc::new(DashMap::default());
-
+        let etag_cache = Arc::new(DashMap::default());
         let duration = Duration::seconds(5);
         let feature_refresher = FeatureRefresher::new(
             Arc::new(unleash_client),
             features_cache,
             engines_cache,
+            etag_cache,
             duration,
             None,
         );
@@ -793,12 +804,14 @@ mod tests {
         );
         let features_cache = Arc::new(DashMap::default());
         let engines_cache = Arc::new(DashMap::default());
+        let etag_cache = Arc::new(DashMap::default());
 
         let duration = Duration::seconds(5);
         let feature_refresher = FeatureRefresher::new(
             Arc::new(unleash_client),
             features_cache,
             engines_cache,
+            etag_cache,
             duration,
             None,
         );
@@ -829,12 +842,14 @@ mod tests {
         );
         let features_cache = Arc::new(DashMap::default());
         let engines_cache = Arc::new(DashMap::default());
+        let etag_cache = Arc::new(DashMap::default());
 
         let duration = Duration::seconds(5);
         let feature_refresher = FeatureRefresher::new(
             Arc::new(unleash_client),
             features_cache,
             engines_cache,
+            etag_cache,
             duration,
             None,
         );
@@ -900,6 +915,7 @@ mod tests {
         upstream_token_cache: Arc<DashMap<String, EdgeToken>>,
         upstream_features_cache: Arc<DashMap<String, ClientFeatures>>,
         upstream_engine_cache: Arc<DashMap<String, EngineState>>,
+        upstream_etag_cache: Arc<DashMap<EdgeToken, EntityTag>>,
     ) -> TestServer {
         test_server(move || {
             HttpService::new(map_config(
@@ -907,6 +923,7 @@ mod tests {
                     .app_data(web::Data::from(upstream_features_cache.clone()))
                     .app_data(web::Data::from(upstream_engine_cache.clone()))
                     .app_data(web::Data::from(upstream_token_cache.clone()))
+                    .app_data(web::Data::from(upstream_etag_cache.clone()))
                     .service(web::scope("/api").configure(crate::client_api::configure_client_api)),
                 |_| AppConfig::default(),
             ))
@@ -920,19 +937,24 @@ mod tests {
             Arc::new(DashMap::default());
         let upstream_engine_cache: Arc<DashMap<String, EngineState>> = Arc::new(DashMap::default());
         let upstream_token_cache: Arc<DashMap<String, EdgeToken>> = Arc::new(DashMap::default());
+        let upstream_etag_cache = Arc::new(DashMap::default());
         let server = client_api_test_server(
             upstream_token_cache,
             upstream_features_cache,
             upstream_engine_cache,
+            upstream_etag_cache,
         )
         .await;
         let unleash_client = UnleashClient::new(server.url("/").as_str(), None).unwrap();
         let features_cache: Arc<DashMap<String, ClientFeatures>> = Arc::new(DashMap::default());
         let engine_cache: Arc<DashMap<String, EngineState>> = Arc::new(DashMap::default());
+        let etag_cache = Arc::new(DashMap::default());
+
         let feature_refresher = FeatureRefresher::new(
             Arc::new(unleash_client),
             features_cache,
             engine_cache,
+            etag_cache,
             Duration::seconds(60),
             None,
         );
@@ -960,6 +982,8 @@ mod tests {
             Arc::new(DashMap::default());
         let upstream_engine_cache: Arc<DashMap<String, EngineState>> = Arc::new(DashMap::default());
         let upstream_token_cache: Arc<DashMap<String, EdgeToken>> = Arc::new(token_cache);
+        let upstream_etag_cache = Arc::new(DashMap::default());
+
         let example_features = features_from_disk("../examples/features.json");
         let cache_key = cache_key(&token);
         let mut engine_state = EngineState::default();
@@ -970,15 +994,18 @@ mod tests {
             upstream_token_cache,
             upstream_features_cache,
             upstream_engine_cache,
+            upstream_etag_cache,
         )
         .await;
         let unleash_client = UnleashClient::new(server.url("/").as_str(), None).unwrap();
         let features_cache: Arc<DashMap<String, ClientFeatures>> = Arc::new(DashMap::default());
         let engine_cache: Arc<DashMap<String, EngineState>> = Arc::new(DashMap::default());
+        let etag_cache = Arc::new(DashMap::default());
         let feature_refresher = FeatureRefresher::new(
             Arc::new(unleash_client),
             features_cache,
             engine_cache,
+            etag_cache,
             Duration::milliseconds(1),
             None,
         );
@@ -1011,12 +1038,17 @@ mod tests {
             Arc::new(DashMap::default());
         let upstream_engine_cache: Arc<DashMap<String, EngineState>> = Arc::new(DashMap::default());
         let upstream_token_cache: Arc<DashMap<String, EdgeToken>> = Arc::new(DashMap::default());
+        let upstream_etag_cache: Arc<DashMap<EdgeToken, EntityTag>> = Arc::new(DashMap::default());
         let token_cache_to_modify = upstream_token_cache.clone();
         let mut valid_token = EdgeToken::try_from("*:development.secret123".to_string()).unwrap();
         valid_token.token_type = Some(TokenType::Client);
         valid_token.status = Validated;
         upstream_token_cache.insert(valid_token.token.clone(), valid_token.clone());
         let example_features = features_from_disk("../examples/features.json");
+        upstream_etag_cache.insert(
+            valid_token.clone(),
+            crate::hashing::client_features_to_etag(&example_features),
+        );
         let cache_key = cache_key(&valid_token);
         let mut engine_state = EngineState::default();
         engine_state.take_state(example_features.clone());
@@ -1026,6 +1058,7 @@ mod tests {
             upstream_token_cache,
             upstream_features_cache,
             upstream_engine_cache,
+            upstream_etag_cache,
         )
         .await;
         let unleash_client = UnleashClient::new(server.url("/").as_str(), None).unwrap();
@@ -1052,6 +1085,7 @@ mod tests {
             Arc::new(DashMap::default());
         let upstream_engine_cache: Arc<DashMap<String, EngineState>> = Arc::new(DashMap::default());
         let upstream_token_cache: Arc<DashMap<String, EdgeToken>> = Arc::new(DashMap::default());
+        let upstream_etag_cache: Arc<DashMap<EdgeToken, EntityTag>> = Arc::new(DashMap::default());
         let token_cache_to_modify = upstream_token_cache.clone();
         let mut dx_token = EdgeToken::try_from("dx:development.secret123".to_string()).unwrap();
         dx_token.token_type = Some(TokenType::Client);
@@ -1071,6 +1105,7 @@ mod tests {
             upstream_token_cache,
             upstream_features_cache,
             upstream_engine_cache,
+            upstream_etag_cache,
         )
         .await;
         let unleash_client = UnleashClient::new(server.url("/").as_str(), None).unwrap();
@@ -1101,6 +1136,7 @@ mod tests {
             Arc::new(DashMap::default());
         let upstream_engine_cache: Arc<DashMap<String, EngineState>> = Arc::new(DashMap::default());
         let upstream_token_cache: Arc<DashMap<String, EdgeToken>> = Arc::new(DashMap::default());
+        let upstream_etag_cache: Arc<DashMap<EdgeToken, EntityTag>> = Arc::new(DashMap::default());
         let mut dx_token = EdgeToken::try_from("dx:development.secret123".to_string()).unwrap();
         dx_token.token_type = Some(TokenType::Client);
         dx_token.status = Validated;
@@ -1119,6 +1155,7 @@ mod tests {
             upstream_token_cache,
             upstream_features_cache,
             upstream_engine_cache,
+            upstream_etag_cache,
         )
         .await;
         let unleash_client = UnleashClient::new(server.url("/").as_str(), None).unwrap();
@@ -1157,6 +1194,7 @@ mod tests {
             Arc::new(DashMap::default());
         let upstream_engine_cache: Arc<DashMap<String, EngineState>> = Arc::new(DashMap::default());
         let upstream_token_cache: Arc<DashMap<String, EdgeToken>> = Arc::new(DashMap::default());
+        let upstream_etag_cache: Arc<DashMap<EdgeToken, EntityTag>> = Arc::new(DashMap::default());
         let mut dx_token = EdgeToken::from_str("dx:development.secret123").unwrap();
         dx_token.token_type = Some(TokenType::Client);
         dx_token.status = Validated;
@@ -1180,6 +1218,7 @@ mod tests {
             upstream_token_cache,
             upstream_features_cache,
             upstream_engine_cache,
+            upstream_etag_cache,
         )
         .await;
         let unleash_client = UnleashClient::new(server.url("/").as_str(), None).unwrap();
@@ -1273,11 +1312,16 @@ mod tests {
             Arc::new(DashMap::default());
         let upstream_engine_cache: Arc<DashMap<String, EngineState>> = Arc::new(DashMap::default());
         let upstream_token_cache: Arc<DashMap<String, EdgeToken>> = Arc::new(DashMap::default());
+        let upstream_etag_cache: Arc<DashMap<EdgeToken, EntityTag>> = Arc::new(DashMap::default());
         let mut eg_token = EdgeToken::from_str("eg:development.devsecret").unwrap();
         eg_token.token_type = Some(TokenType::Client);
         eg_token.status = Validated;
         upstream_token_cache.insert(eg_token.token.clone(), eg_token.clone());
         let example_features = features_from_disk("../examples/hostedexample.json");
+        upstream_etag_cache.insert(
+            eg_token.clone(),
+            crate::hashing::client_features_to_etag(&example_features),
+        );
         let cache_key = cache_key(&eg_token);
         upstream_features_cache.insert(cache_key.clone(), example_features.clone());
         let mut engine_state = EngineState::default();
@@ -1287,6 +1331,7 @@ mod tests {
             upstream_token_cache,
             upstream_features_cache.clone(),
             upstream_engine_cache,
+            upstream_etag_cache.clone(),
         )
         .await;
         let features_cache: Arc<DashMap<String, ClientFeatures>> = Arc::new(DashMap::default());
@@ -1296,7 +1341,8 @@ mod tests {
             tokens_to_refresh: Arc::new(Default::default()),
             features_cache: features_cache.clone(),
             engine_cache: Arc::new(Default::default()),
-            refresh_interval: chrono::Duration::seconds(0),
+            etag_cache: Arc::new(Default::default()),
+            refresh_interval: Duration::seconds(0),
             persistence: None,
         };
 
@@ -1330,7 +1376,7 @@ mod tests {
             .collect();
         dx_data.remove(0);
         let mut token = EdgeToken::from_str("[]:development.somesecret").unwrap();
-        token.status = TokenValidationStatus::Validated;
+        token.status = Validated;
         token.projects = vec![String::from("dx")];
 
         let updated = super::update_projects_from_feature_update(&token, &features, &dx_data);

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -40,6 +40,7 @@ mod tests {
     use actix_http_test::{test_server, TestServer};
     use actix_service::map_config;
     use actix_web::dev::AppConfig;
+    use actix_web::http::header::EntityTag;
     use actix_web::{web, App};
     use dashmap::DashMap;
     use unleash_types::client_features::ClientFeatures;
@@ -61,6 +62,7 @@ mod tests {
         upstream_token_cache: Arc<DashMap<String, EdgeToken>>,
         upstream_features_cache: Arc<DashMap<String, ClientFeatures>>,
         upstream_engine_cache: Arc<DashMap<String, EngineState>>,
+        upstream_etag_cache: Arc<DashMap<EdgeToken, EntityTag>>,
     ) -> TestServer {
         let token_validator = Arc::new(TokenValidator {
             unleash_client: Arc::new(Default::default()),
@@ -85,6 +87,7 @@ mod tests {
                     .app_data(web::Data::from(upstream_token_cache.clone()))
                     .app_data(web::Data::new(metrics_cache))
                     .app_data(web::Data::new(connect_via))
+                    .app_data(web::Data::from(upstream_etag_cache.clone()))
                     .service(
                         web::scope("/api")
                             .configure(crate::client_api::configure_client_api)

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -10,6 +10,7 @@ pub mod edge_api;
 pub mod error;
 pub mod filters;
 pub mod frontend_api;
+pub mod hashing;
 pub mod health_checker;
 pub mod http;
 pub mod internal_backstage;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use actix_cors::Cors;
-use actix_middleware_etag::Etag;
+
 use actix_web::middleware::Logger;
 use actix_web::{web, App, HttpServer};
 use clap::Parser;
@@ -101,7 +101,9 @@ async fn main() -> Result<(), anyhow::Error> {
         };
         app.service(
             web::scope(&base_path)
-                .wrap(Etag)
+                .wrap(unleash_edge::middleware::etag::EdgeETag {
+                    feature_refresher: refresher_for_app_data.clone(),
+                })
                 .wrap(actix_web::middleware::Compress::default())
                 .wrap(actix_web::middleware::NormalizePath::default())
                 .wrap(cors_middleware)

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<(), anyhow::Error> {
         instance_id: args.clone().instance_id,
     };
     let (
-        (token_cache, features_cache, engine_cache),
+        (token_cache, features_cache, engine_cache, etag_cache),
         token_validator,
         feature_refresher,
         persistence,
@@ -102,7 +102,7 @@ async fn main() -> Result<(), anyhow::Error> {
         app.service(
             web::scope(&base_path)
                 .wrap(unleash_edge::middleware::etag::EdgeETag {
-                    feature_refresher: refresher_for_app_data.clone(),
+                    etag_cache: etag_cache.clone(),
                 })
                 .wrap(actix_web::middleware::Compress::default())
                 .wrap(actix_web::middleware::NormalizePath::default())

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -90,7 +90,8 @@ async fn main() -> Result<(), anyhow::Error> {
             .app_data(web::Data::from(metrics_cache.clone()))
             .app_data(web::Data::from(token_cache.clone()))
             .app_data(web::Data::from(features_cache.clone()))
-            .app_data(web::Data::from(engine_cache.clone()));
+            .app_data(web::Data::from(engine_cache.clone()))
+            .app_data(web::Data::from(etag_cache.clone()));
         app = match token_validator.clone() {
             Some(v) => app.app_data(web::Data::from(v)),
             None => app,

--- a/server/src/middleware/etag.rs
+++ b/server/src/middleware/etag.rs
@@ -2,14 +2,14 @@ use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use actix_http::header::{HeaderName, HeaderValue};
+use actix_http::header::HeaderValue;
 use actix_service::{Service, Transform};
 use actix_web::body::{BodySize, BoxBody, EitherBody, MessageBody, None as BodyNone};
 use actix_web::dev::{ServiceRequest, ServiceResponse};
 use actix_web::http::header::{ETag, EntityTag, IfNoneMatch, TryIntoHeaderPair};
 use actix_web::http::Method;
 use actix_web::web::Bytes;
-use actix_web::{HttpMessage, HttpRequest, HttpResponse};
+use actix_web::{HttpMessage, HttpResponse};
 use base64::Engine;
 use core::fmt::Write;
 use dashmap::DashMap;
@@ -17,10 +17,8 @@ use futures::{
     future::{ok, Ready},
     Future,
 };
-use tracing::debug;
 use xxhash_rust::xxh3::xxh3_128;
 
-use crate::http::feature_refresher::FeatureRefresher;
 use crate::types::EdgeToken;
 
 #[derive(Default, Clone)]

--- a/server/src/middleware/etag.rs
+++ b/server/src/middleware/etag.rs
@@ -145,10 +145,11 @@ fn we_know_this_etag_from_upstream(
     client_token: &Option<EdgeToken>,
     if_none_match: &Option<IfNoneMatch>,
 ) -> bool {
-    match (if_none_match, client_token) {
-        (Some(if_none), Some(token)) => etag_cache.get(token).map_or(false, |etag| {
+    if let (Some(if_none), Some(token)) = (if_none_match, client_token) {
+        etag_cache.get(token).map_or(false, |etag| {
             if_none == &IfNoneMatch::Any || if_none.to_string() == etag.to_string()
-        }),
-        _ => false,
+        })
+    } else {
+        false
     }
 }

--- a/server/src/middleware/etag.rs
+++ b/server/src/middleware/etag.rs
@@ -1,0 +1,146 @@
+use std::pin::Pin;
+use std::sync::Arc;
+
+use actix_service::{Service, Transform};
+use actix_web::body::{BodySize, BoxBody, EitherBody, MessageBody, None as BodyNone};
+use actix_web::dev::{ServiceRequest, ServiceResponse};
+use actix_web::http::header::{ETag, EntityTag, IfNoneMatch, TryIntoHeaderPair};
+use actix_web::http::Method;
+use actix_web::web::Bytes;
+use actix_web::{HttpMessage, HttpRequest, HttpResponse};
+use base64::Engine;
+use core::fmt::Write;
+use futures::{
+    future::{ok, Ready},
+    Future,
+};
+use tracing::debug;
+use xxhash_rust::xxh3::xxh3_128;
+
+use crate::http::feature_refresher::FeatureRefresher;
+
+#[derive(Default, Clone)]
+pub struct EdgeETag {
+    pub feature_refresher: Option<Arc<FeatureRefresher>>,
+}
+
+impl<S, B> Transform<S, ServiceRequest> for EdgeETag
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error>,
+    S::Future: 'static,
+    B: MessageBody + 'static,
+{
+    type Response = ServiceResponse<EitherBody<BoxBody>>;
+    type Error = actix_web::Error;
+    type Transform = EdgeETagMiddleware<S>;
+    type InitError = ();
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ok(EdgeETagMiddleware {
+            service: service,
+            feature_refresher: self.feature_refresher.clone(),
+        })
+    }
+}
+type Buffer = str_buf::StrBuf<62>;
+
+pub struct EdgeETagMiddleware<S> {
+    service: S,
+    feature_refresher: Option<Arc<FeatureRefresher>>,
+}
+
+impl<S, B> Service<ServiceRequest> for EdgeETagMiddleware<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error>,
+    S::Future: 'static,
+    B: MessageBody + 'static,
+{
+    type Response = ServiceResponse<EitherBody<BoxBody>>;
+    type Error = actix_web::Error;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<ServiceResponse<EitherBody<BoxBody>>, Self::Error>>>>;
+
+    actix_service::forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let request_etag_header: Option<IfNoneMatch> = req.get_header();
+        let method = req.method().clone();
+        let feature_refresher = self.feature_refresher.clone();
+        debug!("Evaluating ETag");
+        if we_know_this_etag_from_upstream(feature_refresher, &request_etag_header) {
+            Box::pin(async move {
+                return Ok(ServiceResponse::new(
+                    req.request().clone(),
+                    HttpResponse::NotModified().body(BodyNone::new()),
+                )
+                .into_response(HttpResponse::NotModified().body(BodyNone::new()))
+                .map_into_right_body());
+            })
+        } else {
+            let fut = self.service.call(req);
+            Box::pin(async move {
+                let res: ServiceResponse<B> = fut.await?;
+                match method {
+                    Method::GET => {
+                        let mut modified = true;
+                        let mut payload: Option<Bytes> = None;
+                        let mut res = res.map_body(|_h, body| match body.size() {
+                            BodySize::Sized(_size) => {
+                                let bytes = body.try_into_bytes().unwrap_or_else(|_| Bytes::new());
+                                payload = Some(bytes.clone());
+
+                                bytes.clone().boxed()
+                            }
+                            _ => body.boxed(),
+                        });
+                        match payload {
+                            Some(bytes) => {
+                                let response_hash = xxh3_128(&bytes);
+                                let base64 = base64::prelude::BASE64_URL_SAFE
+                                    .encode(response_hash.to_le_bytes());
+                                let mut buff = Buffer::new();
+                                let _ = write!(buff, "{:x}-{}", bytes.len(), base64);
+                                let tag = EntityTag::new_weak(buff.to_string());
+                                if let Some(request_etag_header) = request_etag_header {
+                                    if request_etag_header == IfNoneMatch::Any
+                                        || request_etag_header.to_string() == tag.to_string()
+                                    {
+                                        modified = false
+                                    }
+                                }
+                                if modified {
+                                    if let Ok((name, value)) = ETag(tag.clone()).try_into_pair() {
+                                        res.headers_mut().insert(name, value);
+                                    }
+                                }
+                            }
+                            None => {}
+                        }
+
+                        Ok(match modified {
+                            false => res
+                                .into_response(HttpResponse::NotModified().body(BodyNone::new()))
+                                .map_into_right_body(),
+                            true => res.map_into_left_body(),
+                        })
+                    }
+                    _ => Ok(res.map_into_boxed_body().map_into_left_body()),
+                }
+            })
+        }
+    }
+}
+
+fn we_know_this_etag_from_upstream(
+    feature_refresher: Option<Arc<FeatureRefresher>>,
+    if_none_match: &Option<IfNoneMatch>,
+) -> bool {
+    match if_none_match {
+        Some(none_match) => match feature_refresher {
+            Some(fr) => fr.has_token_with_etag(&none_match),
+            None => false,
+        },
+        None => false,
+    }
+}

--- a/server/src/middleware/mod.rs
+++ b/server/src/middleware/mod.rs
@@ -8,3 +8,5 @@ pub mod validate_token;
 pub mod client_token_from_frontend_token;
 
 pub mod enrich_with_client_ip;
+
+pub mod etag;

--- a/server/src/offline/offline_hotload.rs
+++ b/server/src/offline/offline_hotload.rs
@@ -62,6 +62,7 @@ pub(crate) fn load_offline_engine_cache(
         crate::tokens::cache_key(edge_token),
         client_features.clone(),
     );
+
     let mut engine_state = EngineState::default();
     engine_state.take_state(client_features);
     engine_cache.insert(crate::tokens::cache_key(edge_token), engine_state);


### PR DESCRIPTION
This changes our client features endpoint to rely on etag we get from upstream, avoiding doing the service call and just returning 304 if we match.