### PR TITLE
chore(1-3216): send the same headers in streaming as for polling

### DIFF
--- a/server/src/http/feature_refresher.rs
+++ b/server/src/http/feature_refresher.rs
@@ -290,7 +290,7 @@ impl FeatureRefresher {
                 .context("Failed to create EventSource client for streaming")?
                 .header("Authorization", &token.token)?
                 .header(UNLEASH_APPNAME_HEADER, &app_name)?
-                .header(UNLEASH_INSTANCE_ID_HEADER, "unleash_edge".into())?
+                .header(UNLEASH_INSTANCE_ID_HEADER, "unleash_edge")?
                 .header(
                     UNLEASH_CLIENT_SPEC_HEADER,
                     unleash_yggdrasil::SUPPORTED_SPEC_VERSION,

--- a/server/src/http/feature_refresher.rs
+++ b/server/src/http/feature_refresher.rs
@@ -1,4 +1,3 @@
-use std::borrow::Borrow;
 use std::collections::HashSet;
 use std::{sync::Arc, time::Duration};
 

--- a/server/src/http/feature_refresher.rs
+++ b/server/src/http/feature_refresher.rs
@@ -6,7 +6,7 @@ use chrono::Utc;
 use dashmap::DashMap;
 use eventsource_client::Client;
 use futures::TryStreamExt;
-use reqwest::StatusCode;
+use reqwest::{header, StatusCode};
 use tracing::{debug, info, warn};
 use unleash_types::client_features::ClientFeatures;
 use unleash_types::client_metrics::{ClientApplication, MetricsMetadata};
@@ -271,7 +271,11 @@ impl FeatureRefresher {
     }
 
     /// This is where we set up a listener per token.
-    pub async fn start_streaming_features_background_task(&self) -> anyhow::Result<()> {
+    pub async fn start_streaming_features_background_task(
+        &self,
+        app_name: &str,
+        custom_headers: Vec<(String, String)>,
+    ) -> anyhow::Result<()> {
         use anyhow::Context;
 
         let refreshes = self.get_tokens_due_for_refresh();
@@ -282,6 +286,18 @@ impl FeatureRefresher {
             let es_client = eventsource_client::ClientBuilder::for_url(streaming_url)
                 .context("Failed to create EventSource client for streaming")?
                 .header("Authorization", &token.token)?
+                .header("UNLEASH-APPNAME", app_name.into())?
+                .header("UNLEASH-INSTANCEID", "unleash_edge".into())?
+                .header(
+                    "UNLEASH-CLIENT-SPEC",
+                    unleash_yggdrasil::SUPPORTED_SPEC_VERSION,
+                )?;
+
+            for (key, value) in custom_headers {
+                es_client.header(&key, &value)?;
+            }
+
+            es_client
                 .reconnect(
                     eventsource_client::ReconnectOptions::reconnect(true)
                         .retry_initial(true)

--- a/server/src/http/feature_refresher.rs
+++ b/server/src/http/feature_refresher.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::collections::HashSet;
 use std::{sync::Arc, time::Duration};
 
@@ -15,6 +16,9 @@ use unleash_yggdrasil::EngineState;
 use crate::error::{EdgeError, FeatureError};
 use crate::feature_cache::FeatureCache;
 use crate::filters::{filter_client_features, FeatureFilterSet};
+use crate::http::headers::{
+    UNLEASH_APPNAME_HEADER, UNLEASH_CLIENT_SPEC_HEADER, UNLEASH_INSTANCE_ID_HEADER,
+};
 use crate::types::{build, EdgeResult, TokenType, TokenValidationStatus};
 use crate::{
     persistence::EdgePersistence,
@@ -286,10 +290,10 @@ impl FeatureRefresher {
             let mut es_client_builder = eventsource_client::ClientBuilder::for_url(streaming_url)
                 .context("Failed to create EventSource client for streaming")?
                 .header("Authorization", &token.token)?
-                .header("UNLEASH-APPNAME", &app_name)?
-                .header("UNLEASH-INSTANCEID", "unleash_edge".into())?
+                .header(UNLEASH_APPNAME_HEADER, &app_name)?
+                .header(UNLEASH_INSTANCE_ID_HEADER, "unleash_edge".into())?
                 .header(
-                    "UNLEASH-CLIENT-SPEC",
+                    UNLEASH_CLIENT_SPEC_HEADER,
                     unleash_yggdrasil::SUPPORTED_SPEC_VERSION,
                 )?;
 

--- a/server/src/http/feature_refresher.rs
+++ b/server/src/http/feature_refresher.rs
@@ -274,7 +274,7 @@ impl FeatureRefresher {
     pub async fn start_streaming_features_background_task(
         &self,
         app_name: String,
-        // custom_headers: Vec<(String, String)>,
+        custom_headers: Vec<(String, String)>,
     ) -> anyhow::Result<()> {
         use anyhow::Context;
 
@@ -283,7 +283,7 @@ impl FeatureRefresher {
             let token = refresh.token.clone();
             let streaming_url = self.unleash_client.urls.client_features_stream_url.as_str();
 
-            let es_client_builder = eventsource_client::ClientBuilder::for_url(streaming_url)
+            let mut es_client_builder = eventsource_client::ClientBuilder::for_url(streaming_url)
                 .context("Failed to create EventSource client for streaming")?
                 .header("Authorization", &token.token)?
                 .header("UNLEASH-APPNAME", &app_name)?
@@ -293,9 +293,9 @@ impl FeatureRefresher {
                     unleash_yggdrasil::SUPPORTED_SPEC_VERSION,
                 )?;
 
-            // for (key, value) in custom_headers.clone() {
-            //     es_client_builder = es_client_builder.header(&key, &value)?;
-            // }
+            for (key, value) in custom_headers.clone() {
+                es_client_builder = es_client_builder.header(&key, &value)?;
+            }
 
             let es_client = es_client_builder
                 .reconnect(

--- a/server/src/http/headers.rs
+++ b/server/src/http/headers.rs
@@ -1,0 +1,3 @@
+pub(crate) const UNLEASH_APPNAME_HEADER: &str = "UNLEASH-APPNAME";
+pub(crate) const UNLEASH_INSTANCE_ID_HEADER: &str = "UNLEASH-INSTANCEID";
+pub(crate) const UNLEASH_CLIENT_SPEC_HEADER: &str = "Unleash-Client-Spec";

--- a/server/src/http/mod.rs
+++ b/server/src/http/mod.rs
@@ -2,4 +2,5 @@
 pub mod background_send_metrics;
 pub mod broadcaster;
 pub mod feature_refresher;
+pub(crate) mod headers;
 pub mod unleash_client;

--- a/server/src/http/unleash_client.rs
+++ b/server/src/http/unleash_client.rs
@@ -28,9 +28,9 @@ use crate::types::{
 use crate::urls::UnleashUrls;
 use crate::{error::EdgeError, types::ClientFeaturesRequest};
 
-const UNLEASH_APPNAME_HEADER: &str = "UNLEASH-APPNAME";
-const UNLEASH_INSTANCE_ID_HEADER: &str = "UNLEASH-INSTANCEID";
-const UNLEASH_CLIENT_SPEC_HEADER: &str = "Unleash-Client-Spec";
+use super::headers::UNLEASH_APPNAME_HEADER;
+use super::headers::UNLEASH_CLIENT_SPEC_HEADER;
+use super::headers::UNLEASH_INSTANCE_ID_HEADER;
 
 lazy_static! {
     pub static ref CLIENT_REGISTER_FAILURES: IntGaugeVec = register_int_gauge_vec!(

--- a/server/src/http/unleash_client.rs
+++ b/server/src/http/unleash_client.rs
@@ -20,6 +20,9 @@ use unleash_types::client_metrics::ClientApplication;
 use crate::cli::ClientIdentity;
 use crate::error::EdgeError::EdgeMetricsRequestError;
 use crate::error::{CertificateError, FeatureError};
+use crate::http::headers::{
+    UNLEASH_APPNAME_HEADER, UNLEASH_CLIENT_SPEC_HEADER, UNLEASH_INSTANCE_ID_HEADER,
+};
 use crate::metrics::client_metrics::MetricsBatch;
 use crate::tls::build_upstream_certificate;
 use crate::types::{
@@ -27,10 +30,6 @@ use crate::types::{
 };
 use crate::urls::UnleashUrls;
 use crate::{error::EdgeError, types::ClientFeaturesRequest};
-
-use super::headers::UNLEASH_APPNAME_HEADER;
-use super::headers::UNLEASH_CLIENT_SPEC_HEADER;
-use super::headers::UNLEASH_INSTANCE_ID_HEADER;
 
 lazy_static! {
     pub static ref CLIENT_REGISTER_FAILURES: IntGaugeVec = register_int_gauge_vec!(

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -58,7 +58,13 @@ async fn main() -> Result<(), anyhow::Error> {
         instance_id: args.clone().instance_id,
     };
     let app_name = args.app_name.clone();
+    let custom_headers = match args.mode {
+        cli::EdgeMode::Edge(ref edge) => edge.custom_client_headers.clone(),
+        _ => vec![],
+    };
+
     let internal_backstage_args = args.internal_backstage.clone();
+
     let (
         (token_cache, features_cache, engine_cache),
         token_validator,
@@ -158,12 +164,14 @@ async fn main() -> Result<(), anyhow::Error> {
             let refresher_for_background = feature_refresher.clone().unwrap();
             if edge.streaming {
                 let app_name = app_name.clone();
+                // let custom_headers = match args.mode {
+                //     cli::EdgeMode::Edge(edge) => edge.custom_client_headers,
+                //     _ => vec![],
+                // };
+                let custom_headers = custom_headers.clone();
                 tokio::spawn(async move {
                     let _ = refresher_for_background
-                        .start_streaming_features_background_task(
-                            app_name,
-                            // args.custom_headers,
-                        )
+                        .start_streaming_features_background_task(app_name, custom_headers)
                         .await;
                 });
             }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -164,10 +164,6 @@ async fn main() -> Result<(), anyhow::Error> {
             let refresher_for_background = feature_refresher.clone().unwrap();
             if edge.streaming {
                 let app_name = app_name.clone();
-                // let custom_headers = match args.mode {
-                //     cli::EdgeMode::Edge(edge) => edge.custom_client_headers,
-                //     _ => vec![],
-                // };
                 let custom_headers = custom_headers.clone();
                 tokio::spawn(async move {
                     let _ = refresher_for_background

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -157,9 +157,13 @@ async fn main() -> Result<(), anyhow::Error> {
         cli::EdgeMode::Edge(edge) => {
             let refresher_for_background = feature_refresher.clone().unwrap();
             if edge.streaming {
+                let app_name = app_name.clone();
                 tokio::spawn(async move {
                     let _ = refresher_for_background
-                        .start_streaming_features_background_task()
+                        .start_streaming_features_background_task(
+                            app_name,
+                            // args.custom_headers,
+                        )
                         .await;
                 });
             }


### PR DESCRIPTION
This pr adds the same headers to the streaming clients as we use for polling clients.