### PR TITLE
Fix formatting to avoid JSX rendering bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Unleash Edge adheres to Semantic Versioning (SemVer) on the API and CLI layers. 
 You can view the internal state of Edge at:
 
 - `http://<your-edge-url>/internal-backstage/tokens`: Displays the tokens known to Edge.
--	`http://<your-edge-url>/internal-backstage/features`: Shows the current state of features.
+- `http://<your-edge-url>/internal-backstage/features`: Shows the current state of features.
 
 Note: The `/internal-backstage/*` endpoints should not be publicly accessible.
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,12 @@ Unleash Edge adheres to Semantic Versioning (SemVer) on the API and CLI layers. 
 
 ## Debugging
 
-You can inspect the internal state of edge by looking at http://<your-edge-url>/internal-backstage/tokens to see the tokens that edge knows about and  http://<your-edge-url>/internal-backstage/features to see the current state of features (note that `/internal-backstage/*` should not be exposed to the public).
+You can view the internal state of Edge at:
+
+- `http://<your-edge-url>/internal-backstage/tokens`: Displays the tokens known to Edge.
+-	`http://<your-edge-url>/internal-backstage/features`: Shows the current state of features.
+
+Note: The `/internal-backstage/*` endpoints should not be publicly accessible.
 
 To enable verbose logging, adjust the `RUST_LOG` environment variable. For example, to see logs originating directly from Edge but not its dependencies, you can raise the default log level from `error` to `warning` and set Edge to `debug`, like this:
 


### PR DESCRIPTION
## About the changes
A recent docs change on Edge [broke the docs build](https://github.com/Unleash/unleash/actions/runs/10737877321/job/29781703218?pr=8050). This PR fixes the formatting.

[Markdown deeplink to Debugging section](https://github.com/Unleash/unleash/actions/runs/10737877321/job/29781703218?pr=8050).
