### PR TITLE
chore: make docker example use up to date edge and unleash versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 [![Coverage Status](https://coveralls.io/repos/github/Unleash/unleash-edge/badge.svg?branch=main)](https://coveralls.io/github/Unleash/unleash-edge?branch=main)
 ![downloads](https://img.shields.io/crates/d/unleash-edge.svg)
 
+> Warning: Unleash Edge requires Unleash v4.15.0 or higher
+
 Unleash Edge is the successor to the [Unleash Proxy](https://docs.getunleash.io/how-to/how-to-run-the-unleash-proxy).
 
 Unleash Edge sits between the Unleash API and your SDKs and provides a cached read-replica of your Unleash instance. This means you can scale up your Unleash instance to thousands of connected SDKs without increasing the number of requests you make to your Unleash instance.
@@ -128,9 +130,9 @@ Unleash Edge is distributed as a binary and as a docker image.
 - If you'd like to live on the edge (sic) you can use the tag `edge`. This is built from `HEAD` on each commit
 - When running the docker image, the same CLI arguments that's available when running the binary is available to your `docker run` command. To start successfully you will need to decide which mode you're running in.
   - If running in `edge` mode your command should be
-    - `docker run -p 3063:3063 -e UPSTREAM_URL=<YOUR_UNLEASH_INSTANCE> unleashorg/unleash-edge:v8.0.1 edge`
+    - `docker run -p 3063:3063 -e UPSTREAM_URL=<YOUR_UNLEASH_INSTANCE> unleashorg/unleash-edge:<version> edge`
   - If running in `offline` mode you will need to provide a volume containing your feature toggles file. An example is available inside the examples folder. To use this, you can use the command
-    - `docker run -v ./examples:/edge/data -p 3063:3063 -e BOOTSTRAP_FILE=/edge/data/features.json -e TOKENS='my-secret-123,another-secret-789' unleashorg/unleash-edge:v8.0.1 offline`
+    - `docker run -v ./examples:/edge/data -p 3063:3063 -e BOOTSTRAP_FILE=/edge/data/features.json -e TOKENS='my-secret-123,another-secret-789' unleashorg/unleash-edge:<version> offline`
 
 ### Cargo/Rust
 

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   unleash:
-    image: unleashorg/unleash-server
+    image: unleashorg/unleash-server:latest
     pull_policy: always
     ports:
       - "4242:4242"

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.8"
 services:
   unleash:
     image: unleashorg/unleash-server
+    pull_policy: always
     ports:
       - "4242:4242"
     environment:
@@ -25,7 +26,7 @@ services:
       retries: 5
       start_period: 10s
   edge:
-    image: unleashorg/unleash-edge:v13.0.0
+    image: unleashorg/unleash-edge:latest
     pull_policy: always
     restart: always
     depends_on:


### PR DESCRIPTION
A few small clean ups on our docs an examples:

- Removes all the constant versions in our markdown and examples and replaced with version templates or `latest`
- Makes the minimum version of Unleash required clear
- Marks Unleash as `pull_always` in the example compose