### PR TITLE
fix: Only replace projects covered by token

### DIFF
--- a/server/src/auth/token_validator.rs
+++ b/server/src/auth/token_validator.rs
@@ -172,7 +172,7 @@ mod tests {
     use actix_http::HttpService;
     use actix_http_test::{test_server, TestServer};
     use actix_service::map_config;
-    use actix_web::{App, dev::AppConfig, HttpResponse, web};
+    use actix_web::{dev::AppConfig, web, App, HttpResponse};
     use dashmap::DashMap;
     use serde::{Deserialize, Serialize};
 

--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -46,10 +46,7 @@ fn build_caches() -> CacheContainer {
     )
 }
 
-async fn hydrate_from_persistent_storage(
-    cache: CacheContainer,
-    storage: Arc<dyn EdgePersistence>,
-) {
+async fn hydrate_from_persistent_storage(cache: CacheContainer, storage: Arc<dyn EdgePersistence>) {
     let (token_cache, features_cache, engine_cache) = cache;
     let tokens = storage.load_tokens().await.unwrap_or_else(|error| {
         warn!("Failed to load tokens from cache {error:?}");

--- a/server/src/edge_api.rs
+++ b/server/src/edge_api.rs
@@ -1,7 +1,7 @@
 use actix_web::{
-    HttpRequest,
     post,
     web::{self, Data, Json},
+    HttpRequest,
 };
 use dashmap::DashMap;
 use utoipa;
@@ -58,9 +58,9 @@ pub fn configure_edge_api(cfg: &mut web::ServiceConfig) {
 mod tests {
     use std::sync::Arc;
 
-    use actix_web::{App, test, web};
     use actix_web::http::header::ContentType;
     use actix_web::web::Json;
+    use actix_web::{test, web, App};
     use dashmap::DashMap;
 
     use crate::auth::token_validator::TokenValidator;

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -115,7 +115,6 @@ pub enum EdgeError {
     TokenParseError(String),
     ContextParseError,
     TokenValidationError(StatusCode),
-    InvalidEdgeMode,
 }
 
 impl Error for EdgeError {}
@@ -205,9 +204,6 @@ impl Display for EdgeError {
             EdgeError::NotReady => {
                 write!(f, "Edge is not ready to serve requests")
             }
-            EdgeError::InvalidEdgeMode => {
-                write!(f, "Invalid edge mode")
-            }
         }
     }
 }
@@ -244,7 +240,6 @@ impl ResponseError for EdgeError {
             EdgeError::ClientCacheError => StatusCode::INTERNAL_SERVER_ERROR,
             EdgeError::FrontendExpectedToBeHydrated(_) => StatusCode::INTERNAL_SERVER_ERROR,
             EdgeError::NotReady => StatusCode::SERVICE_UNAVAILABLE,
-            EdgeError::InvalidEdgeMode => StatusCode::BAD_REQUEST,
         }
     }
 

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -115,6 +115,7 @@ pub enum EdgeError {
     TokenParseError(String),
     ContextParseError,
     TokenValidationError(StatusCode),
+    InvalidEdgeMode,
 }
 
 impl Error for EdgeError {}
@@ -204,6 +205,9 @@ impl Display for EdgeError {
             EdgeError::NotReady => {
                 write!(f, "Edge is not ready to serve requests")
             }
+            EdgeError::InvalidEdgeMode => {
+                write!(f, "Invalid edge mode")
+            }
         }
     }
 }
@@ -240,6 +244,7 @@ impl ResponseError for EdgeError {
             EdgeError::ClientCacheError => StatusCode::INTERNAL_SERVER_ERROR,
             EdgeError::FrontendExpectedToBeHydrated(_) => StatusCode::INTERNAL_SERVER_ERROR,
             EdgeError::NotReady => StatusCode::SERVICE_UNAVAILABLE,
+            EdgeError::InvalidEdgeMode => StatusCode::BAD_REQUEST,
         }
     }
 

--- a/server/src/http/background_send_metrics.rs
+++ b/server/src/http/background_send_metrics.rs
@@ -5,14 +5,14 @@ use actix_web::http::StatusCode;
 use chrono::Duration;
 use dashmap::DashMap;
 use lazy_static::lazy_static;
-use prometheus::{IntGauge, IntGaugeVec, Opts, register_int_gauge, register_int_gauge_vec};
+use prometheus::{register_int_gauge, register_int_gauge_vec, IntGauge, IntGaugeVec, Opts};
 use tracing::{error, info, trace, warn};
 
