### PR TITLE
fix: include strategy variant stickiness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,6 +1176,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
+]
+
+[[package]]
 name = "http"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,6 +1351,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "ipnetwork"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,6 +1519,12 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
@@ -3024,9 +3050,9 @@ dependencies = [
 
 [[package]]
 name = "unleash-types"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff718fdcaecdcc682ef3751b2496670e064f4058408ecb4199f0bf065c27181"
+checksum = "b6db70f5a700ad12ebb8ab08483f81eea23de296d5a094d2164e442a5b701d80"
 dependencies = [
  "base64",
  "chrono",
@@ -3039,14 +3065,16 @@ dependencies = [
 
 [[package]]
 name = "unleash-yggdrasil"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9eb99db51abff93ec3e1bff5150add9f42ecd510b6a2e5e59ded8b7f69e008"
+checksum = "37e4c35ce30ecda43c78d1f72ea55fffee3412a5a9c9ddea9de8db4efedaf03e"
 dependencies = [
  "chrono",
  "convert_case 0.6.0",
  "dashmap",
+ "hostname",
  "ipnet",
+ "ipnetwork",
  "lazy_static",
  "murmur3",
  "pest",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -79,8 +79,8 @@ tokio = { version = "1.35.1", features = [
 tracing = { version = "0.1.40", features = ["log"] }
 tracing-subscriber = { version = "0.3.18", features = ["json", "env-filter"] }
 ulid = "1.1.0"
-unleash-types = { version = "0.10", features = ["openapi", "hashes"] }
-unleash-yggdrasil = { version = "0.8.0" }
+unleash-types = { version = "0.11", features = ["openapi", "hashes"] }
+unleash-yggdrasil = { version = "0.9.0" }
 utoipa = { version = "4.2.0", features = ["actix_extras", "chrono"] }
 utoipa-swagger-ui = { version = "6", features = ["actix-web"] }
 [dev-dependencies]

--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -61,8 +61,14 @@ async fn hydrate_from_persistent_storage(
         tracing::debug!("Hydrating features for {key:?}");
         features_cache.insert(key.clone(), features.clone());
         let mut engine_state = EngineState::default();
-        engine_state.take_state(features);
-        engine_cache.insert(key, engine_state);
+
+        if engine_state.take_state(features).is_err() {
+            tracing::warn!(
+                "Loaded an invalid state from persistent storage, bootstrapping has failed"
+            );
+        } else {
+            engine_cache.insert(key, engine_state);
+        }
     }
 
     for target in refresh_targets {

--- a/server/src/middleware/client_token_from_frontend_token.rs
+++ b/server/src/middleware/client_token_from_frontend_token.rs
@@ -195,7 +195,7 @@ mod tests {
         upstream_features_cache.insert(client_token.environment.clone().unwrap(), features.clone());
         let upstream_engine_cache: Arc<DashMap<String, EngineState>> = Arc::new(DashMap::default());
         let mut engine = EngineState::default();
-        engine.take_state(features.clone());
+        engine.take_state(features.clone()).unwrap();
         upstream_engine_cache.insert(client_token.token.clone(), engine);
         let upstream_server = upstream_server(
             upstream_token_cache.clone(),

--- a/server/src/offline/offline_hotload.rs
+++ b/server/src/offline/offline_hotload.rs
@@ -63,8 +63,11 @@ pub(crate) fn load_offline_engine_cache(
         client_features.clone(),
     );
     let mut engine_state = EngineState::default();
-    engine_state.take_state(client_features);
-    engine_cache.insert(crate::tokens::cache_key(edge_token), engine_state);
+    if engine_state.take_state(client_features).is_err() {
+        tracing::warn!("Loaded an invalid feature set from file, likely due to a manual edit, reverting to previous state");
+    } else {
+        engine_cache.insert(crate::tokens::cache_key(edge_token), engine_state);
+    }
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Changes the responses in Edge to include the stickiness property in Strategy Variants.

This technically shouldn't be necessary but this allows us to support versions on our Node SDK that incorrectly use this property for stickiness calculations. 

Note that this PR includes necessary patches to Yggdrasil to handle cases where updating features could fail and previously resulted in crashes in Edge. It's probably useful to review the commit that makes the changes for this patch in isolation: https://github.com/Unleash/unleash-edge/pull/403/commits/ecd3070262b1160a363389686dfce27f62122cf7