### PR TITLE
feat(1-3220): only push updates to listeners in the same environment

### DIFF
--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -50,9 +50,8 @@ pub async fn stream_features(
     let (validated_token, _filter_set, query) =
         get_feature_filter(&edge_token, &token_cache, filter_query.clone())?;
 
-    broadcaster
-        .connect(validated_token, filter_query, query)
-        .await
+    // so we really just need to validate the token here.
+    broadcaster.connect(validated_token, query).await
 }
 
 #[utoipa::path(

--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -50,7 +50,6 @@ pub async fn stream_features(
     let (validated_token, _filter_set, query) =
         get_feature_filter(&edge_token, &token_cache, filter_query.clone())?;
 
-    // so we really just need to validate the token here.
     broadcaster.connect(validated_token, query).await
 }
 

--- a/server/src/http/broadcaster.rs
+++ b/server/src/http/broadcaster.rs
@@ -61,7 +61,6 @@ struct ClientData {
 #[derive(Clone, Debug)]
 struct ClientGroup {
     clients: Vec<ClientData>,
-    // last_hash: u64
 }
 
 pub struct Broadcaster {
@@ -221,11 +220,7 @@ impl Broadcaster {
     }
 
     /// Broadcast new features to all clients.
-    pub async fn broadcast(
-        &self,
-        environment: Option<String>,
-        // connections_to_update: &DashMap<QueryWrapper, ClientGroup>
-    ) {
+    pub async fn broadcast(&self, environment: Option<String>) {
         let mut client_events = Vec::new();
 
         for entry in self.active_connections.iter().filter(|entry| {
@@ -376,7 +371,7 @@ mod test {
             loop {
                 if let Some(event) = rx.recv().await {
                     match event {
-                        Event::Data(data) => {
+                        Event::Data(_) => {
                             panic!("Received an update for an env I'm not subscribed to!");
                         }
                         _ => {

--- a/server/src/http/broadcaster.rs
+++ b/server/src/http/broadcaster.rs
@@ -349,7 +349,6 @@ mod test {
         .await
         .is_err()
         {
-            // If the test times out, kill the app process and fail the test
             panic!("Test timed out waiting for update event");
         }
 
@@ -367,7 +366,7 @@ mod test {
             },
         );
 
-        let result = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        let result = tokio::time::timeout(std::time::Duration::from_secs(1), async {
             loop {
                 if let Some(event) = rx.recv().await {
                     match event {

--- a/server/src/http/broadcaster.rs
+++ b/server/src/http/broadcaster.rs
@@ -27,14 +27,14 @@ struct StreamingQuery {
     pub environment: String,
 }
 
-impl Into<Query> for StreamingQuery {
-    fn into(self) -> Query {
-        Query {
+impl From<StreamingQuery> for Query {
+    fn from(value: StreamingQuery) -> Self {
+        Self {
             tags: None,
-            name_prefix: self.name_prefix,
-            environment: Some(self.environment),
+            name_prefix: value.name_prefix,
+            environment: Some(value.environment),
             inline_segment_constraints: None,
-            projects: Some(self.projects),
+            projects: Some(value.projects),
         }
     }
 }

--- a/server/src/http/broadcaster.rs
+++ b/server/src/http/broadcaster.rs
@@ -125,17 +125,15 @@ impl Broadcaster {
         let mut active_connections = 0i64;
         for mut group in self.active_connections.iter_mut() {
             let mut ok_clients = Vec::new();
+            let clients = std::mem::take(&mut group.clients);
 
-            for ClientData { token, sender } in &group.clients {
+            for ClientData { token, sender } in clients {
                 if sender
                     .send(sse::Event::Comment("keep-alive".into()))
                     .await
                     .is_ok()
                 {
-                    ok_clients.push(ClientData {
-                        token: token.clone(),
-                        sender: sender.clone(),
-                    });
+                    ok_clients.push(ClientData { token, sender });
                 }
             }
 

--- a/server/src/http/broadcaster.rs
+++ b/server/src/http/broadcaster.rs
@@ -15,7 +15,7 @@ use unleash_types::client_features::{ClientFeatures, Query};
 
 use crate::{
     error::EdgeError,
-    feature_cache::FeatureCache,
+    feature_cache::{FeatureCache, UpdateType},
     filters::{filter_client_features, name_prefix_filter, FeatureFilter, FeatureFilterSet},
     types::{EdgeJsonResult, EdgeResult, EdgeToken},
 };
@@ -108,7 +108,14 @@ impl Broadcaster {
         tokio::spawn(async move {
             while let Ok(key) = rx.recv().await {
                 debug!("Received update for key: {:?}", key);
-                this.broadcast().await;
+                match key {
+                    UpdateType::Full(env) | UpdateType::Update(env) => {
+                        this.broadcast(Some(env)).await;
+                    }
+                    UpdateType::Deletion => {
+                        this.broadcast(None).await;
+                    }
+                }
             }
         });
     }
@@ -210,10 +217,16 @@ impl Broadcaster {
     }
 
     /// Broadcast new features to all clients.
-    pub async fn broadcast(&self) {
+    pub async fn broadcast(&self, environment: Option<String>) {
         let mut client_events = Vec::new();
 
-        for entry in self.active_connections.iter() {
+        for entry in self.active_connections.iter().filter(|entry| {
+            if let Some(env) = &environment {
+                entry.key().environment == *env
+            } else {
+                true
+            }
+        }) {
             let (query, group) = entry.pair();
 
             let event_data = self
@@ -254,4 +267,118 @@ fn project_filter(projects: Vec<String>) -> FeatureFilter {
             false
         }
     })
+}
+
+#[cfg(test)]
+mod test {
+    use tokio::time::timeout;
+    use unleash_types::client_features::ClientFeature;
+
+    use crate::feature_cache::FeatureCache;
+
+    use super::*;
+
+    #[actix_web::test]
+    async fn only_updates_clients_in_same_env() {
+        let feature_cache = Arc::new(FeatureCache::default());
+        let broadcaster = Broadcaster::new(feature_cache.clone());
+
+        let env_with_updates = "production";
+        let env_without_updates = "development";
+        for env in &[env_with_updates, env_without_updates] {
+            feature_cache.insert(
+                env.to_string(),
+                ClientFeatures {
+                    version: 0,
+                    features: vec![],
+                    query: None,
+                    segments: None,
+                },
+            );
+        }
+
+        let mut rx = broadcaster
+            .create_connection(
+                StreamingQuery {
+                    name_prefix: None,
+                    environment: env_with_updates.into(),
+                    projects: vec!["dx".to_string()],
+                },
+                "token",
+            )
+            .await
+            .expect("Failed to connect");
+
+        // Drain any initial events to start with a clean state
+        while let Ok(Some(_)) = timeout(Duration::from_secs(1), rx.recv()).await {
+            // ignored
+        }
+
+        feature_cache.insert(
+            env_with_updates.to_string(),
+            ClientFeatures {
+                version: 0,
+                features: vec![ClientFeature {
+                    name: "flag-a".into(),
+                    project: Some("dx".into()),
+                    ..Default::default()
+                }],
+                segments: None,
+                query: None,
+            },
+        );
+
+        if tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                if let Some(event) = rx.recv().await {
+                    match event {
+                        Event::Data(_) => {
+                            // the only kind of data events we send at the moment are unleash-updated events. So if we receive a data event, we've got the update.
+                            break;
+                        }
+                        _ => {
+                            // ignore other events
+                        }
+                    }
+                }
+            }
+        })
+        .await
+        .is_err()
+        {
+            panic!("Test timed out waiting for update event");
+        }
+
+        feature_cache.insert(
+            env_without_updates.to_string(),
+            ClientFeatures {
+                version: 0,
+                features: vec![ClientFeature {
+                    name: "flag-b".into(),
+                    project: Some("dx".into()),
+                    ..Default::default()
+                }],
+                segments: None,
+                query: None,
+            },
+        );
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if let Some(event) = rx.recv().await {
+                    match event {
+                        Event::Data(_) => {
+                            panic!("Received an update for an env I'm not subscribed to!");
+                        }
+                        _ => {
+                            // ignore other events
+                        }
+                    }
+                }
+            }
+        })
+        .await;
+
+        assert!(result.is_err());
+    }
 }

--- a/server/src/http/broadcaster.rs
+++ b/server/src/http/broadcaster.rs
@@ -153,7 +153,7 @@ impl Broadcaster {
     ) -> EdgeResult<Sse<InfallibleStream<ReceiverStream<sse::Event>>>> {
         self.create_connection(StreamingQuery::from((&query, &token)), &token.token)
             .await
-            .map(|rx| Sse::from_infallible_receiver(rx))
+            .map(Sse::from_infallible_receiver)
     }
 
     async fn create_connection(

--- a/server/src/http/broadcaster.rs
+++ b/server/src/http/broadcaster.rs
@@ -202,11 +202,6 @@ impl Broadcaster {
     async fn resolve_features(&self, query: StreamingQuery) -> EdgeJsonResult<ClientFeatures> {
         let filter_set = Broadcaster::get_query_filters(&query);
 
-        println!(
-            "Resolving features. The cache is {:#?}",
-            self.features_cache
-        );
-
         let features = self
             .features_cache
             .get(&query.environment)
@@ -323,8 +318,8 @@ mod test {
             .expect("Failed to connect");
 
         // Drain any initial events to start with a clean state
-        while let Ok(Some(event)) = timeout(Duration::from_secs(1), rx.recv()).await {
-            println!("Discarding initial event: {:?}", event);
+        while let Ok(Some(_)) = timeout(Duration::from_secs(1), rx.recv()).await {
+            // ignored
         }
 
         feature_cache.insert(
@@ -345,8 +340,7 @@ mod test {
             loop {
                 if let Some(event) = rx.recv().await {
                     match event {
-                        Event::Data(data) => {
-                            println!("Received {data:?}");
+                        Event::Data(_) => {
                             // the only kind of data events we send at the moment are unleash-updated events. So if we receive a data event, we've got the update.
                             break;
                         }
@@ -383,7 +377,6 @@ mod test {
                 if let Some(event) = rx.recv().await {
                     match event {
                         Event::Data(data) => {
-                            println!("Received {data:?}");
                             panic!("Received an update for an env I'm not subscribed to!");
                         }
                         _ => {

--- a/server/src/http/broadcaster.rs
+++ b/server/src/http/broadcaster.rs
@@ -124,8 +124,8 @@ impl Broadcaster {
     async fn heartbeat(&self) {
         let mut active_connections = 0i64;
         for mut group in self.active_connections.iter_mut() {
-            let mut ok_clients = Vec::new();
             let clients = std::mem::take(&mut group.clients);
+            let ok_clients = &mut group.clients;
 
             for ClientData { token, sender } in clients {
                 if sender
@@ -138,7 +138,6 @@ impl Broadcaster {
             }
 
             active_connections += ok_clients.len() as i64;
-            group.clients = ok_clients;
         }
         CONNECTED_STREAMING_CLIENTS.set(active_connections)
     }

--- a/server/src/http/broadcaster.rs
+++ b/server/src/http/broadcaster.rs
@@ -33,7 +33,7 @@ impl From<StreamingQuery> for Query {
             tags: None,
             name_prefix: value.name_prefix,
             environment: Some(value.environment),
-            inline_segment_constraints: None,
+            inline_segment_constraints: Some(false),
             projects: Some(value.projects),
         }
     }


### PR DESCRIPTION
This PR updates the broadcaster to only push updates to listeners in the environment it got updates for. In other words, if you get an update for "development" config, you shouldn't push an update to listeners subscribed to the "production" environment.

This is the first step in more selective pushing (the next would be to do as we do in Unleash and hash the result of each query so that we only push out updates when something's actually changed).