### PR TITLE
fix: bootstrap reload in offline mode.

### DIFF
--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -87,10 +87,6 @@ pub(crate) fn build_offline_mode(
     let edge_tokens: Vec<EdgeToken> = tokens
         .iter()
         .map(|token| EdgeToken::from_str(token).unwrap_or_else(|_| EdgeToken::offline_token(token)))
-        .map(|mut token| {
-            token.token_type = Some(TokenType::Client);
-            token
-        })
         .collect();
 
     let edge_client_tokens: Vec<EdgeToken> = client_tokens

--- a/server/src/http/unleash_client.rs
+++ b/server/src/http/unleash_client.rs
@@ -500,7 +500,6 @@ mod tests {
         http::header::EntityTag,
         web, App, HttpResponse,
     };
-    use capture_logger::{begin_capture, pop_captured};
     use chrono::Duration;
     use unleash_types::client_features::{ClientFeature, ClientFeatures};
 

--- a/server/src/internal_backstage.rs
+++ b/server/src/internal_backstage.rs
@@ -327,10 +327,12 @@ mod tests {
             token_cache: Arc::new(DashMap::default()),
             persistence: None,
         };
+        let token_cache: DashMap<String, EdgeToken> = DashMap::default();
         let app = test::init_service(
             App::new()
                 .app_data(web::Data::new(feature_refresher))
                 .app_data(web::Data::new(token_validator))
+                .app_data(web::Data::new(token_cache))
                 .service(web::scope("/internal-backstage").service(super::tokens)),
         )
         .await;

--- a/server/src/internal_backstage.rs
+++ b/server/src/internal_backstage.rs
@@ -65,10 +65,16 @@ pub async fn ready(
 
 #[get("/tokens")]
 pub async fn tokens(
-    feature_refresher: web::Data<FeatureRefresher>,
-    token_validator: web::Data<TokenValidator>,
+    token_cache: web::Data<DashMap<String, EdgeToken>>,
+    feature_refresher: Option<web::Data<FeatureRefresher>>,
+    token_validator: Option<web::Data<TokenValidator>>,
 ) -> EdgeJsonResult<TokenInfo> {
-    Ok(Json(get_token_info(feature_refresher, token_validator)))
+    match (feature_refresher, token_validator) {
+        (Some(feature_refresher), Some(token_validator)) => {
+            Ok(Json(get_token_info(feature_refresher, token_validator)))
+        }
+        _ => Ok(Json(get_offline_token_info(token_cache))),
+    }
 }
 
 fn get_token_info(
@@ -93,6 +99,18 @@ fn get_token_info(
     TokenInfo {
         token_refreshes: refreshes,
         token_validation_status,
+    }
+}
+
+fn get_offline_token_info(token_cache: web::Data<DashMap<String, EdgeToken>>) -> TokenInfo {
+    let edge_tokens: Vec<EdgeToken> = token_cache
+        .iter()
+        .map(|e| e.value().clone())
+        .map(|t| crate::tokens::anonymize_token(&t))
+        .collect();
+    TokenInfo {
+        token_refreshes: vec![],
+        token_validation_status: edge_tokens,
     }
 }
 

--- a/server/src/middleware/validate_token.rs
+++ b/server/src/middleware/validate_token.rs
@@ -14,7 +14,6 @@ pub async fn validate_token(
     req: ServiceRequest,
     srv: crate::middleware::as_async_middleware::Next<impl MessageBody + 'static>,
 ) -> Result<ServiceResponse<impl MessageBody>, actix_web::Error> {
-    trace!("Validating req: {}", req.path());
     let maybe_validator = req.app_data::<Data<TokenValidator>>();
     let token_cache = req
         .app_data::<Data<DashMap<String, EdgeToken>>>()
@@ -27,10 +26,8 @@ pub async fn validate_token(
             let res = match known_token.status {
                 TokenValidationStatus::Validated => match known_token.token_type {
                     Some(TokenType::Frontend) => {
-                        trace!("Got FE token validated {:?}", known_token);
                         if req.path().contains("/api/frontend") || req.path().contains("/api/proxy")
                         {
-                            trace!("Was allowed to access");
                             srv.call(req).await?.map_into_left_body()
                         } else {
                             req.into_response(HttpResponse::Forbidden().finish())
@@ -38,7 +35,6 @@ pub async fn validate_token(
                         }
                     }
                     Some(TokenType::Client) => {
-                        trace!("Got Client token validated {:?}", known_token);
                         if req.path().contains("/api/client") {
                             srv.call(req).await?.map_into_left_body()
                         } else {
@@ -61,7 +57,33 @@ pub async fn validate_token(
         }
         None => {
             let res = match token_cache.get(&token.token) {
-                Some(_) => srv.call(req).await?.map_into_left_body(),
+                Some(t) => {
+                    let token = t.value();
+                    match token.token_type {
+                        Some(TokenType::Client) => {
+                            if req.path().contains("/api/client") {
+                                srv.call(req).await?.map_into_left_body()
+                            } else {
+                                req.into_response(HttpResponse::Forbidden().finish())
+                                    .map_into_right_body()
+                            }
+                        }
+                        Some(TokenType::Frontend) => {
+                            if req.path().contains("/api/frontend")
+                                || req.path().contains("/api/proxy")
+                            {
+                                srv.call(req).await?.map_into_left_body()
+                            } else {
+                                req.into_response(HttpResponse::Forbidden().finish())
+                                    .map_into_right_body()
+                            }
+                        }
+                        None => srv.call(req).await?.map_into_left_body(),
+                        _ => req
+                            .into_response(HttpResponse::Forbidden().finish())
+                            .map_into_right_body(),
+                    }
+                }
                 None => req
                     .into_response(HttpResponse::Forbidden().finish())
                     .map_into_right_body(),

--- a/server/src/middleware/validate_token.rs
+++ b/server/src/middleware/validate_token.rs
@@ -7,7 +7,6 @@ use actix_web::{
     HttpResponse,
 };
 use dashmap::DashMap;
-use tracing::trace;
 
 pub async fn validate_token(
     token: EdgeToken,


### PR DESCRIPTION
After adding support for client and frontend tokens, we did not extend the reloader to check client and frontend token Vecs, this PR extends tokens with FE and Client tokens, to ensure that we refresh the data for all our tokens.

In addition we make /internal-backstage/tokens useful for offline mode as well, to at least be able to see which tokens you added to Edge.

In addition, since offline mode did not set up a token validator, I extended the auth middleware to check if our offline token has a token type set and if they do, limit their access to what they were intended for (client for /api/client, frontend for /api/frontend | /api/proxy)

Fixes: #594

