### PR TITLE
feat: add debian 12 build file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
-*
+target
 !target/aarch64-unknown-linux-gnu/release/unleash-edge
 !target/x86_64-unknown-linux-gnu/release/unleash-edge

--- a/dockerfiles/Dockerfile.debian12
+++ b/dockerfiles/Dockerfile.debian12
@@ -1,0 +1,19 @@
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+WORKDIR /app
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+
+RUN cargo chef cook --release --recipe-path recipe.json
+
+COPY . . 
+RUN cargo build --release
+
+FROM debian:bookworm-slim AS runtime
+RUN apt update -y && apt install libssl-dev -y
+WORKDIR /app
+COPY --from=builder /app/target/release/unleash-edge /usr/local/bin
+ENTRYPOINT ["/usr/local/bin/unleash-edge"]


### PR DESCRIPTION
Also made the dockerignore file just ignore the target folder except for the binaries. Which will allow us to have a docker image that does the building.

The debian12 recipe uses cargo chef to have better layer caching, as well as debian:bookworm-slim as the base image for runtime, which is slightly bigger than distroless.

However, it does not build for both amd64 and aarch yet

Should help for #509 