### PR TITLE
chore: remove compiler flag for delta

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -117,6 +117,3 @@ tracing-test = "0.2.5"
 
 [build-dependencies]
 shadow-rs = "0.37.0"
-
-[features]
-delta = []

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -221,8 +221,8 @@ pub struct EdgeArgs {
     #[clap(long, env, default_value_t = false, requires = "strict")]
     pub delta: bool,
 
-    /// If set to true, it compares features payload with delta payload and logs diff. This is experimental feature and might change. Requires strict mode
-    #[clap(long, env, default_value_t = false, requires = "strict")]
+    /// If set to true, it compares features payload with delta payload and logs diff. This is experimental feature and might change.
+    #[clap(long, env, default_value_t = false, conflicts_with = "delta")]
     pub delta_diff: bool,
 
     /// Sets a remote write url for prometheus metrics, if this is set, prometheus metrics will be written upstream

--- a/server/src/http/refresher/delta_refresher.rs
+++ b/server/src/http/refresher/delta_refresher.rs
@@ -113,8 +113,6 @@ impl FeatureRefresher {
     }
 }
 
-
-#[cfg(feature = "delta")]
 #[cfg(test)]
 mod tests {
     use actix_http::header::IF_NONE_MATCH;

--- a/server/src/http/refresher/feature_refresher.rs
+++ b/server/src/http/refresher/feature_refresher.rs
@@ -451,7 +451,7 @@ impl FeatureRefresher {
     pub async fn hydrate_new_tokens(&self) {
         let hydrations = self.get_tokens_never_refreshed();
         for hydration in hydrations {
-            if cfg!(feature = "delta") && self.delta {
+            if self.delta {
                 self.refresh_single_delta(hydration).await;
             } else {
                 self.refresh_single(hydration).await;
@@ -461,7 +461,7 @@ impl FeatureRefresher {
     pub async fn refresh_features(&self) {
         let refreshes = self.get_tokens_due_for_refresh();
         for refresh in refreshes {
-            if cfg!(feature = "delta") && self.delta {
+            if self.delta {
                 self.refresh_single_delta(refresh).await;
             } else {
                 self.refresh_single(refresh).await;
@@ -522,7 +522,7 @@ impl FeatureRefresher {
                 ClientFeaturesResponse::Updated(features, etag) => {
                     self.handle_client_features_updated(&refresh.token, features, etag)
                         .await;
-                    if cfg!(feature = "delta") && self.delta_diff {
+                    if self.delta_diff {
                         self.compare_delta_cache(&refresh).await;
                     }
                 }


### PR DESCRIPTION
Remove delta compiler flag, so we do not need to compile it manually. Feature flag is enough.