### PR TITLE
feat: verbose error for instance urls with api suffix

### DIFF
--- a/server/src/http/unleash_client.rs
+++ b/server/src/http/unleash_client.rs
@@ -431,6 +431,13 @@ impl UnleashClient {
         &self,
         request: ValidateTokensRequest,
     ) -> EdgeResult<Vec<EdgeToken>> {
+        let check_api_suffix = || {
+            let base_url = self.urls.base_url.to_string();
+            if base_url.ends_with("/api") || base_url.ends_with("/api/") {
+                info!("Try passing the instance URL without '/api'.");
+            }
+        };
+
         let result = self
             .backing_client
             .post(self.urls.edge_validate_url.to_string())
@@ -440,6 +447,7 @@ impl UnleashClient {
             .await
             .map_err(|e| {
                 info!("Failed to validate tokens: [{e:?}]");
+                check_api_suffix();
                 EdgeError::EdgeTokenError
             })?;
         match result.status() {
@@ -473,6 +481,7 @@ impl UnleashClient {
                     self.urls.edge_validate_url.to_string(),
                     s
                 );
+                check_api_suffix();
                 Err(EdgeError::TokenValidationError(
                     reqwest::StatusCode::from_u16(s.as_u16()).unwrap(),
                 ))


### PR DESCRIPTION
## About the changes
In context of Edge, instance URL is easy to mistake with SDK API URL. This could've save me couple minutes of confusion.

```
WARN schedule_revalidation_of_startup_tokens: unleash_edge::http::unleash_client: Failed to validate tokens. Requested url: [https://sandbox.getunleash.io/enterprise/api/edge/validate]. Got status: 401
INFO schedule_revalidation_of_startup_tokens: unleash_edge::http::unleash_client: Try passing the instance URL without '/api'.
```

## Discussion points
- Do we want it as part of the warning instead?
