### PR TITLE
docs: Make README a quickstart and move concept/benchmarking/deploying to separate files

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ minor and patch versions), could potentially break your implementation.
 
 ## Performance
 
-See [Benchmarking](./docs/benchmarking.md)
+See our page on [Edge benchmarking] [Benchmarking](./docs/benchmarking.md)
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ See more about available logging and log levels at https://docs.rs/env_logger/la
 
 - Old Edge version. In order to guarantee metrics on newer Unleash versions, you will need to be using Edge v17.0.0 or
   newer
-- Old SDK clients. We've seen some clients, particularly early Python (1.x branch) as well as earlier .NET SDKs (we
+- Old SDK clients. We've noticed that some clients, particularly early Python (1.x branch) as well as earlier .NET SDKs (we
   recommend you use 4.1.5 or newer) struggle to post metrics with the strict headers Edge requires.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ See more about available logging and log levels at https://docs.rs/env_logger/la
 
 #### Possible reasons
 
-- Old edge version. In order to guarantee metrics on newer Unleash versions, you will need to be using Edge v17.0.0 or
+- Old Edge version. In order to guarantee metrics on newer Unleash versions, you will need to be using Edge v17.0.0 or
   newer
 - Old SDK clients. We've seen some clients, particularly early Python (1.x branch) as well as earlier .NET SDKs (we
   recommend you use 4.1.5 or newer) struggle to post metrics with the strict headers Edge requires.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Edge and the Proxy and how to achieve similar behavior in Edge.
 
 ## Quickstart
 
-Running Edge in docker with recommended setup
+Running Edge in Docker with our recommended setup:
 
 ```shell
 docker run -it -p 3063:3063 -e STRICT=true -e UPSTREAM_URL=<yourunleashinstance> unleashorg/unleash-edge:<mostrecentversion> edge

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ Unleash Edge is distributed as a binary and as a docker image.
 If you have the [Rust toolchain](https://rustup.rs) installed you can build a binary for the platform you're running by
 cloning this repo and running `cargo build --release`. This will give you an `unleash-edge` binary in `./target/release`
 
-## Concepts (see [Concepts](./docs/concepts.md))
+## Concepts
+
+See our page on [Edge concepts](./docs/concepts.md)
 
 ## Metrics
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Running Edge in Docker with our recommended setup:
 docker run -it -p 3063:3063 -e STRICT=true -e UPSTREAM_URL=<yourunleashinstance> unleashorg/unleash-edge:<mostrecentversion> edge
 ```
 
