### PR TITLE
feat: added feature_toggle_usage_total counter

### DIFF
--- a/server/src/prom_metrics.rs
+++ b/server/src/prom_metrics.rs
@@ -138,6 +138,11 @@ fn register_custom_metrics(registry: &prometheus::Registry) {
             crate::http::unleash_client::UPSTREAM_VERSION.clone(),
         ))
         .unwrap();
+    registry
+        .register(Box::new(
+            crate::metrics::client_metrics::FEATURE_TOGGLE_USAGE_TOTAL.clone(),
+        ))
+        .unwrap();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This exposes the feature usage metrics Edge receives (and sends upstream). We might want to add a caveat in the docs that you shouldn't aggregate both Edge and Unleash data (Edge aggregates for you and sends upstream)

fixes: https://github.com/Unleash/unleash-edge/issues/469