### PR TITLE
feat: app_name and instance_id added as label to metrics

### DIFF
--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -260,7 +260,12 @@ async fn build_edge(
 
     let unleash_client = Url::parse(&args.upstream_url.clone())
         .map(|url| {
-            UnleashClient::from_url(url, args.token_header.token_header.clone(), http_client)
+            UnleashClient::from_url(
+                url,
+                args.token_header.token_header.clone(),
+                http_client,
+                client_meta_information.clone(),
+            )
         })
         .map(|c| c.with_custom_client_headers(args.custom_client_headers.clone()))
         .map(Arc::new)

--- a/server/src/http/instance_data.rs
+++ b/server/src/http/instance_data.rs
@@ -58,6 +58,7 @@ impl InstanceDataSending {
                                     url,
                                     args.token_header.token_header.clone(),
                                     http_client,
+                                    client_meta_information.clone(),
                                 )
                             })
                             .map(|c| {

--- a/server/src/http/refresher/feature_refresher.rs
+++ b/server/src/http/refresher/feature_refresher.rs
@@ -709,6 +709,7 @@ mod tests {
             Url::parse("http://localhost:4242").unwrap(),
             "Authorization".to_string(),
             http_client,
+            ClientMetaInformation::test_config(),
         )
     }
 

--- a/server/src/middleware/client_token_from_frontend_token.rs
+++ b/server/src/middleware/client_token_from_frontend_token.rs
@@ -135,13 +135,14 @@ mod tests {
         )
         .await;
 
+        let meta_information = crate::http::unleash_client::ClientMetaInformation::test_config();
         let http_client = new_reqwest_client(
             false,
             None,
             None,
             Duration::seconds(5),
             Duration::seconds(5),
-            crate::http::unleash_client::ClientMetaInformation::test_config(),
+            meta_information.clone(),
         )
         .expect("Failed to create client");
 
@@ -149,6 +150,7 @@ mod tests {
             Url::parse(&upstream_server.url("/")).unwrap(),
             "test-client".into(),
             http_client,
+            meta_information.clone(),
         );
         let local_features_cache: Arc<FeatureCache> = Arc::new(FeatureCache::default());
         let local_token_cache: Arc<DashMap<String, EdgeToken>> = Arc::new(DashMap::default());


### PR DESCRIPTION
In order to be able to separate metrics in grafana. this adds two more labels to the unleash_client prometheus metrics, so that we have the needed labels even in hosted edge.