### PR TITLE
fix: remove bucket creation in s3 persister

### DIFF
--- a/server/tests/s3_tests.rs
+++ b/server/tests/s3_tests.rs
@@ -53,6 +53,14 @@ mod s3_tests {
             .force_path_style(true)
             .build();
 
+        let client = s3::Client::from_conf(config.clone());
+        client
+            .create_bucket()
+            .bucket(bucket_name)
+            .send()
+            .await
+            .expect("Failed to setup S3 bucket pre test run");
+
         //hopefully we don't care, this should just work with localstack
         let persister = S3Persister::new_with_config(bucket_name, config);
 


### PR DESCRIPTION
Having the creation like this breaks buckets in regions other than us-east-1