+use crate::types::TokenRefresh;
 use crate::{
     error::EdgeError,
-    metrics::client_metrics::{MetricsCache, size_of_batch},
+    metrics::client_metrics::{size_of_batch, MetricsCache},
 };
-use crate::types::TokenRefresh;
 
 use super::feature_refresher::FeatureRefresher;
 

--- a/server/src/http/unleash_client.rs
+++ b/server/src/http/unleash_client.rs
@@ -7,25 +7,25 @@ use actix_web::http::header::EntityTag;
 use chrono::Duration;
 use chrono::Utc;
 use lazy_static::lazy_static;
-use prometheus::{HistogramVec, IntGaugeVec, Opts, register_histogram_vec, register_int_gauge_vec};
-use reqwest::{Client, header};
-use reqwest::{ClientBuilder, Identity, RequestBuilder, StatusCode, Url};
+use prometheus::{register_histogram_vec, register_int_gauge_vec, HistogramVec, IntGaugeVec, Opts};
 use reqwest::header::{HeaderMap, HeaderName};
+use reqwest::{header, Client};
+use reqwest::{ClientBuilder, Identity, RequestBuilder, StatusCode, Url};
 use serde::{Deserialize, Serialize};
 use tracing::{info, trace, warn};
 use unleash_types::client_features::ClientFeatures;
 use unleash_types::client_metrics::ClientApplication;
 
-use crate::{error::EdgeError, types::ClientFeaturesRequest};
 use crate::cli::ClientIdentity;
-use crate::error::{CertificateError, FeatureError};
 use crate::error::EdgeError::EdgeMetricsRequestError;
+use crate::error::{CertificateError, FeatureError};
 use crate::metrics::client_metrics::MetricsBatch;
 use crate::tls::build_upstream_certificate;
 use crate::types::{
     ClientFeaturesResponse, EdgeResult, EdgeToken, TokenValidationStatus, ValidateTokensRequest,
 };
 use crate::urls::UnleashUrls;
+use crate::{error::EdgeError, types::ClientFeaturesRequest};
 
 const UNLEASH_APPNAME_HEADER: &str = "UNLEASH-APPNAME";
 const UNLEASH_INSTANCE_ID_HEADER: &str = "UNLEASH-INSTANCEID";
