### PR TITLE
feat: Make keep alive timeout configurable (still default to 5 seconds)

### DIFF
--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -375,6 +375,10 @@ pub struct CliArgs {
     #[clap(long, env, default_value_t = 5)]
     pub edge_request_timeout: u64,
 
+    /// Keepalive timeout for requests to Edge
+    #[clap(long, env, default_value_t = 5)]
+    pub edge_keepalive_timeout: u64,
+
     /// Which log format should Edge use
     #[clap(short, long, env, global = true, value_enum, default_value_t = LogFormat::Plain)]
     pub log_format: LogFormat,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -53,6 +53,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let http_args = args.clone().http;
     let token_header = args.clone().token_header;
     let request_timeout = args.edge_request_timeout;
+    let keepalive_timeout = args.edge_keepalive_timeout;
     let trust_proxy = args.clone().trust_proxy;
     let base_path = http_args.base_path.clone();
     let (metrics_handler, request_metrics) = prom_metrics::instantiate(None, &args.log_format);
@@ -161,6 +162,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let server = server?
         .workers(http_args.workers)
         .shutdown_timeout(5)
+        .keep_alive(std::time::Duration::from_secs(keepalive_timeout))
         .client_request_timeout(std::time::Duration::from_secs(request_timeout));
 
     match schedule_args.mode {


### PR DESCRIPTION
I had a conversation on Slack today, and Edge's keepalive came up. This PR makes it configurable, but still uses the same default that we already had in place of 5 seconds. 