### PR TITLE
refactor: store less information per streaming client

### DIFF
--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -50,9 +50,8 @@ pub async fn stream_features(
     let (validated_token, _filter_set, query) =
         get_feature_filter(&edge_token, &token_cache, filter_query.clone())?;
 
-    broadcaster
-        .connect(validated_token, filter_query, query)
-        .await
+    // so we really just need to validate the token here.
+    broadcaster.connect(validated_token, query).await
 }
 
 #[utoipa::path(

--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -50,7 +50,6 @@ pub async fn stream_features(
     let (validated_token, _filter_set, query) =
         get_feature_filter(&edge_token, &token_cache, filter_query.clone())?;
 
-    // so we really just need to validate the token here.
     broadcaster.connect(validated_token, query).await
 }
 

--- a/server/src/http/broadcaster.rs
+++ b/server/src/http/broadcaster.rs
@@ -61,7 +61,6 @@ struct ClientData {
 #[derive(Clone, Debug)]
 struct ClientGroup {
     clients: Vec<ClientData>,
-    // last_hash: u64
 }
 
 pub struct Broadcaster {
@@ -221,11 +220,7 @@ impl Broadcaster {
     }
 
     /// Broadcast new features to all clients.
-    pub async fn broadcast(
-        &self,
-        environment: Option<String>,
-        // connections_to_update: &DashMap<QueryWrapper, ClientGroup>
-    ) {
+    pub async fn broadcast(&self, environment: Option<String>) {
         let mut client_events = Vec::new();
 
         for entry in self.active_connections.iter().filter(|entry| {
@@ -376,7 +371,7 @@ mod test {
             loop {
                 if let Some(event) = rx.recv().await {
                     match event {
-                        Event::Data(data) => {
+                        Event::Data(_) => {
                             panic!("Received an update for an env I'm not subscribed to!");
                         }
                         _ => {

--- a/server/src/http/broadcaster.rs
+++ b/server/src/http/broadcaster.rs
@@ -349,7 +349,6 @@ mod test {
         .await
         .is_err()
         {
-            // If the test times out, kill the app process and fail the test
             panic!("Test timed out waiting for update event");
         }
 
@@ -367,7 +366,7 @@ mod test {
             },
         );
 
-        let result = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        let result = tokio::time::timeout(std::time::Duration::from_secs(1), async {
             loop {
                 if let Some(event) = rx.recv().await {
                     match event {

--- a/server/src/http/broadcaster.rs
+++ b/server/src/http/broadcaster.rs
@@ -27,14 +27,14 @@ struct StreamingQuery {
     pub environment: String,
 }
 
-impl Into<Query> for StreamingQuery {
-    fn into(self) -> Query {
-        Query {
+impl From<StreamingQuery> for Query {
+    fn from(value: StreamingQuery) -> Self {
+        Self {
             tags: None,
-            name_prefix: self.name_prefix,
-            environment: Some(self.environment),
+            name_prefix: value.name_prefix,
+            environment: Some(value.environment),
             inline_segment_constraints: None,
-            projects: Some(self.projects),
+            projects: Some(value.projects),
         }
     }
 }

--- a/server/src/http/broadcaster.rs
+++ b/server/src/http/broadcaster.rs
@@ -125,17 +125,15 @@ impl Broadcaster {
         let mut active_connections = 0i64;
         for mut group in self.active_connections.iter_mut() {
             let mut ok_clients = Vec::new();
+            let clients = std::mem::take(&mut group.clients);
 
-            for ClientData { token, sender } in &group.clients {
+            for ClientData { token, sender } in clients {
                 if sender
                     .send(sse::Event::Comment("keep-alive".into()))
                     .await
                     .is_ok()
                 {
-                    ok_clients.push(ClientData {
-                        token: token.clone(),
-                        sender: sender.clone(),
-                    });
+                    ok_clients.push(ClientData { token, sender });
                 }
             }
 

--- a/server/src/http/broadcaster.rs
+++ b/server/src/http/broadcaster.rs
@@ -153,7 +153,7 @@ impl Broadcaster {
     ) -> EdgeResult<Sse<InfallibleStream<ReceiverStream<sse::Event>>>> {
         self.create_connection(StreamingQuery::from((&query, &token)), &token.token)
             .await
-            .map(|rx| Sse::from_infallible_receiver(rx))
+            .map(Sse::from_infallible_receiver)
     }
 
     async fn create_connection(

--- a/server/src/http/broadcaster.rs
+++ b/server/src/http/broadcaster.rs
@@ -202,11 +202,6 @@ impl Broadcaster {
     async fn resolve_features(&self, query: StreamingQuery) -> EdgeJsonResult<ClientFeatures> {
         let filter_set = Broadcaster::get_query_filters(&query);
 
-        println!(
-            "Resolving features. The cache is {:#?}",
-            self.features_cache
-        );
-
         let features = self
             .features_cache
             .get(&query.environment)
@@ -323,8 +318,8 @@ mod test {
             .expect("Failed to connect");
 
         // Drain any initial events to start with a clean state
-        while let Ok(Some(event)) = timeout(Duration::from_secs(1), rx.recv()).await {
-            println!("Discarding initial event: {:?}", event);
+        while let Ok(Some(_)) = timeout(Duration::from_secs(1), rx.recv()).await {
+            // ignored
         }
 
         feature_cache.insert(
@@ -345,8 +340,7 @@ mod test {
             loop {
                 if let Some(event) = rx.recv().await {
                     match event {
-                        Event::Data(data) => {
-                            println!("Received {data:?}");
+                        Event::Data(_) => {
                             // the only kind of data events we send at the moment are unleash-updated events. So if we receive a data event, we've got the update.
                             break;
                         }
@@ -383,7 +377,6 @@ mod test {
                 if let Some(event) = rx.recv().await {
                     match event {
                         Event::Data(data) => {
-                            println!("Received {data:?}");
                             panic!("Received an update for an env I'm not subscribed to!");
                         }
                         _ => {

--- a/server/src/http/broadcaster.rs
+++ b/server/src/http/broadcaster.rs
@@ -124,8 +124,8 @@ impl Broadcaster {
     async fn heartbeat(&self) {
         let mut active_connections = 0i64;
         for mut group in self.active_connections.iter_mut() {
-            let mut ok_clients = Vec::new();
             let clients = std::mem::take(&mut group.clients);
+            let ok_clients = &mut group.clients;
 
             for ClientData { token, sender } in clients {
                 if sender
@@ -138,7 +138,6 @@ impl Broadcaster {
             }
 
             active_connections += ok_clients.len() as i64;
-            group.clients = ok_clients;
         }
         CONNECTED_STREAMING_CLIENTS.set(active_connections)
     }

--- a/server/src/http/broadcaster.rs
+++ b/server/src/http/broadcaster.rs
@@ -33,7 +33,7 @@ impl From<StreamingQuery> for Query {
             tags: None,
             name_prefix: value.name_prefix,
             environment: Some(value.environment),
-            inline_segment_constraints: None,
+            inline_segment_constraints: Some(false),
             projects: Some(value.projects),
         }
     }


### PR DESCRIPTION
This PR refactors the broadcaster and what it stores per client:
- I've created a new StreamingQuery struct that has only the data we need,
- I've moved the token storing from client group level to individual client level (and created a ClientData struct)

I realized when setting up the tests for this that the Query, EdgeToken, and FilterQuery all contain more or less the same bits of data. But all we really need is:
1. The actual token string (so that we can boot clients if the token expires)
2. Name prefix, projects, and env.

In the Unleash Types `Query` type, projects and env are optional, but we need them to be present to perform the calculation.

So I created a `StreamingQuery` struct, which consolidates the data we need from the Query and EdgeToken. I also copied in the methods we use for this elsewhere in Unleash and slightly adapted them. I've added notes inline.