### PR TITLE
fix: Removed /edge/metrics and logic for posting to /edge/metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,25 +12,33 @@
 
 Unleash Edge is the successor to the [Unleash Proxy](https://docs.getunleash.io/how-to/how-to-run-the-unleash-proxy).
 
-Unleash Edge sits between the Unleash API and your SDKs and provides a cached read-replica of your Unleash instance. This means you can scale up your Unleash instance to thousands of connected SDKs without increasing the number of requests you make to your Unleash instance.
+Unleash Edge sits between the Unleash API and your SDKs and provides a cached read-replica of your Unleash instance.
+This means you can scale up your Unleash instance to thousands of connected SDKs without increasing the number of
+requests you make to your Unleash instance.
 
 Unleash Edge offers two important features:
 
-- **Performance**: Unleash Edge caches in memory and can run close to your end-users. A single instance can handle tens to hundreds of thousands of requests per second.
-- **Resilience**: Unleash Edge is designed to survive restarts and operate properly even if you lose connection to your Unleash server.
+- **Performance**: Unleash Edge caches in memory and can run close to your end-users. A single instance can handle tens
+  to hundreds of thousands of requests per second.
+- **Resilience**: Unleash Edge is designed to survive restarts and operate properly even if you lose connection to your
+  Unleash server.
 
 Unleash Edge is built to help you scale Unleash.
- * If you're looking for the easiest way to connect your client SDKs you can check out our [Frontend API](https://docs.getunleash.io/reference/front-end-api).
- * If you're looking to learn how to scale your own feature flag system why not check out our recommendations for building and scaling [feature flags](https://docs.getunleash.io/topics/feature-flags/feature-flag-best-practices)
 
+* If you're looking for the easiest way to connect your client SDKs you can check out
+  our [Frontend API](https://docs.getunleash.io/reference/front-end-api).
+* If you're looking to learn how to scale your own feature flag system why not check out our recommendations for
+  building and scaling [feature flags](https://docs.getunleash.io/topics/feature-flags/feature-flag-best-practices)
 
 ## Migrating to Edge from the Proxy
 
-For more info on migrating, check out the [migration guide](./migration-guide.md) that details the differences between Edge and the Proxy and how to achieve similar behavior in Edge.
+For more info on migrating, check out the [migration guide](./migration-guide.md) that details the differences between
+Edge and the Proxy and how to achieve similar behavior in Edge.
 
 ## Running Unleash Edge
 
-Unleash Edge is compiled to a single binary. You can configure it by passing in arguments or setting environment variables.
+Unleash Edge is compiled to a single binary. You can configure it by passing in arguments or setting environment
+variables.
 
 ```shell
 Usage: unleash-edge [OPTIONS] <COMMAND>
@@ -73,21 +81,33 @@ Options:
 ```
 
 ### Built-in Health check
-There is now (from 5.1.0) a subcommand named `health` which will ping your health endpoint and exit with status 0 provided the health endpoint returns 200 OK.
+
+There is now (from 5.1.0) a subcommand named `health` which will ping your health endpoint and exit with status 0
+provided the health endpoint returns 200 OK.
 
 Example:
+
 ```shell
 ./unleash-edge health
 ```
-will check an Edge process running on http://localhost:3063. If you're using base-path or the port variable you should use the `-e --edge-url` CLI arg (or the EDGE_URL environment variable) to tell the health checker where edge is running.
 
-If you're hosting Edge with a self-signed certificate using the tls cli arguments, you should use the `--ca-certificate-file <file_containing_your_ca_and_key_in_pem_format>` flag (or the CA_CERTIFICATE_FILE environment variable) to allow the health checker to trust the self signed certificate.
+will check an Edge process running on http://localhost:3063. If you're using base-path or the port variable you should
+use the `-e --edge-url` CLI arg (or the EDGE_URL environment variable) to tell the health checker where edge is running.
+
+If you're hosting Edge with a self-signed certificate using the tls cli arguments, you should use
+the `--ca-certificate-file <file_containing_your_ca_and_key_in_pem_format>` flag (or the CA_CERTIFICATE_FILE environment
+variable) to allow the health checker to trust the self signed certificate.
 
 ### Built-in Ready check
-There is now (from 12.0.0) a subcommand named `ready` which will ping your ready endpoint and exit with status 0 provided the ready endpoint returns 200 OK and `{ status: "READY" }`. Otherwise it will return status 1 and an error message to signal that Edge is not ready (it has not spoken to upstream or recovered from a persisted backup).
+
+There is now (from 12.0.0) a subcommand named `ready` which will ping your ready endpoint and exit with status 0
+provided the ready endpoint returns 200 OK and `{ status: "READY" }`. Otherwise it will return status 1 and an error
+message to signal that Edge is not ready (it has not spoken to upstream or recovered from a persisted backup).
 
 Examples:
+
 * Edge not running:
+
 ```shell
 $ ./unleash-edge ready
 Error: Failed to connect to ready endpoint at http://localhost:3063/internal-backstage/ready. Failed with status None
@@ -96,13 +116,16 @@ $ echo $?
 ```
 
 * Edge running but not populated its feature cache yet (not spoken to upstream or restored from backup)
+
 ```shell
 $ ./unleash-edge ready
 Error: Ready check returned a different status than READY. It returned EdgeStatus { status: NotReady }
 $ echo $?
 1
 ```
+
 * Edge running and synchronized. I.e. READY
+
 ```shell
 $ ./unleash-edge ready
 OK
@@ -110,8 +133,9 @@ $ echo $?
 0
 ```
 
-If you're hosting Edge with a self-signed certificate using the tls cli arguments, you should use the `--ca-certificate-file <file_containing_your_ca_and_key_in_pem_format>` flag (or the CA_CERTIFICATE_FILE environment variable) to allow the health checker to trust the self signed certificate.
-
+If you're hosting Edge with a self-signed certificate using the tls cli arguments, you should use
+the `--ca-certificate-file <file_containing_your_ca_and_key_in_pem_format>` flag (or the CA_CERTIFICATE_FILE environment
+variable) to allow the health checker to trust the self signed certificate.
 
 ## Getting Unleash Edge
 
@@ -128,15 +152,18 @@ Unleash Edge is distributed as a binary and as a docker image.
 - For dockerhub use the coordinates `unleashorg/unleash-edge:<version>`.
 - For Github package registry use the coordinates `ghpr.io/unleash/unleash-edge:<version>`
 - If you'd like to live on the edge (sic) you can use the tag `edge`. This is built from `HEAD` on each commit
-- When running the docker image, the same CLI arguments that's available when running the binary is available to your `docker run` command. To start successfully you will need to decide which mode you're running in.
-  - If running in `edge` mode your command should be
-    - `docker run -p 3063:3063 -e UPSTREAM_URL=<YOUR_UNLEASH_INSTANCE> unleashorg/unleash-edge:<version> edge`
-  - If running in `offline` mode you will need to provide a volume containing your feature toggles file. An example is available inside the examples folder. To use this, you can use the command
-    - `docker run -v ./examples:/edge/data -p 3063:3063 -e BOOTSTRAP_FILE=/edge/data/features.json -e TOKENS='my-secret-123,another-secret-789' unleashorg/unleash-edge:<version> offline`
+- When running the docker image, the same CLI arguments that's available when running the binary is available to
+  your `docker run` command. To start successfully you will need to decide which mode you're running in.
+    - If running in `edge` mode your command should be
+        - `docker run -p 3063:3063 -e UPSTREAM_URL=<YOUR_UNLEASH_INSTANCE> unleashorg/unleash-edge:<version> edge`
+    - If running in `offline` mode you will need to provide a volume containing your feature toggles file. An example is
+      available inside the examples folder. To use this, you can use the command
+        - `docker run -v ./examples:/edge/data -p 3063:3063 -e BOOTSTRAP_FILE=/edge/data/features.json -e TOKENS='my-secret-123,another-secret-789' unleashorg/unleash-edge:<version> offline`
 
 ### Cargo/Rust
 
-If you have the [Rust toolchain](https://rustup.rs) installed you can build a binary for the platform you're running by cloning this repo and running `cargo build --release`. This will give you an `unleash-edge` binary in `./target/release`
+If you have the [Rust toolchain](https://rustup.rs) installed you can build a binary for the platform you're running by
+cloning this repo and running `cargo build --release`. This will give you an `unleash-edge` binary in `./target/release`
 
 ## Concepts
 
@@ -144,7 +171,8 @@ If you have the [Rust toolchain](https://rustup.rs) installed you can build a bi
 
 Edge currently supports 2 different modes:
 
-- [Edge](#edge) - Connection to upstream node (Unleash instance or another Edge). Supports dynamic tokens, metrics and other advanced features;
+- [Edge](#edge) - Connection to upstream node (Unleash instance or another Edge). Supports dynamic tokens, metrics and
+  other advanced features;
 - [Offline](#offline) - No connection to upstream node. Full control of data and tokens;
 
 #### Edge
@@ -155,9 +183,14 @@ graph LR
   B-->|Fetch toggles| C((Unleash))
 ```
 
-Edge mode is the "standard" mode for Unleash Edge and the one you should default to in most cases. It connects to an upstream node, such as your Unleash instance, and uses that as the source of truth for feature toggles.
+Edge mode is the "standard" mode for Unleash Edge and the one you should default to in most cases. It connects to an
+upstream node, such as your Unleash instance, and uses that as the source of truth for feature toggles.
 
-Other than connecting Edge directly to your Unleash instance, it's also possible to connect to another Edge instance (_daisy chaining_). You can have as many Edge nodes as you'd like between the Edge node your clients are accessing and the Unleash server, and it's also possible for multiple nodes to connect to a single upstream one. Depending on your architecture and requirements this can be a powerful feature, offering you flexibility and scalability when planning your implementation.
+Other than connecting Edge directly to your Unleash instance, it's also possible to connect to another Edge instance (
+_daisy chaining_). You can have as many Edge nodes as you'd like between the Edge node your clients are accessing and
+the Unleash server, and it's also possible for multiple nodes to connect to a single upstream one. Depending on your
+architecture and requirements this can be a powerful feature, offering you flexibility and scalability when planning
+your implementation.
 
 ```mermaid
 graph LR
@@ -168,24 +201,46 @@ graph LR
   E-->|Fetch toggles| F((Unleash))
 ```
 
-This means that, in order to start up, Edge mode needs to know where the upstream node is. This is done by passing the `--upstream-url` command line argument or setting the `UPSTREAM_URL` environment variable.
+This means that, in order to start up, Edge mode needs to know where the upstream node is. This is done by passing
+the `--upstream-url` command line argument or setting the `UPSTREAM_URL` environment variable.
 
-By default, Edge mode uses an in-memory cache to store the features it fetches from the upstream node. However, you may want to use a more persistent storage solution. For this purpose, Edge supports either Redis or a backup file, which you can configure by passing in either the `--redis-url` or `--backup_folder` command line argument, respectively. On start-up, Edge checks whether the persistent backup option is specified, in which case it uses it to populate its internal caches. This can be useful when your Unleash server is unreachable.
+By default, Edge mode uses an in-memory cache to store the features it fetches from the upstream node. However, you may
+want to use a more persistent storage solution. For this purpose, Edge supports either Redis or a backup file, which you
+can configure by passing in either the `--redis-url` or `--backup_folder` command line argument, respectively. On
+start-up, Edge checks whether the persistent backup option is specified, in which case it uses it to populate its
+internal caches. This can be useful when your Unleash server is unreachable.
 
-Persistent storage is useful for high availability and resilience. If an Edge instance using persistent storage is restarted, it will not have to synchronize with upstream before it is ready. The persistent storage is only read on startup and will only be used until Edge is able to synchronize with upstream. Because of this, there is no need to purge the cache. After Edge has synchronized with an upstream, it will periodically save its in-memory state to the persistent storage.
+Persistent storage is useful for high availability and resilience. If an Edge instance using persistent storage is
+restarted, it will not have to synchronize with upstream before it is ready. The persistent storage is only read on
+startup and will only be used until Edge is able to synchronize with upstream. Because of this, there is no need to
+purge the cache. After Edge has synchronized with an upstream, it will periodically save its in-memory state to the
+persistent storage.
 
-Multiple Edge nodes can share the same Redis instance or backup folder. Failure to read from persistent storage will not prevent Edge from starting up. In this case an Edge instance will be ready only after it is able to connect with upstream.
+Multiple Edge nodes can share the same Redis instance or backup folder. Failure to read from persistent storage will not
+prevent Edge from starting up. In this case an Edge instance will be ready only after it is able to connect with
+upstream.
 
-Edge mode also supports dynamic tokens, meaning that Edge doesn't need a token to be provided when starting up. Once we make a request to the `/api/client/features` endpoint using a [client token](https://docs.getunleash.io/reference/api-tokens-and-client-keys#client-tokens) Edge will validate upstream and fetch its respective features. After that, it gets added to the list of known tokens that gets periodically synced, making sure it is a valid token and its features are up-to-date.
+Edge mode also supports dynamic tokens, meaning that Edge doesn't need a token to be provided when starting up. Once we
+make a request to the `/api/client/features` endpoint using
+a [client token](https://docs.getunleash.io/reference/api-tokens-and-client-keys#client-tokens) Edge will validate
+upstream and fetch its respective features. After that, it gets added to the list of known tokens that gets periodically
+synced, making sure it is a valid token and its features are up-to-date.
 
-Even though Edge supports dynamic tokens, you still have the option of providing a token through the command line argument or environment variable. This way, since Edge already knows about your token at start up, it will sync your features for that token and should be ready for your requests right away (_warm up / hot start_).
+Even though Edge supports dynamic tokens, you still have the option of providing a token through the command line
+argument or environment variable. This way, since Edge already knows about your token at start up, it will sync your
+features for that token and should be ready for your requests right away (_warm up / hot start_).
 
 ### Front-end tokens
-[Front-end tokens](https://docs.getunleash.io/reference/api-tokens-and-client-keys#front-end-tokens) can also be used with `/api/frontend` and `/api/proxy` endpoints, however they are not allowed to fetch features upstream.
-In order to use these tokens correctly and make sure they return the correct information, it's important that the features they are allowed to access are already present in that Edge node's features cache.
+
+[Front-end tokens](https://docs.getunleash.io/reference/api-tokens-and-client-keys#front-end-tokens) can also be used
+with `/api/frontend` and `/api/proxy` endpoints, however they are not allowed to fetch features upstream.
+In order to use these tokens correctly and make sure they return the correct information, it's important that the
+features they are allowed to access are already present in that Edge node's features cache.
 The easiest way to ensure this is by passing in at least one client token as one of the command line arguments,
 ensuring it has access to the same features as the front-end token you'll be using.
-If you're using a frontend token that doesn't have data in the node's feature cache, you will receive an HTTP Status code: 511 Network Authentication Required along with a body of which project and environment you will need to add a client token for.
+If you're using a frontend token that doesn't have data in the node's feature cache, you will receive an HTTP Status
+code: 511 Network Authentication Required along with a body of which project and environment you will need to add a
+client token for.
 
 ### Starting in edge mode
 
@@ -240,9 +295,14 @@ graph LR
   B-->|Fetch toggles| C[Features dump]
 ```
 
-Offline mode is useful when there is no connection to an upstream node, such as your Unleash instance or another Edge instance, or as a tool to make working with Unleash easier during development.
+Offline mode is useful when there is no connection to an upstream node, such as your Unleash instance or another Edge
+instance, or as a tool to make working with Unleash easier during development.
 
-To use offline mode, you'll need a features file. The easiest way to get one is to download a JSON dump of a result from a query against an Unleash server on the [/api/client/features](https://docs.getunleash.io/reference/api/unleash/get-client-feature) endpoint. You can also use a hand rolled, human readable JSON version of the features file. Edge will automatically convert it to the API format when it starts up. Here's an example:
+To use offline mode, you'll need a features file. The easiest way to get one is to download a JSON dump of a result from
+a query against an Unleash server on
+the [/api/client/features](https://docs.getunleash.io/reference/api/unleash/get-client-feature) endpoint. You can also
+use a hand rolled, human readable JSON version of the features file. Edge will automatically convert it to the API
+format when it starts up. Here's an example:
 
 ``` json
 {
@@ -260,11 +320,18 @@ To use offline mode, you'll need a features file. The easiest way to get one is 
 }
 ```
 
-The simplified JSON format should be an object with a key for each feature. You can force the result of `is_enabled` in your SDK by setting the enabled property, likewise can also force the result of `get_variant` by specifying the name of the variant you want. This format is primarily for development.
+The simplified JSON format should be an object with a key for each feature. You can force the result of `is_enabled` in
+your SDK by setting the enabled property, likewise can also force the result of `get_variant` by specifying the name of
+the variant you want. This format is primarily for development.
 
-When using offline mode you must specify one or more tokens at startup. These tokens will let your SDKs access Edge. Tokens following the Unleash API format `[project]:[environment].<somesecret>` allow Edge to recognize the project and environment specified in the token, returning only the relevant features to the calling SDK. On the other hand, for tokens not adhering to this format, Edge will return all features if there is an exact match with any of the startup tokens.
+When using offline mode you must specify one or more tokens at startup. These tokens will let your SDKs access Edge.
+Tokens following the Unleash API format `[project]:[environment].<somesecret>` allow Edge to recognize the project and
+environment specified in the token, returning only the relevant features to the calling SDK. On the other hand, for
+tokens not adhering to this format, Edge will return all features if there is an exact match with any of the startup
+tokens.
 
-To make local development easier, you can specify a reload interval in seconds (Since Unleash-Edge 10.0.x); this will cause Edge to reload the features file from disk every X seconds. This can be useful for local development.
+To make local development easier, you can specify a reload interval in seconds (Since Unleash-Edge 10.0.x); this will
+cause Edge to reload the features file from disk every X seconds. This can be useful for local development.
 
 Since offline mode does not connect to an upstream node, it does not support metrics or dynamic tokens.
 
@@ -282,26 +349,38 @@ Options:
 ```
 
 ##### Environments in offline mode
-Currently, Edge does not support multiple environments in offline mode. All tokens added at startup will receive the same list of features passed in as the bootstrap argument.
+
+Currently, Edge does not support multiple environments in offline mode. All tokens added at startup will receive the
+same list of features passed in as the bootstrap argument.
 However, tokens in `<project>:<environment>.<secret>` format will still filter by project.
 
 ## [Metrics](https://docs.getunleash.io/reference/api/unleash/metrics)
 
-**❗ Note:** For Unleash to correctly register SDK usage metrics sent from Edge instances, your Unleash instance must be v4.22 or newer.
+**❗ Note:** For Edge to correctly register SDK usage metrics, your Unleash instance must be v5.9.0.
+**! Note:** If you're daisy chaining you will need at least Edge 17.0.0 upstream of any Edge 19.0.0 to preserve metrics.
 
-Since Edge is designed to avoid overloading its upstream, Edge gathers and accumulates usage metrics from SDKs for a set interval (METRICS_INTERVAL_SECONDS) before posting a batch upstream.
-This reduces load on Unleash instances down to a single call every interval, instead of every single client posting to Unleash for updating metrics.
-Unleash instances running on versions older than 4.22 are not able to handle the batch format posted by Edge, which means you won't see any metrics from clients connected to an Edge instance until you're able to update to 4.22 or newer.
+Since Edge is designed to avoid overloading its upstream, Edge gathers and accumulates usage metrics from SDKs for a set
+interval (METRICS_INTERVAL_SECONDS) before posting a batch upstream.
+This reduces load on Unleash instances down to a single call every interval, instead of every single client posting to
+Unleash for updating metrics.
+Unleash instances running on versions older than 4.22 are not able to handle the batch format posted by Edge, which
+means you won't see any metrics from clients connected to an Edge instance until you're able to update to 4.22 or newer.
 
 ## Compatibility
 
-Unleash Edge adheres to Semantic Versioning (SemVer) on the API and CLI layers. If you're using Unleash Edge as a library in your projects, be cautious, internal codebase changes, which might occur in any version release (including minor and patch versions), could potentially break your implementation.
+Unleash Edge adheres to Semantic Versioning (SemVer) on the API and CLI layers. If you're using Unleash Edge as a
+library in your projects, be cautious, internal codebase changes, which might occur in any version release (including
+minor and patch versions), could potentially break your implementation.
 
 ## Performance
 
-Unleash Edge will scale linearly with CPU. There are k6 benchmarks in the benchmark folder. We've already got some initial numbers from [hey](https://github.com/rakyll/hey).
+Unleash Edge will scale linearly with CPU. There are k6 benchmarks in the benchmark folder. We've already got some
+initial numbers from [hey](https://github.com/rakyll/hey).
 
-Do note that the number of requests Edge can handle does depend on the total size of your toggle response. That is, Edge is faster if you only have 10 toggles with 1 strategy each, than it will be with 1000 toggles with multiple strategies on each. Benchmarks here were run with data fetched from the Unleash demo instance (roughly 100kB (350 features / 200 strategies)) as well as against a small dataset of 5 features with one strategy on each.
+Do note that the number of requests Edge can handle does depend on the total size of your toggle response. That is, Edge
+is faster if you only have 10 toggles with 1 strategy each, than it will be with 1000 toggles with multiple strategies
+on each. Benchmarks here were run with data fetched from the Unleash demo instance (roughly 100kB (350 features / 200
+strategies)) as well as against a small dataset of 5 features with one strategy on each.
 
 Edge was started using
 `docker run --cpus="<cpu>" --memory=128M -p 3063:3063 -e UPSTREAM_URL=<upstream> -e TOKENS="<client token>" unleashorg/unleash-edge:edge -w <number of cpus rounded up to closest integer> edge`
@@ -315,7 +394,7 @@ $ hey -z 10s -H "Authorization: <frontend token>" http://localhost:3063/api/fron
 ```
 
 | CPU | Memory | RPS   | Endpoint      | p95   | Data transferred |
-| --- | ------ | ----- | ------------- | ----- | ---------------- |
+|-----|--------|-------|---------------|-------|------------------|
 | 0.1 | 6.7 Mi | 600   | /api/frontend | 103ms | 76Mi             |
 | 1   | 6.7 Mi | 6900  | /api/frontend | 7.4ms | 866Mi            |
 | 4   | 9.5    | 25300 | /api/frontend | 2.4ms | 3.2Gi            |
@@ -328,7 +407,7 @@ $ hey -z 10s -H "Authorization: <client token>" http://localhost:3063/api/client
 ```
 
 | CPU | Memory observed | RPS   | Endpoint             | p95   | Data transferred |
-| --- | --------------- | ----- | -------------------- | ----- | ---------------- |
+|-----|-----------------|-------|----------------------|-------|------------------|
 | 0.1 | 11 Mi           | 309   | /api/client/features | 199ms | 300 Mi           |
 | 1   | 11 Mi           | 3236  | /api/client/features | 16ms  | 3 Gi             |
 | 4   | 11 Mi           | 12815 | /api/client/features | 4.5ms | 14 Gi            |
@@ -341,7 +420,7 @@ $ hey -z 10s -H "Authorization: <frontend token>" http://localhost:3063/api/fron
 ```
 
 | CPU | Memory  | RPS    | Endpoint      | p95   | Data transferred |
-| --- | ------- | ------ | ------------- | ----- | ---------------- |
+|-----|---------|--------|---------------|-------|------------------|
 | 0.1 | 4.3 Mi  | 3673   | /api/frontend | 93ms  | 9Mi              |
 | 1   | 6.7 Mi  | 39000  | /api/frontend | 1.6ms | 80Mi             |
 | 4   | 6.9 Mi  | 100020 | /api/frontend | 600μs | 252Mi            |
@@ -354,7 +433,7 @@ $ hey -z 10s -H "Authorization: <client token>" http://localhost:3063/api/client
 ```
 
 | CPU | Memory observed | RPS    | Endpoint             | p95   | Data transferred |
-| --- | --------------- | ------ | -------------------- | ----- | ---------------- |
+|-----|-----------------|--------|----------------------|-------|------------------|
 | 0.1 | 4 Mi            | 3298   | /api/client/features | 92ms  | 64 Mi            |
 | 1   | 4 Mi            | 32360  | /api/client/features | 2ms   | 527Mi            |
 | 4   | 11 Mi           | 95838  | /api/client/features | 600μs | 2.13 Gi          |
@@ -362,18 +441,26 @@ $ hey -z 10s -H "Authorization: <client token>" http://localhost:3063/api/client
 
 ## Why choose Unleash Edge over the Unleash Proxy?
 
-Edge offers a superset of the same feature set as the Unleash Proxy and we've made sure it offers the same security and privacy features.
+Edge offers a superset of the same feature set as the Unleash Proxy and we've made sure it offers the same security and
+privacy features.
 
 However, there are a few notable differences between the Unleash Proxy and Unleash Edge:
 
-- Unleash Edge is built to be light and fast, it handles an order of magnitude more requests per second than the Unleash Proxy can, while using two orders of magnitude less memory.
-- All your Unleash environments can be handled by a single instance, no more running multiple instances of the Unleash Proxy to handle both your development and production environments.
+- Unleash Edge is built to be light and fast, it handles an order of magnitude more requests per second than the Unleash
+  Proxy can, while using two orders of magnitude less memory.
+- All your Unleash environments can be handled by a single instance, no more running multiple instances of the Unleash
+  Proxy to handle both your development and production environments.
 - Backend SDKs can connect to Unleash Edge without turning on experimental feature flags.
-- Unleash Edge is smart enough to dynamically resolve the tokens you use to connect to it against the upstream Unleash instance. This means you don't have to worry about knowing in advance what tokens your SDKs use - if you want to swap out the Unleash token your SDK uses, this can be done without ever restarting or worrying about Unleash Edge. Unleash Edge will only collect and cache data for the environments and projects you use.
+- Unleash Edge is smart enough to dynamically resolve the tokens you use to connect to it against the upstream Unleash
+  instance. This means you don't have to worry about knowing in advance what tokens your SDKs use - if you want to swap
+  out the Unleash token your SDK uses, this can be done without ever restarting or worrying about Unleash Edge. Unleash
+  Edge will only collect and cache data for the environments and projects you use.
 
 ## Debugging
 
-You can adjust the `RUST_LOG` environment variable to see more verbose log output. For example, in order to get logs originating directly from Edge but not its dependencies, you can raise the default log level from `error` to `warning` and set Edge to `debug`, like this:
+You can adjust the `RUST_LOG` environment variable to see more verbose log output. For example, in order to get logs
+originating directly from Edge but not its dependencies, you can raise the default log level from `error` to `warning`
+and set Edge to `debug`, like this:
 
 ```sh
 RUST_LOG="warn,unleash_edge=debug" ./unleash-edge #<command>

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -1,6 +1,6 @@
 use utoipa::{
-    openapi::security::{ApiKey, ApiKeyValue, SecurityScheme},
-    Modify, OpenApi,
+    Modify,
+    OpenApi, openapi::security::{ApiKey, ApiKeyValue, SecurityScheme},
 };
 
 #[derive(OpenApi)]
@@ -28,7 +28,6 @@ use utoipa::{
         crate::client_api::metrics,
         crate::client_api::get_feature,
         crate::edge_api::validate,
-        crate::edge_api::metrics
     ),
     components(schemas(
         unleash_types::frontend::FrontendResult,

--- a/server/src/persistence/file.rs
+++ b/server/src/persistence/file.rs
@@ -1,16 +1,17 @@
-use async_trait::async_trait;
+use std::{path::PathBuf, str::FromStr};
 use std::collections::HashMap;
 use std::path::Path;
-use std::{path::PathBuf, str::FromStr};
+
+use async_trait::async_trait;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 use unleash_types::client_features::ClientFeatures;
 
-use crate::types::EdgeToken;
 use crate::{
     error::EdgeError,
     types::{EdgeResult, TokenRefresh},
 };
+use crate::types::EdgeToken;
 
 use super::EdgePersistence;
 
@@ -194,8 +195,8 @@ mod tests {
     use chrono::Utc;
     use unleash_types::client_features::{ClientFeature, ClientFeatures};
 
-    use crate::persistence::file::FilePersister;
     use crate::persistence::EdgePersistence;
+    use crate::persistence::file::FilePersister;
     use crate::types::{EdgeToken, TokenRefresh, TokenType, TokenValidationStatus};
 
     #[tokio::test]
@@ -254,7 +255,6 @@ mod tests {
                 last_refreshed: Some(Utc::now()),
                 last_check: Some(Utc::now()),
                 failure_count: 0,
-                use_client_bulk_endpoint: false,
             },
             TokenRefresh {
                 token: EdgeToken {
@@ -266,7 +266,6 @@ mod tests {
                 last_refreshed: None,
                 last_check: None,
                 failure_count: 0,
-                use_client_bulk_endpoint: false,
             },
         ];
 
@@ -302,29 +301,5 @@ mod tests {
         let reloaded = persister.load_tokens().await.unwrap();
 
         assert_eq!(reloaded, tokens);
-    }
-
-    #[test]
-    fn can_read_token_refresh_without_use_client_bulk_field() {
-        let json = r#"{
-            "token": {
-                "token": "default:development:ajsdkajnsdlsan",
-                "token_type": "client",
-                "environment": "development",
-                "projects": [
-                    "default"
-                ],
-                "status": "Validated"
-            },
-            "etag": "W/\"1234\"",
-            "next_refresh": null,
-            "last_refreshed": "2021-03-09T13:00:00Z",
-            "last_check": "2021-03-09T13:00:00Z",
-            "failure_count": 0
-        }"#;
-
-        let token_refresh: TokenRefresh = serde_json::from_str(json).unwrap();
-
-        assert!(!token_refresh.use_client_bulk_endpoint);
     }
 }

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -1,13 +1,13 @@
-use std::cmp::min;
-use std::fmt;
-use std::fmt::{Debug, Display, Formatter};
-use std::net::IpAddr;
-use std::sync::Arc;
 use std::{
     collections::HashMap,
     hash::{Hash, Hasher},
     str::FromStr,
 };
+use std::cmp::min;
+use std::fmt;
+use std::fmt::{Debug, Display, Formatter};
+use std::net::IpAddr;
+use std::sync::Arc;
 
 use actix_web::{http::header::EntityTag, web::Json};
 use async_trait::async_trait;
@@ -15,7 +15,6 @@ use chrono::{DateTime, Duration, Utc};
 use dashmap::DashMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use shadow_rs::shadow;
-use tracing::trace;
 use unleash_types::client_features::ClientFeatures;
 use unleash_types::client_features::Context;
 use unleash_types::client_metrics::{ClientApplication, ClientMetricsEnv};
@@ -250,8 +249,6 @@ pub struct TokenRefresh {
     pub last_refreshed: Option<DateTime<Utc>>,
     pub last_check: Option<DateTime<Utc>>,
     pub failure_count: u32,
-    #[serde(default)]
-    pub use_client_bulk_endpoint: bool,
 }
 
 #[derive(Clone, Deserialize, Serialize, Debug)]
@@ -274,27 +271,6 @@ impl TokenRefresh {
         Self {
             token,
             etag,
-            last_refreshed: None,
-            last_check: None,
-            next_refresh: None,
-            failure_count: 0,
-            use_client_bulk_endpoint: false,
-        }
-    }
-
-    pub fn new_with_client_bulk_endpoint(
-        token: EdgeToken,
-        etag: Option<EntityTag>,
-        use_client_bulk_endpoint: bool,
-    ) -> Self {
-        trace!(
-            "Registering a token for refresh with use_client_bulk_endpoint: {}",
-            use_client_bulk_endpoint
-        );
-        Self {
-            token,
-            etag,
-            use_client_bulk_endpoint,
             last_refreshed: None,
             last_check: None,
             next_refresh: None,
@@ -511,11 +487,11 @@ mod tests {
 
     use test_case::test_case;
     use tracing::warn;
+    use unleash_types::client_features::Context;
 
     use crate::error::EdgeError::EdgeTokenParseError;
     use crate::http::unleash_client::EdgeTokens;
     use crate::types::{EdgeResult, EdgeToken, IncomingContext};
-    use unleash_types::client_features::Context;
 
     fn test_str(token: &str) -> EdgeToken {
         EdgeToken::from_str(


### PR DESCRIPTION
We no longer want /edge/metrics to be available, since we have released 17.0.0, 17.1.0, 18.0.0 and 18.0.1 with compatibility for both `/edge/metrics` and `/api/client/metrics/bulk` this PR now strips the old endpoint in preparation for releasing 19.0.0. After this is released, you will need at least Unleash 5.9.0 to get metrics from Edge.