### PR TITLE
fix: filter segment events by revision

### DIFF
--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -1678,6 +1678,32 @@ mod tests {
         .await;
 
         assert_eq!(res.events.get(0).unwrap(), &delta_event);
+        assert_eq!(res.events.len(), 1);
+
+        let res = test::call_service(
+            &app,
+            make_delta_request_with_token_and_etag(token.clone(), "11").await,
+        )
+        .await;
+
+        assert_eq!(res.status(), StatusCode::NOT_MODIFIED);
+
+        let delta_event = DeltaEvent::SegmentRemoved {
+            event_id: 12,
+            segment_id: 1,
+        };
+
+        feature_refresher
+            .delta_cache_manager
+            .update_cache("development", &vec![delta_event.clone()]);
+
+        let res = test::call_service(
+            &app,
+            make_delta_request_with_token_and_etag(token.clone(), "12").await,
+        )
+        .await;
+
+        assert_eq!(res.status(), StatusCode::NOT_MODIFIED);
     }
 
     #[tokio::test]

--- a/server/src/delta_filters.rs
+++ b/server/src/delta_filters.rs
@@ -72,7 +72,7 @@ pub(crate) fn combined_filter(
     let segment_filter = is_segment_event_filter();
 
     Box::new(move |event| {
-        segment_filter(event)
+        (segment_filter(event) && revision_filter(event))
             || (name_filter(event) && projects_filter(event) && revision_filter(event))
     })
 }
@@ -91,7 +91,7 @@ fn filter_deltas(
         let events = delta_cache.get_events().clone();
         events
             .iter()
-            .filter(|delta| delta_filters.apply(delta) && delta.get_event_id() >= revision)
+            .filter(|delta| delta_filters.apply(delta))
             .cloned()
             .collect::<Vec<DeltaEvent>>()
     } else {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

We were not filtering segment events by revision so for segment events we were getting extra events

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