-## Deploying Unleash Edge
+## Deploying
 
 See our page on [Deploying Edge](./docs/deploying.md)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![crates.io](https://img.shields.io/crates/v/unleash-edge?label=latest)](https://crates.io/crates/unleash-edge)
 [![Documentation](https://docs.rs/unleash-edge/badge.svg?version=latest)](https://docs.rs/unleash-edge/latest)
 ![MIT licensed](https://img.shields.io/crates/l/unleash-edge.svg)
-[![Dependency Status](https://deps.rs/crate/unleash-edge/19.1.3/status.svg)](https://deps.rs/crate/unleash-edge/19.1.3)
+[![Dependency Status](https://deps.rs/crate/unleash-edge/19.2.0/status.svg)](https://deps.rs/crate/unleash-edge/19.2.0)
 [![CI](https://github.com/Unleash/unleash-edge/actions/workflows/test-with-coverage.yaml/badge.svg)](https://github.com/Unleash/unleash-edge/actions/workflows/test-with-coverage.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/Unleash/unleash-edge/badge.svg?branch=main)](https://coveralls.io/github/Unleash/unleash-edge?branch=main)
 ![downloads](https://img.shields.io/crates/d/unleash-edge.svg)
@@ -35,113 +35,17 @@ Unleash Edge is built to help you scale Unleash.
 For more info on migrating, check out the [migration guide](./migration-guide.md) that details the differences between
 Edge and the Proxy and how to achieve similar behavior in Edge.
 
-## Running Unleash Edge
+## Quickstart
 
-Edge provides a range of powerful ways in which you can run it. For a standard production configuration we recommend the following:
-
-- [Run in Edge mode](#edge): Edge mode connects to your upstream Unleash and syncs feature flags and tokens. This should be the default mode that you choose for most Edge configurations in production.
-- Start Edge with initialization tokens: Edge mode allows you to specify a set of tokens on startup that Edge will use to hydrate data ahead of time. This means that Edge will have the data it requires to respond to frontend API requests and client API requests will not need to hydrate data on demand. **If you are running Edge behind a load balancer and making use of the frontend API, setting startup tokens is necessary for predictable responses from Edge.**
-- Choose a appropriate scope for your initialization tokens: We recommend using one wildcard token per environment. This gives more predictability over the resources that Edge will use at runtime. If Edge needs to run in a sensitive context, starting Edge with tokens that are scoped to all the projects that downstream SDKs are expected to consume is okay.
-
-Unleash Edge is compiled to a single binary. You can configure it by passing in arguments or setting environment
-variables.
+Running Edge in docker with recommended setup
 
 ```shell
-Usage: unleash-edge [OPTIONS] <COMMAND>
-
-Commands:
-  edge     Run in edge mode
-  offline  Run in offline mode
-  help     Print this message or the help of the given subcommand(s)
-
-Options:
-  -p, --port <PORT>
-          Which port should this server listen for HTTP traffic on [env: PORT=] [default: 3063]
-  -i, --interface <INTERFACE>
-          Which interfaces should this server listen for HTTP traffic on [env: INTERFACE=] [default: 0.0.0.0]
-  -b, --base-path <BASE_PATH>
-          Which base path should this server listen for HTTP traffic on [env: BASE_PATH=] [default: ]
-  -w, --workers <WORKERS>
-          How many workers should be started to handle requests. Defaults to number of physical cpus [env: WORKERS=] [default: number of physical cpus]
-      --tls-enable
-          Should we bind TLS [env: TLS_ENABLE=]
-      --tls-server-key <TLS_SERVER_KEY>
-          Server key to use for TLS [env: TLS_SERVER_KEY=] (Needs to be a path to a file)
-      --tls-server-cert <TLS_SERVER_CERT>
-          Server Cert to use for TLS [env: TLS_SERVER_CERT=] (Needs to be a path to a file)
-      --tls-server-port <TLS_SERVER_PORT>
-          Port to listen for https connection on (will use the interfaces already defined) [env: TLS_SERVER_PORT=] [default: 3043]
-      --instance-id <INSTANCE_ID>
-          Instance id. Used for metrics reporting [env: INSTANCE_ID=] [default: Ulid::new()]
-  -a, --app-name <APP_NAME>
-          App name. Used for metrics reporting [env: APP_NAME=] [default: unleash-edge]
-  -h, --help
-          Print help
-  -l, --log-format <LOG_FORMAT>
-        Which log format should Edge use
-      [env: LOG_FORMAT=]
-        [default: `plain`]
-      Possible values: `plain`, `json`, `pretty`
-  --token-header <TOKEN_HEADER>
-      token header to use for edge authorization [env: TOKEN_HEADER=] [default: Authorization]
+docker run -it -p 3063:3063 -e STRICT=true -e UPSTREAM_URL=<yourunleashinstance> unleashorg/unleash-edge:<mostrecentversion> edge
 ```
 
-### Built-in Health check
+## Deploying Unleash Edge
 
-There is now (from 5.1.0) a subcommand named `health` which will ping your health endpoint and exit with status 0
-provided the health endpoint returns 200 OK.
-
-Example:
-
-```shell
-./unleash-edge health
-```
-
-will check an Edge process running on http://localhost:3063. If you're using base-path or the port variable you should
-use the `-e --edge-url` CLI arg (or the EDGE_URL environment variable) to tell the health checker where edge is running.
-
-If you're hosting Edge with a self-signed certificate using the tls cli arguments, you should use
-the `--ca-certificate-file <file_containing_your_ca_and_key_in_pem_format>` flag (or the CA_CERTIFICATE_FILE environment
-variable) to allow the health checker to trust the self signed certificate.
-
-### Built-in Ready check
-
-There is now (from 12.0.0) a subcommand named `ready` which will ping your ready endpoint and exit with status 0
-provided the ready endpoint returns 200 OK and `{ status: "READY" }`. Otherwise it will return status 1 and an error
-message to signal that Edge is not ready (it has not spoken to upstream or recovered from a persisted backup).
-
-Examples:
-
-* Edge not running:
-
-```shell
-$ ./unleash-edge ready
-Error: Failed to connect to ready endpoint at http://localhost:3063/internal-backstage/ready. Failed with status None
-$ echo $?
-1
-```
-
-* Edge running but not populated its feature cache yet (not spoken to upstream or restored from backup)
-
-```shell
-$ ./unleash-edge ready
-Error: Ready check returned a different status than READY. It returned EdgeStatus { status: NotReady }
-$ echo $?
-1
-```
-
-* Edge running and synchronized. I.e. READY
-
-```shell
-$ ./unleash-edge ready
-OK
-$ echo $?
-0
-```
-
-If you're hosting Edge with a self-signed certificate using the tls cli arguments, you should use
-the `--ca-certificate-file <file_containing_your_ca_and_key_in_pem_format>` flag (or the CA_CERTIFICATE_FILE environment
-variable) to allow the health checker to trust the self signed certificate.
+See our page on [Deploying Edge](./docs/deploying.md)
 
 ## Getting Unleash Edge
 
@@ -171,198 +75,11 @@ Unleash Edge is distributed as a binary and as a docker image.
 If you have the [Rust toolchain](https://rustup.rs) installed you can build a binary for the platform you're running by
 cloning this repo and running `cargo build --release`. This will give you an `unleash-edge` binary in `./target/release`
 
-## Concepts
+## Concepts (see [Concepts](./docs/concepts.md))
 
-### Modes
+## Metrics
 
-Edge currently supports 2 different modes:
-
-- [Edge](#edge) - Connection to upstream node (Unleash instance or another Edge). Supports dynamic tokens, metrics and
-  other advanced features;
-- [Offline](#offline) - No connection to upstream node. Full control of data and tokens;
-
-#### Edge
-
-```mermaid
-graph LR
-  A(Client) -->|Fetch toggles| B((Edge))
-  B-->|Fetch toggles| C((Unleash))
-```
-
-Edge mode is the "standard" mode for Unleash Edge and the one you should default to in most cases. It connects to an
-upstream node, such as your Unleash instance, and uses that as the source of truth for feature toggles.
-
-Other than connecting Edge directly to your Unleash instance, it's also possible to connect to another Edge instance (
-_daisy chaining_). You can have as many Edge nodes as you'd like between the Edge node your clients are accessing and
-the Unleash server, and it's also possible for multiple nodes to connect to a single upstream one. Depending on your
-architecture and requirements this can be a powerful feature, offering you flexibility and scalability when planning
-your implementation.
-
-```mermaid
-graph LR
-  A(Client 1) -->|Fetch toggles| C((Edge 1))
-  B(Client 2) -->|Fetch toggles| D((Edge 2))
-  C-->|Fetch toggles| E((Edge 3))
-  D-->|Fetch toggles| E
-  E-->|Fetch toggles| F((Unleash))
-```
-
-This means that, in order to start up, Edge mode needs to know where the upstream node is. This is done by passing
-the `--upstream-url` command line argument or setting the `UPSTREAM_URL` environment variable.
-
-By default, Edge mode uses an in-memory cache to store the features it fetches from the upstream node. However, you may
-want to use a more persistent storage solution. For this purpose, Edge supports either Redis or a backup file, which you
-can configure by passing in either the `--redis-url` or `--backup_folder` command line argument, respectively. On
-start-up, Edge checks whether the persistent backup option is specified, in which case it uses it to populate its
-internal caches. This can be useful when your Unleash server is unreachable.
-
-Persistent storage is useful for high availability and resilience. If an Edge instance using persistent storage is
-restarted, it will not have to synchronize with upstream before it is ready. The persistent storage is only read on
-startup and will only be used until Edge is able to synchronize with upstream. Because of this, there is no need to
-purge the cache. After Edge has synchronized with an upstream, it will periodically save its in-memory state to the
-persistent storage.
-
-Multiple Edge nodes can share the same Redis instance or backup folder. Failure to read from persistent storage will not
-prevent Edge from starting up. In this case an Edge instance will be ready only after it is able to connect with
-upstream.
-
-Edge mode also supports dynamic tokens, meaning that Edge doesn't need a token to be provided when starting up. Once we
-make a request to the `/api/client/features` endpoint using
-a [client token](https://docs.getunleash.io/reference/api-tokens-and-client-keys#client-tokens) Edge will validate
-upstream and fetch its respective features. After that, it gets added to the list of known tokens that gets periodically
-synced, making sure it is a valid token and its features are up-to-date.
-
-Even though Edge supports dynamic tokens, you still have the option of providing a token through the command line
-argument or environment variable. This way, since Edge already knows about your token at start up, it will sync your
-features for that token and should be ready for your requests right away (_warm up / hot start_).
-
-### Front-end tokens
-
-[Front-end tokens](https://docs.getunleash.io/reference/api-tokens-and-client-keys#front-end-tokens) can also be used
-with `/api/frontend` and `/api/proxy` endpoints, however they are not allowed to fetch features upstream.
-In order to use these tokens correctly and make sure they return the correct information, it's important that the
-features they are allowed to access are already present in that Edge node's features cache.
-The easiest way to ensure this is by passing in at least one client token as one of the command line arguments,
-ensuring it has access to the same features as the front-end token you'll be using.
-If you're using a frontend token that doesn't have data in the node's feature cache, you will receive an HTTP Status
-code: 511 Network Authentication Required along with a body of which project and environment you will need to add a
-client token for.
-
-### Starting in edge mode
-
-To see parameters available when running in this mode, run:
-
-```bash
-$ unleash-edge edge -h
-Run in edge mode
-
-Usage: unleash-edge edge [OPTIONS] --upstream-url <UPSTREAM_URL>
-
-Options:
-  -u, --upstream-url <UPSTREAM_URL>
-          Where is your upstream URL. Remember, this is the URL to your instance, without any trailing /api suffix [env: UPSTREAM_URL=]
-  -r, --redis-url <REDIS_URL>
-          A URL pointing to a running Redis instance. Edge will use this instance to persist feature and token data and read this back after restart. Mutually exclusive with the --backup-folder option [env: REDIS_URL=]
-  -b, --backup-folder <BACKUP_FOLDER>
-          A path to a local folder. Edge will write feature and token data to disk in this folder and read this back after restart. Mutually exclusive with the --redis-url option [env: BACKUP_FOLDER=]
-  -m, --metrics-interval-seconds <METRICS_INTERVAL_SECONDS>
-          How often should we post metrics upstream? [env: METRICS_INTERVAL_SECONDS=] [default: 60]
-  -f, --features-refresh-interval-seconds <FEATURES_REFRESH_INTERVAL_SECONDS>
-          How long between each refresh for a token [env: FEATURES_REFRESH_INTERVAL_SECONDS=] [default: 10]
-      --token-revalidation-interval-seconds <TOKEN_REVALIDATION_INTERVAL_SECONDS>
-          How long between each revalidation of a token [env: TOKEN_REVALIDATION_INTERVAL_SECONDS=] [default: 3600]
-  -t, --tokens <TOKENS>
-          Get data for these client tokens at startup. Accepts comma-separated list of tokens. Hot starts your feature cache [env: TOKENS=]
-  -H, --custom-client-headers <CUSTOM_CLIENT_HEADERS>
-          Expects curl header format (-H <HEADERNAME>: <HEADERVALUE>) for instance `-H X-Api-Key: mysecretapikey` [env: CUSTOM_CLIENT_HEADERS=]
-  -s, --skip-ssl-verification
-          If set to true, we will skip SSL verification when connecting to the upstream Unleash server [env: SKIP_SSL_VERIFICATION=]
-      --pkcs8-client-certificate-file <PKCS8_CLIENT_CERTIFICATE_FILE>
-          Client certificate chain in PEM encoded X509 format with the leaf certificate first. The certificate chain should contain any intermediate certificates that should be sent to clients to allow them to build a chain to a trusted root [env: PKCS8_CLIENT_CERTIFICATE_FILE=]
-      --pkcs8-client-key-file <PKCS8_CLIENT_KEY_FILE>
-          Client key is a PEM encoded PKCS#8 formatted private key for the leaf certificate [env: PKCS8_CLIENT_KEY_FILE=]
-      --pkcs12-identity-file <PKCS12_IDENTITY_FILE>
-          Identity file in pkcs12 format. Typically this file has a pfx extension [env: PKCS12_IDENTITY_FILE=]
-      --pkcs12-passphrase <PKCS12_PASSPHRASE>
-          Passphrase used to unlock the pkcs12 file [env: PKCS12_PASSPHRASE=]
-      --upstream-certificate-file <UPSTREAM_CERTIFICATE_FILE>
-          Extra certificate passed to the client for building its trust chain. Needs to be in PEM format (crt or pem extensions usually are) [env: UPSTREAM_CERTIFICATE_FILE=]
-
-  -h, --help
-          Print help
-
-```
-
-#### Offline
-
-```mermaid
-graph LR
-  A(Client) -->|Fetch toggles| B((Edge))
-  B-->|Fetch toggles| C[Features dump]
-```
-
-Offline mode is useful when there is no connection to an upstream node, such as your Unleash instance or another Edge
-instance, or as a tool to make working with Unleash easier during development.
-
-To use offline mode, you'll need a features file. The easiest way to get one is to download a JSON dump of a result from
-a query against an Unleash server on
-the [/api/client/features](https://docs.getunleash.io/reference/api/unleash/get-client-feature) endpoint. You can also
-use a hand rolled, human readable JSON version of the features file. Edge will automatically convert it to the API
-format when it starts up. Here's an example:
-
-``` json
-{
-  "featureOne": {
-    "enabled": true,
-    "variant": "variantOne"
-  },
-  "featureTwo": {
-    "enabled": false,
-    "variant": "variantTwo"
-  },
-  "featureThree": {
-    "enabled": true
-  }
-}
-```
-
-The simplified JSON format should be an object with a key for each feature. You can force the result of `is_enabled` in
-your SDK by setting the enabled property, likewise can also force the result of `get_variant` by specifying the name of
-the variant you want. This format is primarily for development.
-
-When using offline mode you must specify one or more tokens at startup. These tokens will let your SDKs access Edge.
-Tokens following the Unleash API format `[project]:[environment].<somesecret>` allow Edge to recognize the project and
-environment specified in the token, returning only the relevant features to the calling SDK. On the other hand, for
-tokens not adhering to this format, Edge will return all features if there is an exact match with any of the startup
-tokens.
-
-To make local development easier, you can specify a reload interval in seconds (Since Unleash-Edge 10.0.x); this will
-cause Edge to reload the features file from disk every X seconds. This can be useful for local development.
-
-Since offline mode does not connect to an upstream node, it does not support metrics or dynamic tokens.
-
-To launch in this mode, run:
-
-```bash
-$ ./unleash-edge offline --help
-Usage: unleash-edge offline [OPTIONS]
-
-Options:
-  -b, --bootstrap-file <BOOTSTRAP_FILE>         [env: BOOTSTRAP_FILE=]
-  -t, --tokens <TOKENS>                         [env: TOKENS=]
-  -r, --reload-interval <RELOAD_INTERVAL>       [env: RELOAD_INTERVAL=]
-
-```
-
-##### Environments in offline mode
-
-Currently, Edge does not support multiple environments in offline mode. All tokens added at startup will receive the
-same list of features passed in as the bootstrap argument.
-However, tokens in `<project>:<environment>.<secret>` format will still filter by project.
-
-## [Metrics](https://docs.getunleash.io/reference/api/unleash/metrics)
-
-**❗ Note:** For Edge to correctly register SDK usage metrics, your Unleash instance must be v5.9.0.
+**❗ Note:** For Edge to correctly register SDK usage metrics, your Unleash instance must be v5.9.0 or newer.
 **! Note:** If you're daisy chaining you will need at least Edge 17.0.0 upstream of any Edge 19.0.0 to preserve metrics.
 
 Since Edge is designed to avoid overloading its upstream, Edge gathers and accumulates usage metrics from SDKs for a set
@@ -380,87 +97,7 @@ minor and patch versions), could potentially break your implementation.
 
 ## Performance
 
-Unleash Edge will scale linearly with CPU. There are k6 benchmarks in the benchmark folder. We've already got some
-initial numbers from [hey](https://github.com/rakyll/hey).
-
-Do note that the number of requests Edge can handle does depend on the total size of your toggle response. That is, Edge
-is faster if you only have 10 toggles with 1 strategy each, than it will be with 1000 toggles with multiple strategies
-on each. Benchmarks here were run with data fetched from the Unleash demo instance (roughly 100kB (350 features / 200
-strategies)) as well as against a small dataset of 5 features with one strategy on each.
-
-Edge was started using
-`docker run --cpus="<cpu>" --memory=128M -p 3063:3063 -e UPSTREAM_URL=<upstream> -e TOKENS="<client token>" unleashorg/unleash-edge:edge -w <number of cpus rounded up to closest integer> edge`
-
-Then we run hey against the proxy endpoint, evaluating toggles
-
-### Large Dataset (350 features (100kB))
-
-```shell
-$ hey -z 10s -H "Authorization: <frontend token>" http://localhost:3063/api/frontend`
-```
-
-| CPU | Memory | RPS   | Endpoint      | p95   | Data transferred |
-|-----|--------|-------|---------------|-------|------------------|
-| 0.1 | 6.7 Mi | 600   | /api/frontend | 103ms | 76Mi             |
-| 1   | 6.7 Mi | 6900  | /api/frontend | 7.4ms | 866Mi            |
-| 4   | 9.5    | 25300 | /api/frontend | 2.4ms | 3.2Gi            |
-| 8   | 15     | 40921 | /api/frontend | 1.6ms | 5.26Gi           |
-
-and against our client features endpoint.
-
-```shell
-$ hey -z 10s -H "Authorization: <client token>" http://localhost:3063/api/client/features
-```
-
-| CPU | Memory observed | RPS   | Endpoint             | p95   | Data transferred |
-|-----|-----------------|-------|----------------------|-------|------------------|
-| 0.1 | 11 Mi           | 309   | /api/client/features | 199ms | 300 Mi           |
-| 1   | 11 Mi           | 3236  | /api/client/features | 16ms  | 3 Gi             |
-| 4   | 11 Mi           | 12815 | /api/client/features | 4.5ms | 14 Gi            |
-| 8   | 17 Mi           | 23207 | /api/client/features | 2.7ms | 26 Gi            |
-
-### Small Dataset (5 features (2kB))
-
-```shell
-$ hey -z 10s -H "Authorization: <frontend token>" http://localhost:3063/api/frontend`
-```
-
-| CPU | Memory  | RPS    | Endpoint      | p95   | Data transferred |
-|-----|---------|--------|---------------|-------|------------------|
-| 0.1 | 4.3 Mi  | 3673   | /api/frontend | 93ms  | 9Mi              |
-| 1   | 6.7 Mi  | 39000  | /api/frontend | 1.6ms | 80Mi             |
-| 4   | 6.9 Mi  | 100020 | /api/frontend | 600μs | 252Mi            |
-| 8   | 12.5 Mi | 141090 | /api/frontend | 600μs | 324Mi            |
-
-and against our client features endpoint.
-
-```shell
-$ hey -z 10s -H "Authorization: <client token>" http://localhost:3063/api/client/features
-```
-
-| CPU | Memory observed | RPS    | Endpoint             | p95   | Data transferred |
-|-----|-----------------|--------|----------------------|-------|------------------|
-| 0.1 | 4 Mi            | 3298   | /api/client/features | 92ms  | 64 Mi            |
-| 1   | 4 Mi            | 32360  | /api/client/features | 2ms   | 527Mi            |
-| 4   | 11 Mi           | 95838  | /api/client/features | 600μs | 2.13 Gi          |
-| 8   | 17 Mi           | 129381 | /api/client/features | 490μs | 2.87 Gi          |
-
-## Why choose Unleash Edge over the Unleash Proxy?
-
-Edge offers a superset of the same feature set as the Unleash Proxy and we've made sure it offers the same security and
-privacy features.
-
-However, there are a few notable differences between the Unleash Proxy and Unleash Edge:
-
-- Unleash Edge is built to be light and fast, it handles an order of magnitude more requests per second than the Unleash
-  Proxy can, while using two orders of magnitude less memory.
-- All your Unleash environments can be handled by a single instance, no more running multiple instances of the Unleash
-  Proxy to handle both your development and production environments.
-- Backend SDKs can connect to Unleash Edge without turning on experimental feature flags.
-- Unleash Edge is smart enough to dynamically resolve the tokens you use to connect to it against the upstream Unleash
-  instance. This means you don't have to worry about knowing in advance what tokens your SDKs use - if you want to swap
-  out the Unleash token your SDK uses, this can be done without ever restarting or worrying about Unleash Edge. Unleash
-  Edge will only collect and cache data for the environments and projects you use.
+See [Benchmarking](./docs/benchmarking.md)
 
 ## Debugging
 
@@ -479,8 +116,11 @@ See more about available logging and log levels at https://docs.rs/env_logger/la
 ### Missing metrics in upstream server
 
 #### Possible reasons
-- Old edge version. In order to guarantee metrics on newer Unleash versions, you will need to be using Edge v17.0.0 or newer
-- Old SDK clients. We've seen some clients, particularly early Python (1.x branch) as well as earlier .NET SDKs (we recommend you use 4.1.5 or newer) struggle to post metrics with the strict headers Edge requires.
+
+- Old edge version. In order to guarantee metrics on newer Unleash versions, you will need to be using Edge v17.0.0 or
+  newer
+- Old SDK clients. We've seen some clients, particularly early Python (1.x branch) as well as earlier .NET SDKs (we
+  recommend you use 4.1.5 or newer) struggle to post metrics with the strict headers Edge requires.
 
 ## Development
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,0 +1,68 @@
+# Benchmarking
+
+## Performance
+
+Unleash Edge will scale linearly with CPU. There are k6 benchmarks in the benchmark folder. We've already got some
+initial numbers from [hey](https://github.com/rakyll/hey).
+
+Do note that the number of requests Edge can handle does depend on the total size of your toggle response. That is, Edge
+is faster if you only have 10 toggles with 1 strategy each, than it will be with 1000 toggles with multiple strategies
+on each. Benchmarks here were run with data fetched from the Unleash demo instance (roughly 100kB (350 features / 200
+strategies)) as well as against a small dataset of 5 features with one strategy on each.
+
+Edge was started using
+`docker run --cpus="<cpu>" --memory=128M -p 3063:3063 -e UPSTREAM_URL=<upstream> -e TOKENS="<client token>" unleashorg/unleash-edge:edge -w <number of cpus rounded up to closest integer> edge`
+
+Then we run hey against the proxy endpoint, evaluating toggles
+
+### Large Dataset (350 features (100kB))
+
+```shell
+$ hey -z 10s -H "Authorization: <frontend token>" http://localhost:3063/api/frontend`
+```
+
+| CPU | Memory | RPS   | Endpoint      | p95   | Data transferred |
+|-----|--------|-------|---------------|-------|------------------|
+| 0.1 | 6.7 Mi | 600   | /api/frontend | 103ms | 76Mi             |
+| 1   | 6.7 Mi | 6900  | /api/frontend | 7.4ms | 866Mi            |
+| 4   | 9.5    | 25300 | /api/frontend | 2.4ms | 3.2Gi            |
+| 8   | 15     | 40921 | /api/frontend | 1.6ms | 5.26Gi           |
+
+and against our client features endpoint.
+
+```shell
+$ hey -z 10s -H "Authorization: <client token>" http://localhost:3063/api/client/features
+```
+
+| CPU | Memory observed | RPS   | Endpoint             | p95   | Data transferred |
+|-----|-----------------|-------|----------------------|-------|------------------|
+| 0.1 | 11 Mi           | 309   | /api/client/features | 199ms | 300 Mi           |
+| 1   | 11 Mi           | 3236  | /api/client/features | 16ms  | 3 Gi             |
+| 4   | 11 Mi           | 12815 | /api/client/features | 4.5ms | 14 Gi            |
+| 8   | 17 Mi           | 23207 | /api/client/features | 2.7ms | 26 Gi            |
+
+### Small Dataset (5 features (2kB))
+
+```shell
+$ hey -z 10s -H "Authorization: <frontend token>" http://localhost:3063/api/frontend`
+```
+
+| CPU | Memory  | RPS    | Endpoint      | p95   | Data transferred |
+|-----|---------|--------|---------------|-------|------------------|
+| 0.1 | 4.3 Mi  | 3673   | /api/frontend | 93ms  | 9Mi              |
+| 1   | 6.7 Mi  | 39000  | /api/frontend | 1.6ms | 80Mi             |
+| 4   | 6.9 Mi  | 100020 | /api/frontend | 600μs | 252Mi            |
+| 8   | 12.5 Mi | 141090 | /api/frontend | 600μs | 324Mi            |
+
+and against our client features endpoint.
+
+```shell
+$ hey -z 10s -H "Authorization: <client token>" http://localhost:3063/api/client/features
+```
+
+| CPU | Memory observed | RPS    | Endpoint             | p95   | Data transferred |
+|-----|-----------------|--------|----------------------|-------|------------------|
+| 0.1 | 4 Mi            | 3298   | /api/client/features | 92ms  | 64 Mi            |
+| 1   | 4 Mi            | 32360  | /api/client/features | 2ms   | 527Mi            |
+| 4   | 11 Mi           | 95838  | /api/client/features | 600μs | 2.13 Gi          |
+| 8   | 17 Mi           | 129381 | /api/client/features | 490μs | 2.87 Gi          |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,188 @@
+# Concepts
+
+### Modes
+
+Edge currently supports 2 different modes:
+
+- [Edge](#edge) - Connection to upstream node (Unleash instance or another Edge). Supports dynamic tokens, metrics and
+  other advanced features;
+- [Offline](#offline) - No connection to upstream node. Full control of data and tokens;
+
+#### Edge
+
+```mermaid
+graph LR
+  A(Client) -->|Fetch toggles| B((Edge))
+  B-->|Fetch toggles| C((Unleash))
+```
+
+Edge mode is the "standard" mode for Unleash Edge and the one you should default to in most cases. It connects to an
+upstream node, such as your Unleash instance, and uses that as the source of truth for feature toggles.
+
+Other than connecting Edge directly to your Unleash instance, it's also possible to connect to another Edge instance (
+_daisy chaining_). You can have as many Edge nodes as you'd like between the Edge node your clients are accessing and
+the Unleash server, and it's also possible for multiple nodes to connect to a single upstream one. Depending on your
+architecture and requirements this can be a powerful feature, offering you flexibility and scalability when planning
+your implementation.
+
+```mermaid
+graph LR
+  A(Client 1) -->|Fetch toggles| C((Edge 1))
+  B(Client 2) -->|Fetch toggles| D((Edge 2))
+  C-->|Fetch toggles| E((Edge 3))
+  D-->|Fetch toggles| E
+  E-->|Fetch toggles| F((Unleash))
+```
+
+This means that, in order to start up, Edge mode needs to know where the upstream node is. This is done by passing
+the `--upstream-url` command line argument or setting the `UPSTREAM_URL` environment variable.
+
+By default, Edge mode uses an in-memory cache to store the features it fetches from the upstream node. However, you may
+want to use a more persistent storage solution. For this purpose, Edge supports either Redis or a backup file, which you
+can configure by passing in either the `--redis-url` or `--backup_folder` command line argument, respectively. On
+start-up, Edge checks whether the persistent backup option is specified, in which case it uses it to populate its
+internal caches. This can be useful when your Unleash server is unreachable.
+
+Persistent storage is useful for high availability and resilience. If an Edge instance using persistent storage is
+restarted, it will not have to synchronize with upstream before it is ready. The persistent storage is only read on
+startup and will only be used until Edge is able to synchronize with upstream. Because of this, there is no need to
+purge the cache. After Edge has synchronized with an upstream, it will periodically save its in-memory state to the
+persistent storage.
+
+Multiple Edge nodes can share the same Redis instance or backup folder. Failure to read from persistent storage will not
+prevent Edge from starting up. In this case an Edge instance will be ready only after it is able to connect with
+upstream.
+
+Edge mode also supports dynamic tokens, meaning that Edge doesn't need a token to be provided when starting up. Once we
+make a request to the `/api/client/features` endpoint using
+a [client token](https://docs.getunleash.io/reference/api-tokens-and-client-keys#client-tokens) Edge will validate
+upstream and fetch its respective features. After that, it gets added to the list of known tokens that gets periodically
+synced, making sure it is a valid token and its features are up-to-date.
+
+Even though Edge supports dynamic tokens, you still have the option of providing a token through the command line
+argument or environment variable. This way, since Edge already knows about your token at start up, it will sync your
+features for that token and should be ready for your requests right away (_warm up / hot start_).
+
+### Front-end tokens
+
+[Front-end tokens](https://docs.getunleash.io/reference/api-tokens-and-client-keys#front-end-tokens) can also be used
+with `/api/frontend` and `/api/proxy` endpoints, however they are not allowed to fetch features upstream.
+In order to use these tokens correctly and make sure they return the correct information, it's important that the
+features they are allowed to access are already present in that Edge node's features cache.
+The easiest way to ensure this is by passing in at least one client token as one of the command line arguments,
+ensuring it has access to the same features as the front-end token you'll be using.
+If you're using a frontend token that doesn't have data in the node's feature cache, you will receive an HTTP Status
+code: 511 Network Authentication Required along with a body of which project and environment you will need to add a
+client token for.
+
+### Starting in edge mode
+
+To see parameters available when running in this mode, run:
+
+```bash
+$ unleash-edge edge -h
+Run in edge mode
+
+Usage: unleash-edge edge [OPTIONS] --upstream-url <UPSTREAM_URL>
+
+Options:
+  -u, --upstream-url <UPSTREAM_URL>
+          Where is your upstream URL. Remember, this is the URL to your instance, without any trailing /api suffix [env: UPSTREAM_URL=]
+  -r, --redis-url <REDIS_URL>
+          A URL pointing to a running Redis instance. Edge will use this instance to persist feature and token data and read this back after restart. Mutually exclusive with the --backup-folder option [env: REDIS_URL=]
+  -b, --backup-folder <BACKUP_FOLDER>
+          A path to a local folder. Edge will write feature and token data to disk in this folder and read this back after restart. Mutually exclusive with the --redis-url option [env: BACKUP_FOLDER=]
+  -m, --metrics-interval-seconds <METRICS_INTERVAL_SECONDS>
+          How often should we post metrics upstream? [env: METRICS_INTERVAL_SECONDS=] [default: 60]
+  -f, --features-refresh-interval-seconds <FEATURES_REFRESH_INTERVAL_SECONDS>
+          How long between each refresh for a token [env: FEATURES_REFRESH_INTERVAL_SECONDS=] [default: 10]
+      --token-revalidation-interval-seconds <TOKEN_REVALIDATION_INTERVAL_SECONDS>
+          How long between each revalidation of a token [env: TOKEN_REVALIDATION_INTERVAL_SECONDS=] [default: 3600]
+  -t, --tokens <TOKENS>
+          Get data for these client tokens at startup. Accepts comma-separated list of tokens. Hot starts your feature cache [env: TOKENS=]
+  -H, --custom-client-headers <CUSTOM_CLIENT_HEADERS>
+          Expects curl header format (-H <HEADERNAME>: <HEADERVALUE>) for instance `-H X-Api-Key: mysecretapikey` [env: CUSTOM_CLIENT_HEADERS=]
+  -s, --skip-ssl-verification
+          If set to true, we will skip SSL verification when connecting to the upstream Unleash server [env: SKIP_SSL_VERIFICATION=]
+      --pkcs8-client-certificate-file <PKCS8_CLIENT_CERTIFICATE_FILE>
+          Client certificate chain in PEM encoded X509 format with the leaf certificate first. The certificate chain should contain any intermediate certificates that should be sent to clients to allow them to build a chain to a trusted root [env: PKCS8_CLIENT_CERTIFICATE_FILE=]
+      --pkcs8-client-key-file <PKCS8_CLIENT_KEY_FILE>
+          Client key is a PEM encoded PKCS#8 formatted private key for the leaf certificate [env: PKCS8_CLIENT_KEY_FILE=]
+      --pkcs12-identity-file <PKCS12_IDENTITY_FILE>
+          Identity file in pkcs12 format. Typically this file has a pfx extension [env: PKCS12_IDENTITY_FILE=]
+      --pkcs12-passphrase <PKCS12_PASSPHRASE>
+          Passphrase used to unlock the pkcs12 file [env: PKCS12_PASSPHRASE=]
+      --upstream-certificate-file <UPSTREAM_CERTIFICATE_FILE>
+          Extra certificate passed to the client for building its trust chain. Needs to be in PEM format (crt or pem extensions usually are) [env: UPSTREAM_CERTIFICATE_FILE=]
+
+  -h, --help
+          Print help
+
+```
+
+#### Offline
+
+```mermaid
+graph LR
+  A(Client) -->|Fetch toggles| B((Edge))
+  B-->|Fetch toggles| C[Features dump]
+```
+
+Offline mode is useful when there is no connection to an upstream node, such as your Unleash instance or another Edge
+instance, or as a tool to make working with Unleash easier during development.
+
+To use offline mode, you'll need a features file. The easiest way to get one is to download a JSON dump of a result from
+a query against an Unleash server on
+the [/api/client/features](https://docs.getunleash.io/reference/api/unleash/get-client-feature) endpoint. You can also
+use a hand rolled, human readable JSON version of the features file. Edge will automatically convert it to the API
+format when it starts up. Here's an example:
+
+``` json
+{
+  "featureOne": {
+    "enabled": true,
+    "variant": "variantOne"
+  },
+  "featureTwo": {
+    "enabled": false,
+    "variant": "variantTwo"
+  },
+  "featureThree": {
+    "enabled": true
+  }
+}
+```
+
+The simplified JSON format should be an object with a key for each feature. You can force the result of `is_enabled` in
+your SDK by setting the enabled property, likewise can also force the result of `get_variant` by specifying the name of
+the variant you want. This format is primarily for development.
+
+When using offline mode you must specify one or more tokens at startup. These tokens will let your SDKs access Edge.
+Tokens following the Unleash API format `[project]:[environment].<somesecret>` allow Edge to recognize the project and
+environment specified in the token, returning only the relevant features to the calling SDK. On the other hand, for
+tokens not adhering to this format, Edge will return all features if there is an exact match with any of the startup
+tokens.
+
+To make local development easier, you can specify a reload interval in seconds (Since Unleash-Edge 10.0.x); this will
+cause Edge to reload the features file from disk every X seconds. This can be useful for local development.
+
+Since offline mode does not connect to an upstream node, it does not support metrics or dynamic tokens.
+
+To launch in this mode, run:
+
+```bash
+$ ./unleash-edge offline --help
+Usage: unleash-edge offline [OPTIONS]
+
+Options:
+  -b, --bootstrap-file <BOOTSTRAP_FILE>         [env: BOOTSTRAP_FILE=]
+  -t, --tokens <TOKENS>                         [env: TOKENS=]
+  -r, --reload-interval <RELOAD_INTERVAL>       [env: RELOAD_INTERVAL=]
+
+```
+
+##### Environments in offline mode
+
+Currently, Edge does not support multiple environments in offline mode. All tokens added at startup will receive the
+same list of features passed in as the bootstrap argument.
+However, tokens in `<project>:<environment>.<secret>` format will still filter by project.

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -1,0 +1,117 @@
+# Deploying
+
+## Running Unleash Edge
+
+Edge provides a range of powerful ways in which you can run it. For a standard production configuration we recommend the
+following:
+
+- [Run in Edge mode](#edge): Edge mode connects to your upstream Unleash and syncs feature flags and tokens. This should
+  be the default mode that you choose for most Edge configurations in production.
+- Start Edge with initialization tokens: Edge mode allows you to specify a set of tokens on startup that Edge will use
+  to hydrate data ahead of time. This means that Edge will have the data it requires to respond to frontend API requests
+  and client API requests will not need to hydrate data on demand. **If you are running Edge behind a load balancer and
+  making use of the frontend API, setting startup tokens is necessary for predictable responses from Edge.**
+- Choose a appropriate scope for your initialization tokens: We recommend using one wildcard token per environment. This
+  gives more predictability over the resources that Edge will use at runtime. If Edge needs to run in a sensitive
+  context, starting Edge with tokens that are scoped to all the projects that downstream SDKs are expected to consume is
+  okay.
+
+Unleash Edge is compiled to a single binary. You can configure it by passing in arguments or setting environment
+variables.
+
+```shell
+Usage: unleash-edge [OPTIONS] <COMMAND>
+
+Commands:
+  edge     Run in edge mode
+  offline  Run in offline mode
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+  -p, --port <PORT>
+          Which port should this server listen for HTTP traffic on [env: PORT=] [default: 3063]
+  -i, --interface <INTERFACE>
+          Which interfaces should this server listen for HTTP traffic on [env: INTERFACE=] [default: 0.0.0.0]
+  -b, --base-path <BASE_PATH>
+          Which base path should this server listen for HTTP traffic on [env: BASE_PATH=] [default: ]
+  -w, --workers <WORKERS>
+          How many workers should be started to handle requests. Defaults to number of physical cpus [env: WORKERS=] [default: number of physical cpus]
+      --tls-enable
+          Should we bind TLS [env: TLS_ENABLE=]
+      --tls-server-key <TLS_SERVER_KEY>
+          Server key to use for TLS [env: TLS_SERVER_KEY=] (Needs to be a path to a file)
+      --tls-server-cert <TLS_SERVER_CERT>
+          Server Cert to use for TLS [env: TLS_SERVER_CERT=] (Needs to be a path to a file)
+      --tls-server-port <TLS_SERVER_PORT>
+          Port to listen for https connection on (will use the interfaces already defined) [env: TLS_SERVER_PORT=] [default: 3043]
+      --instance-id <INSTANCE_ID>
+          Instance id. Used for metrics reporting [env: INSTANCE_ID=] [default: Ulid::new()]
+  -a, --app-name <APP_NAME>
+          App name. Used for metrics reporting [env: APP_NAME=] [default: unleash-edge]
+  -h, --help
+          Print help
+  -l, --log-format <LOG_FORMAT>
+        Which log format should Edge use
+      [env: LOG_FORMAT=]
+        [default: `plain`]
+      Possible values: `plain`, `json`, `pretty`
+  --token-header <TOKEN_HEADER>
+      token header to use for edge authorization [env: TOKEN_HEADER=] [default: Authorization]
+```
+
+### Built-in Health check
+
+There is now (from 5.1.0) a subcommand named `health` which will ping your health endpoint and exit with status 0
+provided the health endpoint returns 200 OK.
+
+Example:
+
+```shell
+./unleash-edge health
+```
+
+will check an Edge process running on http://localhost:3063. If you're using base-path or the port variable you should
+use the `-e --edge-url` CLI arg (or the EDGE_URL environment variable) to tell the health checker where edge is running.
+
+If you're hosting Edge with a self-signed certificate using the tls cli arguments, you should use
+the `--ca-certificate-file <file_containing_your_ca_and_key_in_pem_format>` flag (or the CA_CERTIFICATE_FILE environment
+variable) to allow the health checker to trust the self signed certificate.
+
+### Built-in Ready check
+
+There is now (from 12.0.0) a subcommand named `ready` which will ping your ready endpoint and exit with status 0
+provided the ready endpoint returns 200 OK and `{ status: "READY" }`. Otherwise it will return status 1 and an error
+message to signal that Edge is not ready (it has not spoken to upstream or recovered from a persisted backup).
+
+Examples:
+
+* Edge not running:
+
+```shell
+$ ./unleash-edge ready
+Error: Failed to connect to ready endpoint at http://localhost:3063/internal-backstage/ready. Failed with status None
+$ echo $?
+1
+```
+
+* Edge running but not populated its feature cache yet (not spoken to upstream or restored from backup)
+
+```shell
+$ ./unleash-edge ready
+Error: Ready check returned a different status than READY. It returned EdgeStatus { status: NotReady }
+$ echo $?
+1
+```
+
+* Edge running and synchronized. I.e. READY
+
+```shell
+$ ./unleash-edge ready
+OK
+$ echo $?
+0
+```
+
+If you're hosting Edge with a self-signed certificate using the tls cli arguments, you should use
+the `--ca-certificate-file <file_containing_your_ca_and_key_in_pem_format>` flag (or the CA_CERTIFICATE_FILE environment
+variable) to allow the health checker to trust the self signed certificate.

--- a/migration-guide.md
+++ b/migration-guide.md
@@ -1,13 +1,17 @@
 # Migrating from the Unleash Proxy to Edge
 
-Edge is built to be a near drop-in replacement for the Unleash proxy, but there are some differences. This guide takes you through
+Edge is built to be a near drop-in replacement for the Unleash proxy, but there are some differences. This guide takes
+you through
+
 - the differences between Edge and the Unleash proxy
 - how to migrate from the Unleash proxy to Edge
 - in cases where the feature set isn't equivalent, how to achieve the same results in Edge.
 
-A full [Docker compose file](./examples/docker-compose.yml) is also provided. It will spin up Edge, Unleash, and Redis, to allow you to understand the configuration options in context.
+A full [Docker compose file](./examples/docker-compose.yml) is also provided. It will spin up Edge, Unleash, and Redis,
+to allow you to understand the configuration options in context.
 
-After starting the compose, you should be able to access the Unleash UI at `http://localhost:4242`, add a toggle, and cURL the edge instance with:
+After starting the compose, you should be able to access the Unleash UI at `http://localhost:4242`, add a toggle, and
+cURL the edge instance with:
 
 ``` sh
 curl --location --request GET 'http://0.0.0.0:3063/api/client/features' \
@@ -18,59 +22,138 @@ curl --location --request GET 'http://0.0.0.0:3063/api/client/features' \
 
 ## Not supported
 
-- [Custom Strategies](https://docs.getunleash.io/reference/custom-activation-strategies) are not supported in Edge today. If you need to use a custom strategy, you will need to use the Unleash proxy. We believe that the overwhelming majority of custom strategies are better expressed as a set of [strategy constraints](https://docs.getunleash.io/reference/strategy-constraints). If you have a situation where constraints **cannot** replace your strategy, please raise this as an issue with details on what you're trying to achieve. We are looking into supporting custom strategies in Edge in the future.
+- [Custom Strategies](https://docs.getunleash.io/reference/custom-activation-strategies) are not supported in Edge
+  today. If you need to use a custom strategy, you will need to use the Unleash proxy. We believe that the overwhelming
+  majority of custom strategies are better expressed as a set
+  of [strategy constraints](https://docs.getunleash.io/reference/strategy-constraints). If you have a situation where
+  constraints **cannot** replace your strategy, please raise this as an issue with details on what you're trying to
+  achieve. We are looking into supporting custom strategies in Edge in the future.
 
-- Legacy proxy Tokens. If you're using the proxy, you may be using the legacy proxy token format. These are not supported in Edge. You will need to create a new front end SDK token in the Unleash UI and use that. These are the same tokens that the front end API requires. Because of the way Edge handles API tokens, this is not a feature we're planning to support.
+- Legacy proxy Tokens. If you're using the proxy, you may be using the legacy proxy token format. These are not
+  supported in Edge. You will need to create a new front end SDK token in the Unleash UI and use that. These are the
+  same tokens that the front end API requires. Because of the way Edge handles API tokens, this is not a feature we're
+  planning to support.
 
-- CORS configuration. Edge does not support CORS configuration, we accept any request. If you need this feature, please raise an issue or submit a PR.
+- CORS configuration. Edge does not support CORS configuration, we accept any request. If you need this feature, please
+  raise an issue or submit a PR.
 
-- Context enrichers. The Unleash proxy provides an experimental option to automatically enrich requests with additional context. This is not supported in currently in Edge, we're open to adding this feature to Edge, opening an issue would help us to know that this is a valuable feature to you.
+- Context enrichers. The Unleash proxy provides an experimental option to automatically enrich requests with additional
+  context. This is not supported in currently in Edge, we're open to adding this feature to Edge, opening an issue would
+  help us to know that this is a valuable feature to you.
 
-- JS integration. Edge is written in Rust. The Unleash proxy is written JavaScript. If you're wrapping the proxy code in your own JavaScript, you'll need to port that equivalent code to Rust. Generally, if you have a deep integration on the existing proxy, we would recommend either not moving to Edge, or to reach out to us to discuss your use case.
-
+- JS integration. Edge is written in Rust. The Unleash proxy is written JavaScript. If you're wrapping the proxy code in
+  your own JavaScript, you'll need to port that equivalent code to Rust. Generally, if you have a deep integration on
+  the existing proxy, we would recommend either not moving to Edge, or to reach out to us to discuss your use case.
 
 ## Existing features in new ways
 
-This section is to detail features that have changed in meaningful ways from the proxy implementation. These features all exist in Edge but you may find yourself thinking about them in new ways.
+This section is to detail features that have changed in meaningful ways from the proxy implementation. These features
+all exist in Edge but you may find yourself thinking about them in new ways.
 
-- New modes of operation. Edge supports two modes of operation - Edge mode and Offline mode. Offline mode is described in more detail later. If you're using the proxy today, you very likely want Edge mode. Edge mode will allow Unleash to sync its feature information from upstream Unleash instances and serve requests from that information in a similar way to the proxy. Unlike the proxy you need to specify the mode on startup. Example run command:
+- New modes of operation. Edge supports two modes of operation - Edge mode and Offline mode. Offline mode is described
+  in more detail later. If you're using the proxy today, you very likely want Edge mode. Edge mode will allow Unleash to
+  sync its feature information from upstream Unleash instances and serve requests from that information in a similar way
+  to the proxy. Unlike the proxy you need to specify the mode on startup. Example run command:
 
     ``` sh
     ./edge edge --upstream-url http://localhost:4242
     ```
 
-- API Tokens. If you're using the proxy, you'll be familiar with the idea of specifying a token for the proxy to communicate with Unleash. This is not strictly necessary when using Edge; Edge is smart enough to reuse the tokens that are sent from your backend SDKs and intelligently and dynamically determine what tokens are necessary to provide a full set of details to all the SDKs that it's seen. This is all handled behind the scenes for you, so if you're only using backend SDKs, not specifying a token is fine. In practice, this means that the very first request to Edge that Edge doesn't currently have data for, will result in Edge blocking that request until it can resolve that data. If you want to hot start your cache and avoid this problem or you're using front end SDKs with Edge, you can specify a token in the Edge configuration. Note that if you're using a front end SDK then you'll either need to specify a backend SDK token at startup or ensure that at least one request has been made to Edge with a valid SDK token that is able to resolve all the environments and projects that you want to use front end SDKs with.
+- API Tokens. If you're using the proxy, you'll be familiar with the idea of specifying a token for the proxy to
+  communicate with Unleash. This is not strictly necessary when using Edge; Edge is smart enough to reuse the tokens
+  that are sent from your backend SDKs and intelligently and dynamically determine what tokens are necessary to provide
+  a full set of details to all the SDKs that it's seen. This is all handled behind the scenes for you, so if you're only
+  using backend SDKs, not specifying a token is fine. In practice, this means that the very first request to Edge that
+  Edge doesn't currently have data for, will result in Edge blocking that request until it can resolve that data. If you
+  want to hot start your cache and avoid this problem or you're using front end SDKs with Edge, you can specify a token
+  in the Edge configuration. Note that if you're using a front end SDK then you'll either need to specify a backend SDK
+  token at startup or ensure that at least one request has been made to Edge with a valid SDK token that is able to
+  resolve all the environments and projects that you want to use front end SDKs with.
 
 
-- Backups. By default the Unleash proxy will dump all of its feature information to disk to ensure that restarts have all the data you need to start serving requests as fast as possible. Edge does this by default but it also allows you the option to set other methods of storage rather than just flat files. Today we only support Redis (if you want support for a storage technology that we don't support, please feel free to raise ticket or open a PR!). To use Redis, you'll need to specify a valid connection to your storage provider in the Edge configuration. This means that Edge will lazily sync its data to the specified provider in the background and read that back on startup, if present. If you're using Redis, you'll need to ensure that the Redis instance is available before starting Edge. Example run command:
+- Backups. By default the Unleash proxy will dump all of its feature information to disk to ensure that restarts have
+  all the data you need to start serving requests as fast as possible. Edge does this by default but it also allows you
+  the option to set other methods of storage rather than just flat files. Today we only support Redis (if you want
+  support for a storage technology that we don't support, please feel free to raise ticket or open a PR!). To use Redis,
+  you'll need to specify a valid connection to your storage provider in the Edge configuration. This means that Edge
+  will lazily sync its data to the specified provider in the background and read that back on startup, if present. If
+  you're using Redis, you'll need to ensure that the Redis instance is available before starting Edge. Example run
+  command:
 
     ``` sh
     ./edge edge --upstream-url http://localhost:4242 --redis-url redis://localhost:6379
 
     ```
 
-- Multiple environments. The Unleash proxy only supports a single environment, provided by your API key when starting up. Edge does not suffer from this limitation, any connecting SDK can freely use API tokens to scope its request to an environment, project or both, so long as the upstream Unleash instance has that token. This is dynamically determined by Edge, so adding a new token to the upstream Unleash and using that token in an SDK talking to Edge will work without restarting Edge or changing configuration.
+- Multiple environments. The Unleash proxy only supports a single environment, provided by your API key when starting
+  up. Edge does not suffer from this limitation, any connecting SDK can freely use API tokens to scope its request to an
+  environment, project or both, so long as the upstream Unleash instance has that token. This is dynamically determined
+  by Edge, so adding a new token to the upstream Unleash and using that token in an SDK talking to Edge will work
+  without restarting Edge or changing configuration.
 
-- Scaling out Edge. Edge is built with high performance scaling as a first class citizen. Typically, the proxy would be scaled out by spinning up multiple instances, due to the limitations in JS engines that prevent using all available cores. The other reason for potentially scaling out the proxy is that the proxy doesn't support multiple environments. Edge doesn't have these requirements, multiple environments are supported out the box and Edge, by default, will use all the processing power that's available to it to scale up. Edge runs cold. Unless you're running Edge at extreme scaling levels, it's very likely that you won't need to scale out your Edge instance at all; in fact, its more likely that you want to _reduce_ the resources available to Edge.
-
+- Scaling out Edge. Edge is built with high performance scaling as a first class citizen. Typically, the proxy would be
+  scaled out by spinning up multiple instances, due to the limitations in JS engines that prevent using all available
+  cores. The other reason for potentially scaling out the proxy is that the proxy doesn't support multiple environments.
+  Edge doesn't have these requirements, multiple environments are supported out the box and Edge, by default, will use
+  all the processing power that's available to it to scale up. Edge runs cold. Unless you're running Edge at extreme
+  scaling levels, it's very likely that you won't need to scale out your Edge instance at all; in fact, its more likely
+  that you want to _reduce_ the resources available to Edge.
 
 ## Existing features with new configuration options
 
-This section unpacks the small changes in Edge from the proxy. These are ports of existing features or configuration that have small changes. These shouldn't affect how you use Edge and the ideas here are similar to the proxy, only small details have changed.
+This section unpacks the small changes in Edge from the proxy. These are ports of existing features or configuration
+that have small changes. These shouldn't affect how you use Edge and the ideas here are similar to the proxy, only small
+details have changed.
 
-- Unleash URL. The proxy requires that you specify an Unleash URL to the upstream server, in the format https://{unleashUrl}/api. Edge has changed this, the URL that Edge requires is https://{unleashUrl}, without the `/api` suffix.
+- Unleash URL. The proxy requires that you specify an Unleash URL to the upstream server, in the format https:
+  //{unleashUrl}/api. Edge has changed this, the URL that Edge requires is https://{unleashUrl}, without the `/api`
+  suffix.
 
-- Backend SDK support. The proxy does support connecting to backend SDKs, but it requires some configuration and setting some experimental feature flags. Edge supports this out the box, no additional configuration is required.
-
+- Backend SDK support. The proxy does support connecting to backend SDKs, but it requires some configuration and setting
+  some experimental feature flags. Edge supports this out the box, no additional configuration is required.
 
 ## New features
 
-- Offline mode. Edge can be used in a purely offline mode. While the proxy does support this, it requires a little work to get there. Edge, on the other hand, supports this directly and out the box. This can be useful for testing or development environments where you don't want to have to run an Unleash instance or want to freeze your configuration in place. Example run command:
+- Offline mode. Edge can be used in a purely offline mode. While the proxy does support this, it requires a little work
+  to get there. Edge, on the other hand, supports this directly and out the box. This can be useful for testing or
+  development environments where you don't want to have to run an Unleash instance or want to freeze your configuration
+  in place. Example run command:
 
     ``` sh
     ./edge offline --tokens "*.development.some-test-token"  --bootstrap-file ./examples/features.json
     ```
 
-    This will start Edge in offline mode and set the initial feature set to the contents of the `features.json` file. Edge will not send metrics to upstream Unleash instances, update its feature information, or dynamically resolve tokens. Note that you must set a token or tokens on startup in this mode - Edge will only use this set of tokens to validate incoming requests, this doesn't have to be a valid Unleash token, so this is very similar to the original proxy tokens.
+  This will start Edge in offline mode and set the initial feature set to the contents of the `features.json` file. Edge
+  will not send metrics to upstream Unleash instances, update its feature information, or dynamically resolve tokens.
+  Note that you must set a token or tokens on startup in this mode - Edge will only use this set of tokens to validate
+  incoming requests, this doesn't have to be a valid Unleash token, so this is very similar to the original proxy
+  tokens.
 
-- Daisy chaining. Edge is capable of both mimicking an Unleash server and talking to an Unleash server. This means that Edge can use another Edge instance as another upstream source. This can be extremely useful for high scaling scenarios where you can have a single instance close to your SDKs that retrieves all toggles for all projects and environments and specific Edge instances syncing to the parent Edge instance, with much more narrowly defined API tokens for security reasons. No extra configuration is needed to achieve this, simply point the downstream Edge instance at the upstream Edge instance and it will automatically resolve the tokens and features from the upstream Edge instance. Metrics will propagate up the daisy chain from downstream Edge instances to upstream instances until the metrics hit the end of the chain. There are two important details you need to be aware of when using daisy chaining with a top level instance in offline mode. Firstly, you won't receive any metrics for your connected SDKs - the metrics will propagate all the way to the final offline instance in the chain and then be discarded. Secondly, the top level instance needs to be started with all the API tokens necessary to serve downstream SDK requests.
+- Daisy chaining. Edge is capable of both mimicking an Unleash server and talking to an Unleash server. This means that
+  Edge can use another Edge instance as another upstream source. This can be extremely useful for high scaling scenarios
+  where you can have a single instance close to your SDKs that retrieves all toggles for all projects and environments
+  and specific Edge instances syncing to the parent Edge instance, with much more narrowly defined API tokens for
+  security reasons. No extra configuration is needed to achieve this, simply point the downstream Edge instance at the
+  upstream Edge instance and it will automatically resolve the tokens and features from the upstream Edge instance.
+  Metrics will propagate up the daisy chain from downstream Edge instances to upstream instances until the metrics hit
+  the end of the chain. There are two important details you need to be aware of when using daisy chaining with a top
+  level instance in offline mode. Firstly, you won't receive any metrics for your connected SDKs - the metrics will
+  propagate all the way to the final offline instance in the chain and then be discarded. Secondly, the top level
+  instance needs to be started with all the API tokens necessary to serve downstream SDK requests.
+
+## Why choose Unleash Edge over the Unleash Proxy?
+
+Edge offers a superset of the same feature set as the Unleash Proxy and we've made sure it offers the same security and
+privacy features.
+
+However, there are a few notable differences between the Unleash Proxy and Unleash Edge:
+
+- Unleash Edge is built to be light and fast, it handles an order of magnitude more requests per second than the Unleash
+  Proxy can, while using two orders of magnitude less memory.
+- All your Unleash environments can be handled by a single instance, no more running multiple instances of the Unleash
+  Proxy to handle both your development and production environments.
+- Backend SDKs can connect to Unleash Edge without turning on experimental feature flags.
+- Unleash Edge is smart enough to dynamically resolve the tokens you use to connect to it against the upstream Unleash
+  instance. This means you don't have to worry about knowing in advance what tokens your SDKs use - if you want to swap
+  out the Unleash token your SDK uses, this can be done without ever restarting or worrying about Unleash Edge. Unleash
+  Edge will only collect and cache data for the environments and projects you use.

--- a/server/README.md
+++ b/server/README.md
@@ -32,110 +32,20 @@ Unleash Edge is built to help you scale Unleash.
 
 ## Migrating to Edge from the Proxy
 
-For more info on migrating, check out the [migration guide](./migration-guide.md) that details the differences between
+For more info on migrating, check out the [migration guide](../migration-guide.md) that details the differences between
 Edge and the Proxy and how to achieve similar behavior in Edge.
 
-## Running Unleash Edge
+## Quickstart
 
-Unleash Edge is compiled to a single binary. You can configure it by passing in arguments or setting environment
-variables.
-
-```shell
-Usage: unleash-edge [OPTIONS] <COMMAND>
-
-Commands:
-  edge     Run in edge mode
-  offline  Run in offline mode
-  help     Print this message or the help of the given subcommand(s)
-
-Options:
-  -p, --port <PORT>
-          Which port should this server listen for HTTP traffic on [env: PORT=] [default: 3063]
-  -i, --interface <INTERFACE>
-          Which interfaces should this server listen for HTTP traffic on [env: INTERFACE=] [default: 0.0.0.0]
-  -b, --base-path <BASE_PATH>
-          Which base path should this server listen for HTTP traffic on [env: BASE_PATH=] [default: ]
-  -w, --workers <WORKERS>
-          How many workers should be started to handle requests. Defaults to number of physical cpus [env: WORKERS=] [default: number of physical cpus]
-      --tls-enable
-          Should we bind TLS [env: TLS_ENABLE=]
-      --tls-server-key <TLS_SERVER_KEY>
-          Server key to use for TLS [env: TLS_SERVER_KEY=] (Needs to be a path to a file)
-      --tls-server-cert <TLS_SERVER_CERT>
-          Server Cert to use for TLS [env: TLS_SERVER_CERT=] (Needs to be a path to a file)
-      --tls-server-port <TLS_SERVER_PORT>
-          Port to listen for https connection on (will use the interfaces already defined) [env: TLS_SERVER_PORT=] [default: 3043]
-      --instance-id <INSTANCE_ID>
-          Instance id. Used for metrics reporting [env: INSTANCE_ID=] [default: Ulid::new()]
-  -a, --app-name <APP_NAME>
-          App name. Used for metrics reporting [env: APP_NAME=] [default: unleash-edge]
-  -h, --help
-          Print help
-  -l, --log-format <LOG_FORMAT>
-        Which log format should Edge use
-      [env: LOG_FORMAT=]
-        [default: `plain`]
-      Possible values: `plain`, `json`, `pretty`
-  --token-header <TOKEN_HEADER>
-      token header to use for edge authorization [env: TOKEN_HEADER=] [default: Authorization]
-```
-
-### Built-in Health check
-
-There is now (from 5.1.0) a subcommand named `health` which will ping your health endpoint and exit with status 0
-provided the health endpoint returns 200 OK.
-
-Example:
+Running Edge in docker with recommended setup
 
 ```shell
-./unleash-edge health
+docker run -it -p 3063:3063 -e STRICT=true -e UPSTREAM_URL=<yourunleashinstance> unleashorg/unleash-edge:<mostrecentversion> edge
 ```
 
-will check an Edge process running on http://localhost:3063. If you're using base-path or the port variable you should
-use the `-e --edge-url` CLI arg (or the EDGE_URL environment variable) to tell the health checker where edge is running.
+## Deploying Unleash Edge
 
-If you're hosting Edge with a self-signed certificate using the tls cli arguments, you should use
-the `--ca-certificate-file <file_containing_your_ca_and_key_in_pem_format>` flag (or the CA_CERTIFICATE_FILE environment
-variable) to allow the health checker to trust the self signed certificate.
-
-### Built-in Ready check
-
-There is now (from 12.0.0) a subcommand named `ready` which will ping your ready endpoint and exit with status 0
-provided the ready endpoint returns 200 OK and `{ status: "READY" }`. Otherwise it will return status 1 and an error
-message to signal that Edge is not ready (it has not spoken to upstream or recovered from a persisted backup).
-
-Examples:
-
-* Edge not running:
-
-```shell
-$ ./unleash-edge ready
-Error: Failed to connect to ready endpoint at http://localhost:3063/internal-backstage/ready. Failed with status None
-$ echo $?
-1
-```
-
-* Edge running but not populated its feature cache yet (not spoken to upstream or restored from backup)
-
-```shell
-$ ./unleash-edge ready
-Error: Ready check returned a different status than READY. It returned EdgeStatus { status: NotReady }
-$ echo $?
-1
-```
-
-* Edge running and synchronized. I.e. READY
-
-```shell
-$ ./unleash-edge ready
-OK
-$ echo $?
-0
-```
-
-If you're hosting Edge with a self-signed certificate using the tls cli arguments, you should use
-the `--ca-certificate-file <file_containing_your_ca_and_key_in_pem_format>` flag (or the CA_CERTIFICATE_FILE environment
-variable) to allow the health checker to trust the self signed certificate.
+See our page on [Deploying Edge](../docs/deploying.md)
 
 ## Getting Unleash Edge
 
@@ -165,198 +75,11 @@ Unleash Edge is distributed as a binary and as a docker image.
 If you have the [Rust toolchain](https://rustup.rs) installed you can build a binary for the platform you're running by
 cloning this repo and running `cargo build --release`. This will give you an `unleash-edge` binary in `./target/release`
 
-## Concepts
+## Concepts (see [Concepts](../docs/concepts.md))
 
-### Modes
+## Metrics
 
-Edge currently supports 2 different modes:
-
-- [Edge](#edge) - Connection to upstream node (Unleash instance or another Edge). Supports dynamic tokens, metrics and
-  other advanced features;
-- [Offline](#offline) - No connection to upstream node. Full control of data and tokens;
-
-#### Edge
-
-```mermaid
-graph LR
-  A(Client) -->|Fetch toggles| B((Edge))
-  B-->|Fetch toggles| C((Unleash))
-```
-
-Edge mode is the "standard" mode for Unleash Edge and the one you should default to in most cases. It connects to an
-upstream node, such as your Unleash instance, and uses that as the source of truth for feature toggles.
-
-Other than connecting Edge directly to your Unleash instance, it's also possible to connect to another Edge instance (
-_daisy chaining_). You can have as many Edge nodes as you'd like between the Edge node your clients are accessing and
-the Unleash server, and it's also possible for multiple nodes to connect to a single upstream one. Depending on your
-architecture and requirements this can be a powerful feature, offering you flexibility and scalability when planning
-your implementation.
-
-```mermaid
-graph LR
-  A(Client 1) -->|Fetch toggles| C((Edge 1))
-  B(Client 2) -->|Fetch toggles| D((Edge 2))
-  C-->|Fetch toggles| E((Edge 3))
-  D-->|Fetch toggles| E
-  E-->|Fetch toggles| F((Unleash))
-```
-
-This means that, in order to start up, Edge mode needs to know where the upstream node is. This is done by passing
-the `--upstream-url` command line argument or setting the `UPSTREAM_URL` environment variable.
-
-By default, Edge mode uses an in-memory cache to store the features it fetches from the upstream node. However, you may
-want to use a more persistent storage solution. For this purpose, Edge supports either Redis or a backup file, which you
-can configure by passing in either the `--redis-url` or `--backup_folder` command line argument, respectively. On
-start-up, Edge checks whether the persistent backup option is specified, in which case it uses it to populate its
-internal caches. This can be useful when your Unleash server is unreachable.
-
-Persistent storage is useful for high availability and resilience. If an Edge instance using persistent storage is
-restarted, it will not have to synchronize with upstream before it is ready. The persistent storage is only read on
-startup and will only be used until Edge is able to synchronize with upstream. Because of this, there is no need to
-purge the cache. After Edge has synchronized with an upstream, it will periodically save its in-memory state to the
-persistent storage.
-
-Multiple Edge nodes can share the same Redis instance or backup folder. Failure to read from persistent storage will not
-prevent Edge from starting up. In this case an Edge instance will be ready only after it is able to connect with
-upstream.
-
-Edge mode also supports dynamic tokens, meaning that Edge doesn't need a token to be provided when starting up. Once we
-make a request to the `/api/client/features` endpoint using
-a [client token](https://docs.getunleash.io/reference/api-tokens-and-client-keys#client-tokens) Edge will validate
-upstream and fetch its respective features. After that, it gets added to the list of known tokens that gets periodically
-synced, making sure it is a valid token and its features are up-to-date.
-
-Even though Edge supports dynamic tokens, you still have the option of providing a token through the command line
-argument or environment variable. This way, since Edge already knows about your token at start up, it will sync your
-features for that token and should be ready for your requests right away (_warm up / hot start_).
-
-### Front-end tokens
-
-[Front-end tokens](https://docs.getunleash.io/reference/api-tokens-and-client-keys#front-end-tokens) can also be used
-with `/api/frontend` and `/api/proxy` endpoints, however they are not allowed to fetch features upstream.
-In order to use these tokens correctly and make sure they return the correct information, it's important that the
-features they are allowed to access are already present in that Edge node's features cache.
-The easiest way to ensure this is by passing in at least one client token as one of the command line arguments,
-ensuring it has access to the same features as the front-end token you'll be using.
-If you're using a frontend token that doesn't have data in the node's feature cache, you will receive an HTTP Status
-code: 511 Network Authentication Required along with a body of which project and environment you will need to add a
-client token for.
-
-### Starting in edge mode
-
-To see parameters available when running in this mode, run:
-
-```bash
-$ unleash-edge edge -h
-Run in edge mode
-
-Usage: unleash-edge edge [OPTIONS] --upstream-url <UPSTREAM_URL>
-
-Options:
-  -u, --upstream-url <UPSTREAM_URL>
-          Where is your upstream URL. Remember, this is the URL to your instance, without any trailing /api suffix [env: UPSTREAM_URL=]
-  -r, --redis-url <REDIS_URL>
-          A URL pointing to a running Redis instance. Edge will use this instance to persist feature and token data and read this back after restart. Mutually exclusive with the --backup-folder option [env: REDIS_URL=]
-  -b, --backup-folder <BACKUP_FOLDER>
-          A path to a local folder. Edge will write feature and token data to disk in this folder and read this back after restart. Mutually exclusive with the --redis-url option [env: BACKUP_FOLDER=]
-  -m, --metrics-interval-seconds <METRICS_INTERVAL_SECONDS>
-          How often should we post metrics upstream? [env: METRICS_INTERVAL_SECONDS=] [default: 60]
-  -f, --features-refresh-interval-seconds <FEATURES_REFRESH_INTERVAL_SECONDS>
-          How long between each refresh for a token [env: FEATURES_REFRESH_INTERVAL_SECONDS=] [default: 10]
-      --token-revalidation-interval-seconds <TOKEN_REVALIDATION_INTERVAL_SECONDS>
-          How long between each revalidation of a token [env: TOKEN_REVALIDATION_INTERVAL_SECONDS=] [default: 3600]
-  -t, --tokens <TOKENS>
-          Get data for these client tokens at startup. Accepts comma-separated list of tokens. Hot starts your feature cache [env: TOKENS=]
-  -H, --custom-client-headers <CUSTOM_CLIENT_HEADERS>
-          Expects curl header format (-H <HEADERNAME>: <HEADERVALUE>) for instance `-H X-Api-Key: mysecretapikey` [env: CUSTOM_CLIENT_HEADERS=]
-  -s, --skip-ssl-verification
-          If set to true, we will skip SSL verification when connecting to the upstream Unleash server [env: SKIP_SSL_VERIFICATION=]
-      --pkcs8-client-certificate-file <PKCS8_CLIENT_CERTIFICATE_FILE>
-          Client certificate chain in PEM encoded X509 format with the leaf certificate first. The certificate chain should contain any intermediate certificates that should be sent to clients to allow them to build a chain to a trusted root [env: PKCS8_CLIENT_CERTIFICATE_FILE=]
-      --pkcs8-client-key-file <PKCS8_CLIENT_KEY_FILE>
-          Client key is a PEM encoded PKCS#8 formatted private key for the leaf certificate [env: PKCS8_CLIENT_KEY_FILE=]
-      --pkcs12-identity-file <PKCS12_IDENTITY_FILE>
-          Identity file in pkcs12 format. Typically this file has a pfx extension [env: PKCS12_IDENTITY_FILE=]
-      --pkcs12-passphrase <PKCS12_PASSPHRASE>
-          Passphrase used to unlock the pkcs12 file [env: PKCS12_PASSPHRASE=]
-      --upstream-certificate-file <UPSTREAM_CERTIFICATE_FILE>
-          Extra certificate passed to the client for building its trust chain. Needs to be in PEM format (crt or pem extensions usually are) [env: UPSTREAM_CERTIFICATE_FILE=]
-
-  -h, --help
-          Print help
-
-```
-
-#### Offline
-
-```mermaid
-graph LR
-  A(Client) -->|Fetch toggles| B((Edge))
-  B-->|Fetch toggles| C[Features dump]
-```
-
-Offline mode is useful when there is no connection to an upstream node, such as your Unleash instance or another Edge
-instance, or as a tool to make working with Unleash easier during development.
-
-To use offline mode, you'll need a features file. The easiest way to get one is to download a JSON dump of a result from
-a query against an Unleash server on
-the [/api/client/features](https://docs.getunleash.io/reference/api/unleash/get-client-feature) endpoint. You can also
-use a hand rolled, human readable JSON version of the features file. Edge will automatically convert it to the API
-format when it starts up. Here's an example:
-
-``` json
-{
-  "featureOne": {
-    "enabled": true,
-    "variant": "variantOne"
-  },
-  "featureTwo": {
-    "enabled": false,
-    "variant": "variantTwo"
-  },
-  "featureThree": {
-    "enabled": true
-  }
-}
-```
-
-The simplified JSON format should be an object with a key for each feature. You can force the result of `is_enabled` in
-your SDK by setting the enabled property, likewise can also force the result of `get_variant` by specifying the name of
-the variant you want. This format is primarily for development.
-
-When using offline mode you must specify one or more tokens at startup. These tokens will let your SDKs access Edge.
-Tokens following the Unleash API format `[project]:[environment].<somesecret>` allow Edge to recognize the project and
-environment specified in the token, returning only the relevant features to the calling SDK. On the other hand, for
-tokens not adhering to this format, Edge will return all features if there is an exact match with any of the startup
-tokens.
-
-To make local development easier, you can specify a reload interval in seconds (Since Unleash-Edge 10.0.x); this will
-cause Edge to reload the features file from disk every X seconds. This can be useful for local development.
-
-Since offline mode does not connect to an upstream node, it does not support metrics or dynamic tokens.
-
-To launch in this mode, run:
-
-```bash
-$ ./unleash-edge offline --help
-Usage: unleash-edge offline [OPTIONS]
-
-Options:
-  -b, --bootstrap-file <BOOTSTRAP_FILE>         [env: BOOTSTRAP_FILE=]
-  -t, --tokens <TOKENS>                         [env: TOKENS=]
-  -r, --reload-interval <RELOAD_INTERVAL>       [env: RELOAD_INTERVAL=]
-
-```
-
-##### Environments in offline mode
-
-Currently, Edge does not support multiple environments in offline mode. All tokens added at startup will receive the
-same list of features passed in as the bootstrap argument.
-However, tokens in `<project>:<environment>.<secret>` format will still filter by project.
-
-## [Metrics](https://docs.getunleash.io/reference/api/unleash/metrics)
-
-**❗ Note:** For Edge to correctly register SDK usage metrics, your Unleash instance must be v5.9.0.
+**❗ Note:** For Edge to correctly register SDK usage metrics, your Unleash instance must be v5.9.0 or newer.
 **! Note:** If you're daisy chaining you will need at least Edge 17.0.0 upstream of any Edge 19.0.0 to preserve metrics.
 
 Since Edge is designed to avoid overloading its upstream, Edge gathers and accumulates usage metrics from SDKs for a set
@@ -374,87 +97,7 @@ minor and patch versions), could potentially break your implementation.
 
 ## Performance
 
-Unleash Edge will scale linearly with CPU. There are k6 benchmarks in the benchmark folder. We've already got some
-initial numbers from [hey](https://github.com/rakyll/hey).
-
-Do note that the number of requests Edge can handle does depend on the total size of your toggle response. That is, Edge
-is faster if you only have 10 toggles with 1 strategy each, than it will be with 1000 toggles with multiple strategies
-on each. Benchmarks here were run with data fetched from the Unleash demo instance (roughly 100kB (350 features / 200
-strategies)) as well as against a small dataset of 5 features with one strategy on each.
-
-Edge was started using
-`docker run --cpus="<cpu>" --memory=128M -p 3063:3063 -e UPSTREAM_URL=<upstream> -e TOKENS="<client token>" unleashorg/unleash-edge:edge -w <number of cpus rounded up to closest integer> edge`
-
-Then we run hey against the proxy endpoint, evaluating toggles
-
-### Large Dataset (350 features (100kB))
-
-```shell
-$ hey -z 10s -H "Authorization: <frontend token>" http://localhost:3063/api/frontend`
-```
-
-| CPU | Memory | RPS   | Endpoint      | p95   | Data transferred |
-|-----|--------|-------|---------------|-------|------------------|
-| 0.1 | 6.7 Mi | 600   | /api/frontend | 103ms | 76Mi             |
-| 1   | 6.7 Mi | 6900  | /api/frontend | 7.4ms | 866Mi            |
-| 4   | 9.5    | 25300 | /api/frontend | 2.4ms | 3.2Gi            |
-| 8   | 15     | 40921 | /api/frontend | 1.6ms | 5.26Gi           |
-
-and against our client features endpoint.
-
-```shell
-$ hey -z 10s -H "Authorization: <client token>" http://localhost:3063/api/client/features
-```
-
-| CPU | Memory observed | RPS   | Endpoint             | p95   | Data transferred |
-|-----|-----------------|-------|----------------------|-------|------------------|
-| 0.1 | 11 Mi           | 309   | /api/client/features | 199ms | 300 Mi           |
-| 1   | 11 Mi           | 3236  | /api/client/features | 16ms  | 3 Gi             |
-| 4   | 11 Mi           | 12815 | /api/client/features | 4.5ms | 14 Gi            |
-| 8   | 17 Mi           | 23207 | /api/client/features | 2.7ms | 26 Gi            |
-
-### Small Dataset (5 features (2kB))
-
-```shell
-$ hey -z 10s -H "Authorization: <frontend token>" http://localhost:3063/api/frontend`
-```
-
-| CPU | Memory  | RPS    | Endpoint      | p95   | Data transferred |
-|-----|---------|--------|---------------|-------|------------------|
-| 0.1 | 4.3 Mi  | 3673   | /api/frontend | 93ms  | 9Mi              |
-| 1   | 6.7 Mi  | 39000  | /api/frontend | 1.6ms | 80Mi             |
-| 4   | 6.9 Mi  | 100020 | /api/frontend | 600μs | 252Mi            |
-| 8   | 12.5 Mi | 141090 | /api/frontend | 600μs | 324Mi            |
-
-and against our client features endpoint.
-
-```shell
-$ hey -z 10s -H "Authorization: <client token>" http://localhost:3063/api/client/features
-```
-
-| CPU | Memory observed | RPS    | Endpoint             | p95   | Data transferred |
-|-----|-----------------|--------|----------------------|-------|------------------|
-| 0.1 | 4 Mi            | 3298   | /api/client/features | 92ms  | 64 Mi            |
-| 1   | 4 Mi            | 32360  | /api/client/features | 2ms   | 527Mi            |
-| 4   | 11 Mi           | 95838  | /api/client/features | 600μs | 2.13 Gi          |
-| 8   | 17 Mi           | 129381 | /api/client/features | 490μs | 2.87 Gi          |
-
-## Why choose Unleash Edge over the Unleash Proxy?
-
-Edge offers a superset of the same feature set as the Unleash Proxy and we've made sure it offers the same security and
-privacy features.
-
-However, there are a few notable differences between the Unleash Proxy and Unleash Edge:
-
-- Unleash Edge is built to be light and fast, it handles an order of magnitude more requests per second than the Unleash
-  Proxy can, while using two orders of magnitude less memory.
-- All your Unleash environments can be handled by a single instance, no more running multiple instances of the Unleash
-  Proxy to handle both your development and production environments.
-- Backend SDKs can connect to Unleash Edge without turning on experimental feature flags.
-- Unleash Edge is smart enough to dynamically resolve the tokens you use to connect to it against the upstream Unleash
-  instance. This means you don't have to worry about knowing in advance what tokens your SDKs use - if you want to swap
-  out the Unleash token your SDK uses, this can be done without ever restarting or worrying about Unleash Edge. Unleash
-  Edge will only collect and cache data for the environments and projects you use.
+See [Benchmarking](../docs/benchmarking.md)
 
 ## Debugging
 
@@ -473,9 +116,12 @@ See more about available logging and log levels at https://docs.rs/env_logger/la
 ### Missing metrics in upstream server
 
 #### Possible reasons
-- Old edge version. In order to guarantee metrics on newer Unleash versions, you will need to be using Edge v17.0.0 or newer
-- Old SDK clients. We've seen some clients, particularly early Python (1.x branch) as well as earlier .NET SDKs (we recommend you use 4.1.5 or newer) struggle to post metrics with the strict headers Edge requires.
+
+- Old edge version. In order to guarantee metrics on newer Unleash versions, you will need to be using Edge v17.0.0 or
+  newer
+- Old SDK clients. We've seen some clients, particularly early Python (1.x branch) as well as earlier .NET SDKs (we
+  recommend you use 4.1.5 or newer) struggle to post metrics with the strict headers Edge requires.
 
 ## Development
 
-See our [Contributors guide](./CONTRIBUTING.md) as well as our [development-guide](./development-guide.md)
+See our [Contributors guide](../CONTRIBUTING.md) as well as our [development-guide](../development-guide.md)

--- a/server/README.md
+++ b/server/README.md
@@ -40,7 +40,7 @@ Edge and the Proxy and how to achieve similar behavior in Edge.
 Running Edge in docker with recommended setup
 
 ```shell
-docker run -it -p 3063:3063 -e STRICT=true -e UPSTREAM_URL=<yourunleashinstance> unleashorg/unleash-edge:<mostrecentversion> edge
+docker run -it -p 3063:3063 -e STRICT=true -e TOKENS=<comma separated list of tokens edge should use to authenticate and poll upstream> -e UPSTREAM_URL=<yourunleashinstance> unleashorg/unleash-edge:<mostrecentversion> edge
 ```
 
 ## Deploying Unleash Edge

--- a/server/README.md
+++ b/server/README.md
@@ -3,7 +3,7 @@
 [![crates.io](https://img.shields.io/crates/v/unleash-edge?label=latest)](https://crates.io/crates/unleash-edge)
 [![Documentation](https://docs.rs/unleash-edge/badge.svg?version=latest)](https://docs.rs/unleash-edge/latest)
 ![MIT licensed](https://img.shields.io/crates/l/unleash-edge.svg)
-[![Dependency Status](https://deps.rs/crate/unleash-edge/19.1.3/status.svg)](https://deps.rs/crate/unleash-edge/19.1.3)
+[![Dependency Status](https://deps.rs/crate/unleash-edge/19.2.0/status.svg)](https://deps.rs/crate/unleash-edge/19.2.0)
 [![CI](https://github.com/Unleash/unleash-edge/actions/workflows/test-with-coverage.yaml/badge.svg)](https://github.com/Unleash/unleash-edge/actions/workflows/test-with-coverage.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/Unleash/unleash-edge/badge.svg?branch=main)](https://coveralls.io/github/Unleash/unleash-edge?branch=main)
 ![downloads](https://img.shields.io/crates/d/unleash-edge.svg)


### PR DESCRIPTION
Start of the work with regards to making our README the one-stop shop to understand how to run Edge. Moving deployment, concepts, migration and other details into separate files to keep README concise and easy to read.