### PR TITLE
refactor: minor cleanup after #618

### DIFF
--- a/server/src/filters.rs
+++ b/server/src/filters.rs
@@ -59,17 +59,20 @@ pub(crate) fn name_match_filter(name_prefix: String) -> FeatureFilter {
     Box::new(move |f| f.name.starts_with(&name_prefix))
 }
 
-pub(crate) fn project_filter(token: &EdgeToken) -> FeatureFilter {
-    let token = token.clone();
+pub(crate) fn project_filter_from_projects(projects: Vec<String>) -> FeatureFilter {
     Box::new(move |feature| {
         if let Some(feature_project) = &feature.project {
-            token.projects.is_empty()
-                || token.projects.contains(&"*".to_string())
-                || token.projects.contains(feature_project)
+            projects.is_empty()
+                || projects.contains(&"*".to_string())
+                || projects.contains(feature_project)
         } else {
             false
         }
     })
+}
+
+pub(crate) fn project_filter(token: &EdgeToken) -> FeatureFilter {
+    project_filter_from_projects(token.projects.clone())
 }
 
 #[cfg(test)]

--- a/server/src/http/broadcaster.rs
+++ b/server/src/http/broadcaster.rs
@@ -16,7 +16,9 @@ use unleash_types::client_features::{ClientFeatures, Query};
 use crate::{
     error::EdgeError,
     feature_cache::{FeatureCache, UpdateType},
-    filters::{filter_client_features, name_prefix_filter, FeatureFilter, FeatureFilterSet},
+    filters::{
+        filter_client_features, name_prefix_filter, project_filter_from_projects, FeatureFilterSet,
+    },
     types::{EdgeJsonResult, EdgeResult, EdgeToken},
 };
 
@@ -191,7 +193,7 @@ impl Broadcaster {
         } else {
             FeatureFilterSet::default()
         }
-        .with_filter(project_filter(query.projects.clone()));
+        .with_filter(project_filter_from_projects(query.projects.clone()));
         filter_set
     }
 
@@ -255,18 +257,6 @@ impl Broadcaster {
 
         let _ = future::join_all(send_events).await;
     }
-}
-
-fn project_filter(projects: Vec<String>) -> FeatureFilter {
-    Box::new(move |feature| {
-        if let Some(feature_project) = &feature.project {
-            projects.is_empty()
-                || projects.contains(&"*".to_string())
-                || projects.contains(feature_project)
-        } else {
-            false
-        }
-    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR performs a small amount of cleanup after #618 based on the PR discussion. Specifically, it:

- Adds a new `project_filter_from_projects` function to the filters file, and makes `project_filter` fall back to that on the back end (we can discuss the names here, but doing it this way saved me touching any more code)
- Reverts the `std::mem::take` shenanigans in favor of cloning. Even though it clones one string per attached listener every 30 seconds, it's probably not going to cause a lot of memory overhead given that we drop the original shortly thereafter. 