@@ -497,13 +497,15 @@ mod tests {
     use actix_middleware_etag::Etag;
     use actix_service::map_config;
     use actix_web::{
-        App,
         dev::{AppConfig, ServiceRequest, ServiceResponse},
-        http::header::EntityTag, HttpResponse, web,
+        http::header::EntityTag,
+        web, App, HttpResponse,
     };
     use chrono::Duration;
     use unleash_types::client_features::{ClientFeature, ClientFeatures};
 
+    use crate::cli::ClientIdentity;
+    use crate::http::unleash_client::new_reqwest_client;
     use crate::{
         cli::TlsOptions,
         middleware::as_async_middleware::as_async_middleware,
@@ -513,8 +515,6 @@ mod tests {
             ValidateTokensRequest,
         },
     };
-    use crate::cli::ClientIdentity;
-    use crate::http::unleash_client::new_reqwest_client;
 
     use super::{EdgeTokens, UnleashClient};
 

--- a/server/src/internal_backstage.rs
+++ b/server/src/internal_backstage.rs
@@ -146,10 +146,10 @@ mod tests {
     use std::str::FromStr;
     use std::sync::Arc;
 
-    use actix_web::{App, web};
     use actix_web::body::MessageBody;
     use actix_web::http::header::ContentType;
     use actix_web::test;
+    use actix_web::{web, App};
     use chrono::Duration;
     use dashmap::DashMap;
     use unleash_types::client_features::{ClientFeature, ClientFeatures};

--- a/server/src/internal_backstage.rs
+++ b/server/src/internal_backstage.rs
@@ -68,6 +68,13 @@ pub async fn tokens(
     feature_refresher: web::Data<FeatureRefresher>,
     token_validator: web::Data<TokenValidator>,
 ) -> EdgeJsonResult<TokenInfo> {
+    Ok(Json(get_token_info(feature_refresher, token_validator)))
+}
+
+fn get_token_info(
+    feature_refresher: web::Data<FeatureRefresher>,
+    token_validator: web::Data<TokenValidator>,
+) -> TokenInfo {
     let refreshes: Vec<TokenRefresh> = feature_refresher
         .tokens_to_refresh
         .iter()
@@ -83,10 +90,10 @@ pub async fn tokens(
         .map(|e| e.value().clone())
         .map(|t| crate::tokens::anonymize_token(&t))
         .collect();
-    Ok(Json(TokenInfo {
+    TokenInfo {
         token_refreshes: refreshes,
         token_validation_status,
-    }))
+    }
 }
 
 #[get("/metricsbatch")]

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -1,6 +1,6 @@
 use utoipa::{
-    Modify,
-    OpenApi, openapi::security::{ApiKey, ApiKeyValue, SecurityScheme},
+    openapi::security::{ApiKey, ApiKeyValue, SecurityScheme},
+    Modify, OpenApi,
 };
 
 #[derive(OpenApi)]

--- a/server/src/ready_checker.rs
+++ b/server/src/ready_checker.rs
@@ -68,8 +68,8 @@ mod tests {
     use actix_http::HttpService;
     use actix_http_test::test_server;
     use actix_service::map_config;
-    use actix_web::{App, HttpResponse, web};
     use actix_web::dev::AppConfig;
+    use actix_web::{web, App, HttpResponse};
     use dashmap::DashMap;
     use unleash_types::client_features::{ClientFeature, ClientFeatures};
 

--- a/server/src/tokens.rs
+++ b/server/src/tokens.rs
@@ -335,6 +335,25 @@ mod tests {
     }
 
     #[test]
+    fn test_project_tokens() {
+        let df_projects: Vec<TokenRefresh> = vec![
+            test_token(Some("my secret"), Some("development"), vec!["df-web"]),
+            test_token(
+                Some("my other secret"),
+                Some("development"),
+                vec!["df-platform"],
+            ),
+        ]
+        .into_iter()
+        .map(|t| TokenRefresh::new(t, None))
+        .collect();
+        let actual: Vec<EdgeToken> = simplify(&df_projects)
+            .iter()
+            .map(|x| x.token.clone())
+            .collect();
+        assert_eq!(actual.len(), 2);
+    }
+    #[test]
     fn test_single_project_token_is_covered_by_wildcard() {
         let self_token = EdgeToken {
             projects: vec!["*".into()],

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -1,13 +1,13 @@
-use std::cmp::min;
-use std::fmt;
-use std::fmt::{Debug, Display, Formatter};
-use std::net::IpAddr;
-use std::sync::Arc;
 use std::{
     collections::HashMap,
     hash::{Hash, Hasher},
     str::FromStr,
 };
+use std::cmp::min;
+use std::fmt;
+use std::fmt::{Debug, Display, Formatter};
+use std::net::IpAddr;
+use std::sync::Arc;
 
 use actix_web::{http::header::EntityTag, web::Json};
 use async_trait::async_trait;
@@ -247,7 +247,7 @@ pub struct TokenRefresh {
     pub etag: Option<EntityTag>,
     pub next_refresh: Option<DateTime<Utc>>,
     pub last_refreshed: Option<DateTime<Utc>>,
-    pub last_feature_count: usize,
+    pub last_feature_count: Option<usize>,
     pub last_check: Option<DateTime<Utc>>,
     pub failure_count: u32,
 }
@@ -276,7 +276,7 @@ impl TokenRefresh {
             last_check: None,
             next_refresh: None,
             failure_count: 0,
-            last_feature_count: 0,
+            last_feature_count: None,
         }
     }
 
@@ -327,7 +327,7 @@ impl TokenRefresh {
             next_refresh: Some(next_refresh),
             last_refreshed: Some(now),
             last_check: Some(now),
-            last_feature_count: feature_count,
+            last_feature_count: Some(feature_count),
             etag,
             ..self.clone()
         }

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -478,14 +478,6 @@ pub struct TokenInfo {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct EdgeModeInfo {
-    pub upstream: String,
-}
-
-pub struct OfflineModeInfo {}
-
-#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct ClientMetric {
     pub key: MetricsKey,
     pub bucket: ClientMetricsEnv,


### PR DESCRIPTION
Previously, if the update was empty, we assumed we needed to replace all stored features. This is not the case. We only need to remove the projects that are connected to the token we're using for the merge.

In addition, debug output on `/internal-backstage/tokens` now includes how many features was received in the update

