### PR TITLE
fix: degrade broken toggles gracefully in frontend api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3138,9 +3138,9 @@ dependencies = [
 
 [[package]]
 name = "unleash-yggdrasil"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e4c35ce30ecda43c78d1f72ea55fffee3412a5a9c9ddea9de8db4efedaf03e"
+checksum = "8c78f30652e8111ef252948f0f6f89155a5baf96767adca7db6465a2ecf55b95"
 dependencies = [
  "chrono",
  "convert_case 0.6.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3138,9 +3138,9 @@ dependencies = [
 
 [[package]]
 name = "unleash-yggdrasil"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c78f30652e8111ef252948f0f6f89155a5baf96767adca7db6465a2ecf55b95"
+checksum = "02cec99a5677823a367a6eb1e6ff7606bb5412d453e30a4d447d5bb9430ad221"
 dependencies = [
  "chrono",
  "convert_case 0.6.0",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -78,7 +78,7 @@ tracing = { version = "0.1.40", features = ["log"] }
 tracing-subscriber = { version = "0.3.18", features = ["json", "env-filter"] }
 ulid = "1.1.1"
 unleash-types = { version = "0.11", features = ["openapi", "hashes"] }
-unleash-yggdrasil = { version = "0.9.0" }
+unleash-yggdrasil = { version = "0.10.0" }
 utoipa = { version = "4.2.0", features = ["actix_extras", "chrono"] }
 utoipa-swagger-ui = { version = "6", features = ["actix-web"] }
 [dev-dependencies]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -78,7 +78,7 @@ tracing = { version = "0.1.40", features = ["log"] }
 tracing-subscriber = { version = "0.3.18", features = ["json", "env-filter"] }
 ulid = "1.1.1"
 unleash-types = { version = "0.11", features = ["openapi", "hashes"] }
-unleash-yggdrasil = { version = "0.10.0" }
+unleash-yggdrasil = { version = "0.11.0" }
 utoipa = { version = "4.2.0", features = ["actix_extras", "chrono"] }
 utoipa-swagger-ui = { version = "6", features = ["actix-web"] }
 [dev-dependencies]

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -96,6 +96,7 @@ pub enum EdgeError {
     ClientHydrationFailed(String),
     ClientRegisterError,
     FrontendNotYetHydrated(FrontendHydrationMissing),
+    FrontendExpectedToBeHydrated(String),
     FeatureNotFound(String),
     PersistenceError(String),
     EdgeMetricsError,
@@ -196,6 +197,9 @@ impl Display for EdgeError {
             EdgeError::ClientCacheError => {
                 write!(f, "Fetching client features from cache failed")
             }
+            EdgeError::FrontendExpectedToBeHydrated(message) => {
+                write!(f, "{}", message)
+            }
         }
     }
 }
@@ -230,6 +234,7 @@ impl ResponseError for EdgeError {
             EdgeError::ReadyCheckError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             EdgeError::ClientHydrationFailed(_) => StatusCode::INTERNAL_SERVER_ERROR,
             EdgeError::ClientCacheError => StatusCode::INTERNAL_SERVER_ERROR,
+            EdgeError::FrontendExpectedToBeHydrated(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 

--- a/server/src/frontend_api.rs
+++ b/server/src/frontend_api.rs
@@ -314,7 +314,7 @@ fn get_enabled_features(
     })?;
     let feature_results = engine.resolve_all(&context_with_ip, &None).ok_or_else(|| {
         EdgeError::FrontendExpectedToBeHydrated(
-            "Feature cache has not been hydrated yet, but it was expected to be".into(),
+            "Feature cache has not been hydrated yet, but it was expected to be. This can be due to a race condition from calling edge before it's ready. This error might auto resolve as soon as edge is able to fetch from upstream".into(),
         )
     })?;
     Ok(Json(frontend_from_yggdrasil(
@@ -515,7 +515,7 @@ async fn post_enabled_features(
         })?;
     let feature_results = engine.resolve_all(&context_with_ip, &None).ok_or_else(|| {
         EdgeError::FrontendExpectedToBeHydrated(
-            "Feature cache has not been hydrated yet, but it was expected to be".into(),
+            "Feature cache has not been hydrated yet, but it was expected to be. This can be due to a race condition from calling edge before it's ready. This error might auto resolve as soon as edge is able to fetch from upstream".into(),
         )
     })?;
 
@@ -765,7 +765,7 @@ pub fn get_all_features(
     })?;
     let feature_results = engine.resolve_all(&context_with_ip, &None).ok_or_else(|| {
         EdgeError::FrontendExpectedToBeHydrated(
-            "Feature cache has not been hydrated yet, but it was expected to be".into(),
+            "Feature cache has not been hydrated yet, but it was expected to be. This can be due to a race condition from calling edge before it's ready. This error might auto resolve as soon as edge is able to fetch from upstream".into(),
         )
     })?;
     Ok(Json(frontend_from_yggdrasil(feature_results, true, &token)))

--- a/server/src/frontend_api.rs
+++ b/server/src/frontend_api.rs
@@ -222,7 +222,7 @@ fn post_all_features(
     })?;
     let feature_results = engine.resolve_all(&context_with_ip, &None).ok_or_else(|| {
         EdgeError::FrontendExpectedToBeHydrated(
-            "Feature cache has not been hydrated yet, but it was expected to be".into(),
+            "Feature cache has not been hydrated yet, but it was expected to be. This can be due to a race condition from calling edge before it's ready. This error might auto resolve as soon as edge is able to fetch from upstream".into(),
         )
     })?;
     Ok(Json(frontend_from_yggdrasil(feature_results, true, &token)))

--- a/server/src/frontend_api.rs
+++ b/server/src/frontend_api.rs
@@ -220,7 +220,11 @@ fn post_all_features(
     let engine = engine_cache.get(&key).ok_or_else(|| {
         EdgeError::FrontendNotYetHydrated(FrontendHydrationMissing::from(&edge_token))
     })?;
-    let feature_results = engine.resolve_all(&context_with_ip, &None).unwrap();
+    let feature_results = engine.resolve_all(&context_with_ip, &None).ok_or_else(|| {
+        EdgeError::FrontendExpectedToBeHydrated(
+            "Feature cache has not been hydrated yet, but it was expected to be".into(),
+        )
+    })?;
     Ok(Json(frontend_from_yggdrasil(feature_results, true, &token)))
 }
 
@@ -308,7 +312,11 @@ fn get_enabled_features(
     let engine = engine_cache.get(&key).ok_or_else(|| {
         EdgeError::FrontendNotYetHydrated(FrontendHydrationMissing::from(&edge_token))
     })?;
-    let feature_results = engine.resolve_all(&context_with_ip, &None).unwrap();
+    let feature_results = engine.resolve_all(&context_with_ip, &None).ok_or_else(|| {
+        EdgeError::FrontendExpectedToBeHydrated(
+            "Feature cache has not been hydrated yet, but it was expected to be".into(),
+        )
+    })?;
     Ok(Json(frontend_from_yggdrasil(
         feature_results,
         false,
@@ -505,7 +513,12 @@ async fn post_enabled_features(
         .ok_or_else(|| {
             EdgeError::FrontendNotYetHydrated(FrontendHydrationMissing::from(&edge_token))
         })?;
-    let feature_results = engine.resolve_all(&context_with_ip, &None).unwrap();
+    let feature_results = engine.resolve_all(&context_with_ip, &None).ok_or_else(|| {
+        EdgeError::FrontendExpectedToBeHydrated(
+            "Feature cache has not been hydrated yet, but it was expected to be".into(),
+        )
+    })?;
+
     Ok(Json(frontend_from_yggdrasil(
         feature_results,
         false,
@@ -750,7 +763,11 @@ pub fn get_all_features(
     let engine = engine_cache.get(&key).ok_or_else(|| {
         EdgeError::FrontendNotYetHydrated(FrontendHydrationMissing::from(&edge_token))
     })?;
-    let feature_results = engine.resolve_all(&context_with_ip, &None).unwrap();
+    let feature_results = engine.resolve_all(&context_with_ip, &None).ok_or_else(|| {
+        EdgeError::FrontendExpectedToBeHydrated(
+            "Feature cache has not been hydrated yet, but it was expected to be".into(),
+        )
+    })?;
     Ok(Json(frontend_from_yggdrasil(feature_results, true, &token)))
 }
 


### PR DESCRIPTION
This upgrades Yggdrasil to a version that's tolerant to all kinds of toggle compile failures. It also makes the frontend/proxy apis return errors rather than panic when resolving toggles that should exist but don't