### PR TITLE
fix: add timeout for redis read and write ops.

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -27,7 +27,6 @@ actix-middleware-etag = "0.3.0"
 actix-service = "2.0.2"
 actix-web = { version = "4.5.1", features = ["rustls-0_22", "compress-zstd"] }
 ahash = "0.8.10"
-
 anyhow = "1.0.80"
 async-trait = "0.1.80"
 chrono = { version = "0.4.38", features = ["serde"] }
@@ -53,7 +52,11 @@ opentelemetry_sdk = { version = "0.21.2", features = [
 prometheus = { version = "0.13.4", features = ["process"] }
 prometheus-static-metric = "0.5.1"
 rand = "0.8.5"
-redis = { version = "0.25.3", features = ["tokio-comp", "tokio-rustls-comp", "cluster"] }
+redis = { version = "0.25.3", features = [
+    "tokio-comp",
+    "tokio-rustls-comp",
+    "cluster",
+] }
 reqwest = { version = "0.11.27", default-features = false, features = [
     "rustls",
     "json",

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -2,6 +2,7 @@ use std::fmt::{Display, Formatter};
 use std::net::IpAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::time::Duration;
 
 use cidr::{Ipv4Cidr, Ipv6Cidr};
 use clap::{ArgGroup, Args, Parser, Subcommand, ValueEnum};
@@ -67,6 +68,12 @@ pub struct RedisArgs {
     pub redis_secure: bool,
     #[clap(long, env, default_value_t = RedisScheme::Redis, value_enum)]
     pub redis_scheme: RedisScheme,
+    /// Timeout (in milliseconds) for waiting for a successful connection to redis, when restoring
+    #[clap(long, env, default_value_t = 2000)]
+    pub redis_read_connection_timeout_milliseconds: u64,
+    /// Timeout (in milliseconds) for waiting for a successful connection to redis when persisting
+    #[clap(long, env, default_value_t = 2000)]
+    pub redis_write_connection_timeout_milliseconds: u64,
 }
 
 impl RedisArgs {
@@ -96,6 +103,12 @@ impl RedisArgs {
                 }
                 base_url
         }).map(|f| f.to_string())
+    }
+    pub fn read_timeout(&self) -> std::time::Duration {
+        Duration::from_millis(self.redis_read_connection_timeout_milliseconds)
+    }
+    pub fn write_timeout(&self) -> std::time::Duration {
+        Duration::from_millis(self.redis_write_connection_timeout_milliseconds)
     }
 }
 #[derive(Args, Debug, Clone)]

--- a/server/tests/redis_test.rs
+++ b/server/tests/redis_test.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{str::FromStr, time::Duration};
 
 use redis::Client;
 use testcontainers::runners::AsyncRunner;
@@ -11,6 +11,8 @@ use unleash_edge::{
     types::{EdgeToken, TokenType},
 };
 
+const TEST_TIMEOUT: Duration = std::time::Duration::from_millis(1000);
+
 async fn setup_redis() -> (Client, String, ContainerAsync<Redis>) {
     let node = Redis.start().await;
     let host_port = node.get_host_port_ipv4(6379).await;
@@ -22,7 +24,7 @@ async fn setup_redis() -> (Client, String, ContainerAsync<Redis>) {
 #[tokio::test]
 async fn redis_saves_and_restores_features_correctly() {
     let (_client, url, _node) = setup_redis().await;
-    let redis_persister = RedisPersister::new(&url).unwrap();
+    let redis_persister = RedisPersister::new(&url, TEST_TIMEOUT, TEST_TIMEOUT).unwrap();
 
     let features = ClientFeatures {
         features: vec![ClientFeature {
@@ -45,7 +47,7 @@ async fn redis_saves_and_restores_features_correctly() {
 #[tokio::test]
 async fn redis_saves_and_restores_edge_tokens_correctly() {
     let (_client, url, _node) = setup_redis().await;
-    let redis_persister = RedisPersister::new(&url).unwrap();
+    let redis_persister = RedisPersister::new(&url, TEST_TIMEOUT, TEST_TIMEOUT).unwrap();
     let mut project_specific_token =
         EdgeToken::from_str("someproject:development.abcdefghijklmnopqr").unwrap();
     project_specific_token.token_type = Some(TokenType::Client);


### PR DESCRIPTION
Previously, if you gave us a redis url that was valid, but used the wrong protocol (so rediss when connecting to insecure, or redis when connecting to secure), operations against Redis got stuck. This PR adds a timeout setting (setting it to default of 2000 ms, but configurable).

This does add time when url is completely invalid (i.e. there's nothing listening), but it prevents the client from getting stuck indefinitely if something answers, but redis can't get an answer.