### PR TITLE
feat: internal-backstage endpoints are disableable.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -66,6 +66,18 @@ This document contains the help content for the `unleash-edge` command-line prog
 * `--token-header <TOKEN_HEADER>` — token header to use for edge authorization
 
   Default value: `Authorization`
+* `--disable-metrics-batch-endpoint` — Disables /internal-backstage/metricsbatch endpoint
+
+   This endpoint shows the current cached client metrics
+* `--disable-metrics-endpoint` — Disables /internal-backstage/metrics endpoint
+
+   Typically used for prometheus scraping metrics.
+* `--disable-features-endpoint` — Disables /internal-backstage/features endpoint
+
+   Used to show current cached features across environments
+* `--disable-tokens-endpoint` — Disables /internal-backstage/tokens endpoint
+
+   Used to show tokens used to refresh feature caches, but also tokens already validated/invalidated against upstream
 
 
 
@@ -130,6 +142,7 @@ Run in edge mode
 * `--redis-write-connection-timeout-milliseconds <REDIS_WRITE_CONNECTION_TIMEOUT_MILLISECONDS>` — Timeout (in milliseconds) for waiting for a successful connection to redis when persisting
 
   Default value: `2000`
+* `--s3-bucket-name <S3_BUCKET_NAME>` — Bucket name to use for storing feature and token data
 * `--token-header <TOKEN_HEADER>` — Token header to use for both edge authorization and communication with the upstream server
 
   Default value: `Authorization`
@@ -139,6 +152,13 @@ Run in edge mode
 * `--dynamic` — If set to true, Edge starts with dynamic behavior. Dynamic behavior means that Edge will accept tokens outside the scope of the startup tokens
 
   Default value: `false`
+* `--prometheus-remote-write-url <PROMETHEUS_REMOTE_WRITE_URL>` — Sets a remote write url for prometheus metrics, if this is set, prometheus metrics will be written upstream
+* `--prometheus-push-interval <PROMETHEUS_PUSH_INTERVAL>` — Sets the interval for prometheus push metrics, only relevant if `prometheus_remote_write_url` is set. Defaults to 60 seconds
+
+  Default value: `60`
+* `--prometheus-username <PROMETHEUS_USERNAME>`
+* `--prometheus-password <PROMETHEUS_PASSWORD>`
+* `--prometheus-user-id <PROMETHEUS_USER_ID>`
 
 
 
@@ -196,3 +216,4 @@ Perform a ready check against a running edge instance
     This document was generated automatically by
     <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
 </i></small>
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,15 +2896,14 @@ dependencies = [
  "parking_lot",
  "procfs",
  "protobuf",
- "reqwest",
  "thiserror",
 ]
 
 [[package]]
 name = "prometheus-reqwest-remote-write"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048bf9b7b460e4ee902571219fee43afe4dc46a77f3beb095d53f36070fdf650"
+checksum = "c6da310719525cefd34f55a5ec472047b0e2d49d1c71281e7a5a85c14ff50a74"
 dependencies = [
  "prometheus",
  "prost",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -55,8 +55,8 @@ opentelemetry_sdk = { version = "0.24.0", features = [
     "serde_json",
     "logs",
 ] }
-prometheus = { version = "0.13.4", features = ["process", "push"] }
-prometheus-reqwest-remote-write = { version = "0.1.1" }
+prometheus = { version = "0.13.4", features = ["process"] }
+prometheus-reqwest-remote-write = { version = "0.2.1" }
 prometheus-static-metric = "0.5.1"
 rand = "0.8.5"
 redis = { version = "0.27.0", features = [

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -279,6 +279,30 @@ pub struct HealthCheckArgs {
 }
 
 #[derive(Args, Debug, Clone)]
+pub struct InternalBackstageArgs {
+    /// Disables /internal-backstage/metricsbatch endpoint
+    ///
+    /// This endpoint shows the current cached client metrics
+    #[clap(long, env, global = true)]
+    pub disable_metrics_batch_endpoint: bool,
+    /// Disables /internal-backstage/metrics endpoint
+    ///
+    /// Typically used for prometheus scraping metrics.
+    #[clap(long, env, global = true)]
+    pub disable_metrics_endpoint: bool,
+    /// Disables /internal-backstage/features endpoint
+    ///
+    /// Used to show current cached features across environments
+    #[clap(long, env, global = true)]
+    pub disable_features_endpoint: bool,
+    /// Disables /internal-backstage/tokens endpoint
+    ///
+    /// Used to show tokens used to refresh feature caches, but also tokens already validated/invalidated against upstream
+    #[clap(long, env, global = true)]
+    pub disable_tokens_endpoint: bool,
+}
+
+#[derive(Args, Debug, Clone)]
 pub struct TokenHeader {
     /// Token header to use for edge authorization.
     #[clap(long, env, global = true, default_value = "Authorization")]
@@ -350,6 +374,9 @@ pub struct CliArgs {
     /// token header to use for edge authorization.
     #[clap(long, env, global = true, default_value = "Authorization")]
     pub token_header: TokenHeader,
+
+    #[clap(flatten)]
+    pub internal_backstage: InternalBackstageArgs,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -56,6 +56,8 @@ async fn main() -> Result<(), anyhow::Error> {
         app_name: args.clone().app_name,
         instance_id: args.clone().instance_id,
     };
+    let app_name = args.app_name.clone();
+    let internal_backstage_args = args.internal_backstage.clone();
     let (
         (token_cache, features_cache, engine_cache),
         token_validator,
@@ -114,6 +116,7 @@ async fn main() -> Result<(), anyhow::Error> {
                     internal_backstage::configure_internal_backstage(
                         service_cfg,
                         metrics_handler.clone(),
+                        internal_backstage_args.clone(),
                     )
                 }))
                 .service(
@@ -169,7 +172,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 _ = validator.schedule_revalidation_of_startup_tokens(edge.tokens, lazy_feature_refresher) => {
                     tracing::info!("Token validator validation of startup tokens was unexpectedly shut down");
                 }
-                _ = metrics_pusher::prometheus_remote_write(prom_registry_for_write, edge.prometheus_remote_write_url, edge.prometheus_push_interval, edge.prometheus_username, edge.prometheus_password) => {
+                _ = metrics_pusher::prometheus_remote_write(prom_registry_for_write, edge.prometheus_remote_write_url, edge.prometheus_push_interval, edge.prometheus_username, edge.prometheus_password, app_name) => {
                     tracing::info!("Prometheus push unexpectedly shut down");
                 }
             }


### PR DESCRIPTION
Sensitive endpoint (tokens, features, metricsbatch, metrics) can now all be turned off with separate flags


Co-authored-by: Simon Hornby <liquidwicked64@gmail.com>