### PR TITLE
fix: Update docker image to use the nonroot tag of distroless

### DIFF
--- a/Dockerfile.publish
+++ b/Dockerfile.publish
@@ -1,8 +1,8 @@
 # FINAL arch images
-FROM --platform=amd64 gcr.io/distroless/cc-debian12 as final-amd64
+FROM --platform=amd64 gcr.io/distroless/cc-debian12:nonroot as final-amd64
 COPY target/x86_64-unknown-linux-gnu/release/unleash-edge /unleash-edge
 
-FROM --platform=arm64 gcr.io/distroless/cc-debian11 as final-arm64
+FROM --platform=arm64 gcr.io/distroless/cc-debian11:nonroot as final-arm64
 COPY target/aarch64-unknown-linux-gnu/release/unleash-edge /unleash-edge
 
 # Final image


### PR DESCRIPTION
Fixes: #483 