### PR TITLE
fix: make metrics interval not climb forever

### DIFF
--- a/server/src/http/background_send_metrics.rs
+++ b/server/src/http/background_send_metrics.rs
@@ -43,6 +43,11 @@ lazy_static! {
         &["environment"]
     )
     .unwrap();
+    pub static ref METRICS_INTERVAL_BETWEEN_SEND: IntGauge = register_int_gauge!(Opts::new(
+        "metrics_interval_between_send",
+        "Interval between sending metrics"
+    ))
+    .unwrap();
 }
 
 fn decide_where_to_post(
@@ -115,17 +120,17 @@ pub async fn send_metrics_task(
                                     }
                                     StatusCode::NOT_FOUND => {
                                         failures = 10;
-                                        interval = new_interval(interval, failures, 5);
+                                        interval = new_interval(send_interval, failures);
                                         error!("Upstream said we are trying to post to an endpoint that doesn't exist. backing off to {} seconds", interval.num_seconds());
                                     }
                                     StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED => {
                                         failures = 10;
-                                        interval = new_interval(interval, failures, 5);
+                                        interval = new_interval(send_interval, failures);
                                         error!("Upstream said we were not allowed to post metrics, backing off to {} seconds", interval.num_seconds());
                                     }
                                     StatusCode::TOO_MANY_REQUESTS => {
                                         failures = max(10, failures + 1);
-                                        interval = new_interval(interval, failures, 5);
+                                        interval = new_interval(send_interval, failures);
                                         info!(
                                             "Upstream said it was too busy, backing off to {} seconds",
                                             interval.num_seconds()
@@ -137,7 +142,7 @@ pub async fn send_metrics_task(
                                     | StatusCode::SERVICE_UNAVAILABLE
                                     | StatusCode::GATEWAY_TIMEOUT => {
                                         failures = max(10, failures + 1);
-                                        interval = new_interval(interval, failures, 5);
+                                        interval = new_interval(send_interval, failures);
                                         info!("Upstream said it is struggling. It returned Http status {}. Backing off to {} seconds", status_code, interval.num_seconds());
                                         metrics_cache.reinsert_batch(batch);
                                     }
@@ -154,7 +159,7 @@ pub async fn send_metrics_task(
                         }
                     } else {
                         failures = max(0, failures - 1);
-                        interval = new_interval(interval, failures, 5);
+                        interval = new_interval(send_interval, failures);
                     }
                 }
             }
@@ -163,32 +168,26 @@ pub async fn send_metrics_task(
             "Done posting traces. Sleeping for {} seconds and then going again",
             interval.num_seconds()
         );
+        METRICS_INTERVAL_BETWEEN_SEND.set(interval.num_seconds());
         tokio::time::sleep(std::time::Duration::from_secs(interval.num_seconds() as u64)).await;
     }
 }
 
-fn new_interval(send_interval: Duration, failures: i32, max_jitter_seconds: u8) -> Duration {
+fn new_interval(send_interval: i64, failures: i64) -> Duration {
     let added_interval_from_failure = send_interval * failures;
-    let jitter = random_jitter_seconds(max_jitter_seconds);
-    send_interval + added_interval_from_failure + jitter
-}
-
-fn random_jitter_seconds(max_jitter_seconds: u8) -> Duration {
-    let jitter = rand::thread_rng().gen_range(0..max_jitter_seconds);
-    Duration::seconds(jitter as i64)
+    Duration::seconds(send_interval + added_interval_from_failure)
 }
 
 #[cfg(test)]
 mod tests {
     use crate::http::background_send_metrics::new_interval;
     use crate::types::{EdgeToken, TokenRefresh};
-    use chrono::Duration;
     use dashmap::DashMap;
     use std::sync::Arc;
 
     #[tokio::test]
     pub async fn new_interval_does_not_overflow() {
-        let metrics = new_interval(Duration::seconds(300), 10, 5);
+        let metrics = new_interval(300, 10);
         assert!(metrics.num_seconds() < 3305);
     }
 

--- a/server/src/prom_metrics.rs
+++ b/server/src/prom_metrics.rs
@@ -110,6 +110,11 @@ fn register_custom_metrics(registry: &prometheus::Registry) {
         .unwrap();
     registry
         .register(Box::new(
+            background_send_metrics::METRICS_INTERVAL_BETWEEN_SEND.clone(),
+        ))
+        .unwrap();
+    registry
+        .register(Box::new(
             crate::http::unleash_client::CLIENT_FEATURE_FETCH_FAILURES.clone(),
         ))
         .unwrap();


### PR DESCRIPTION
Previously we used the previous iteration of the loop's interval to decide next interval. This PR changes to always use the initial send_interval as what to base the interval calculation of

fixes: #436 