### PR TITLE
chore(1-3217): run SSE listener in infinite loop

### DIFF
--- a/server/src/http/feature_refresher.rs
+++ b/server/src/http/feature_refresher.rs
@@ -366,8 +366,16 @@ impl FeatureRefresher {
                     })
                     .map_err(|e| warn!("Error in SSE stream: {:?}", e));
 
-                while let Ok(Some(handler)) = stream.try_next().await {
-                    handler.await;
+                loop {
+                    match stream.try_next().await {
+                        Ok(Some(handler)) => handler.await,
+                        Ok(None) => {
+                            info!("SSE stream ended? Handler was None, anyway. Reconnecting.");
+                        }
+                        Err(e) => {
+                            info!("SSE stream error: {e:?}. Reconnecting");
+                        }
+                    }
                 }
             });
         }


### PR DESCRIPTION
Instead of using `while let Ok(...)` To run the listening loop, we'll just use a plain old loop. This is an experiment to see if this'll make it always reconnect succesfully.