### PR TITLE
fix: added error if no tokens are valid when starting in strict mode

### DIFF
--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -285,6 +285,10 @@ async fn build_edge(args: &EdgeArgs, app_name: &str) -> EdgeResult<EdgeInfo> {
         .await;
     }
 
+    if args.strict && token_cache.is_empty() {
+        error!("You started Edge in strict mode, but Edge was not able to validate any of the tokens configured at startup");
+        return Err(EdgeError::NoTokens("No valid tokens was provided on startup. At least one valid token must be specified at startup when running in Strict mode".into()));
+    }
     for validated_token in token_cache
         .iter()
         .filter(|candidate| candidate.value().token_type == Some(TokenType::Client))


### PR DESCRIPTION
From conversations with customers, if you feed edge with invalid tokens in strict mode, edge will quietly reject the invalid tokens, but the initial check that we actually had tokens will succeed, so will happily continue running after rejecting the tokens.

This PR checks that have valid tokens after validating tokens on startup.