### PR TITLE
feat: flush metrics on clean shutdown

### DIFF
--- a/server/src/http/background_send_metrics.rs
+++ b/server/src/http/background_send_metrics.rs
@@ -67,6 +67,37 @@ fn decide_where_to_post(
     }
 }
 
+pub async fn send_metrics_one_shot(
+    metrics_cache: Arc<MetricsCache>,
+    feature_refresher: Arc<FeatureRefresher>,
+) {
+    let envs = metrics_cache.get_metrics_by_environment();
+    for (env, batch) in envs.iter() {
+        let (use_new_endpoint, token) =
+            decide_where_to_post(env, feature_refresher.tokens_to_refresh.clone());
+        let batches = metrics_cache.get_appropriately_sized_env_batches(batch);
+        trace!("Posting {} batches for {env}", batches.len());
+        for batch in batches {
+            if !batch.applications.is_empty() || !batch.metrics.is_empty() {
+                let result = if use_new_endpoint {
+                    feature_refresher
+                        .unleash_client
+                        .send_bulk_metrics_to_client_endpoint(batch.clone(), &token)
+                        .await
+                } else {
+                    feature_refresher
+                        .unleash_client
+                        .send_batch_metrics(batch.clone())
+                        .await
+                };
+                if let Err(edge_error) = result {
+                    warn!("Shut down metrics flush failed with {edge_error:?}")
+                }
+            }
+        }
+    }
+}
+
 pub async fn send_metrics_task(
     metrics_cache: Arc<MetricsCache>,
     feature_refresher: Arc<FeatureRefresher>,


### PR DESCRIPTION
Flushes metrics to upstream on shutdown. Needs a bit of love and/or discussion before merge:

1) Be cool if this was tested by the same things that test the standard metrics send but I don't see those tests (currently tested by humans)
2) Is 5 parameters to a function too much? It feels like too much