### PR TITLE
chore(1-3211): handle minor edge cases for errors

### DIFF
--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -43,20 +43,16 @@ pub async fn get_features(
 #[get("/streaming")]
 pub async fn stream_features(
     edge_token: EdgeToken,
+    broadcaster: Data<Broadcaster>,
     token_cache: Data<DashMap<String, EdgeToken>>,
     filter_query: Query<FeatureFilters>,
-    req: HttpRequest,
 ) -> EdgeResult<impl Responder> {
     let (validated_token, _filter_set, query) =
         get_feature_filter(&edge_token, &token_cache, filter_query.clone())?;
-    match req.app_data::<Data<Broadcaster>>() {
-        Some(broadcaster) => {
-            broadcaster
-                .connect(validated_token, filter_query, query)
-                .await
-        }
-        _ => Err(EdgeError::ClientCacheError),
-    }
+
+    broadcaster
+        .connect(validated_token, filter_query, query)
+        .await
 }
 
 #[utoipa::path(

--- a/server/src/http/broadcaster.rs
+++ b/server/src/http/broadcaster.rs
@@ -181,7 +181,7 @@ impl Broadcaster {
             // 1. We'll only allow streaming in strict mode
             // 2. We'll check whether the token is subsumed *before* trying to add it to the broadcaster
             // If both of these are true, then we should never hit this case (if Thomas's understanding is correct).
-            None => Err(EdgeError::ClientCacheError),
+            None => Err(EdgeError::AuthorizationDenied),
         }
     }
 


### PR DESCRIPTION
This PR stops up a couple shortcuts taken for the initial streaming implementation in edge.

Mostly just returns better errors where possible.