### PR TITLE
feat: make delta aligned with streaming, support only strict

### DIFF
--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -213,12 +213,12 @@ pub struct EdgeArgs {
     #[clap(long, env, default_value_t = false, conflicts_with = "strict")]
     pub dynamic: bool,
 
-    /// If set to true. Edge connects to upstream using streaming instead of polling. Requires strict mode
+    /// If set to true, Edge connects to upstream using streaming instead of polling. Requires strict mode
     #[clap(long, env, default_value_t = false, requires = "strict")]
     pub streaming: bool,
 
-    /// If set to true. Edge connects to upstream using delta polling instead of normal polling. This is experimental feature and might and change.
-    #[clap(long, env, default_value_t = false, conflicts_with = "streaming")]
+    /// If set to true, Edge connects to upstream using delta polling instead of normal polling. This is experimental feature and might and change. Requires strict mode
+    #[clap(long, env, default_value_t = false, requires = "strict")]
     pub delta: bool,
 
     /// Sets a remote write url for prometheus metrics, if this is set, prometheus metrics will be written upstream


### PR DESCRIPTION
Align delta with streaming, only to work in strict mode and not conflicting.

We are not supporting legacy dynamic mode.