### PR TITLE
chore: add deprecation logs for dynamic behavior

### DIFF
--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -178,6 +178,10 @@ pub struct EdgeArgs {
     /// If set to true, Edge starts with strict behavior. Strict behavior means that Edge will refuse tokens outside of the scope of the startup tokens
     #[clap(long, env, default_value_t = false)]
     pub strict: bool,
+
+    /// If set to true, Edge starts with dynamic behavior. Dynamic behavior means that Edge will accept tokens outside of the scope of the startup tokens
+    #[clap(long, env, default_value_t = false, conflicts_with = "strict")]
+    pub dynamic: bool,
 }
 
 pub fn string_to_header_tuple(s: &str) -> Result<(String, String), String> {


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2385/add-deprecation-logs-to-dynamic-behavior

Adds deprecation logs for dynamic behavior.

This should cover phase 1 of our [migration plan](https://linear.app/unleash/document/migration-plan-b3d7f35abc4e)

No explicit behavior:
![image](https://github.com/Unleash/unleash-edge/assets/14320932/8616e1e8-951c-4827-9bc1-4e13896fb5e1)

Explicitly dynamic:
![image](https://github.com/Unleash/unleash-edge/assets/14320932/cf1dc8ab-9c99-41ce-be2a-1b0559abbe55)

Explicitly strict:
![image](https://github.com/Unleash/unleash-edge/assets/14320932/f0dcc1c0-5579-4aa8-8c46-c07119488524)