### PR TITLE
feat: add allow-list and deny-list middlewares

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -63,9 +63,7 @@ This document contains the help content for the `unleash-edge` command-line prog
   the [Access-Control-Allow-Methods](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods)
   header to this value
 * `--allow-list <ALLOW_LIST>` — Configures the AllowList middleware to only accept requests from IPs that belong to the
-  CIDRs configured here. Defaults to 0.0.0.0/0 (ALL Ips)
-
-  Default value: `0.0.0.0/0`
+  CIDRs configured here. Defaults to 0.0.0.0/0, ::/0 (ALL Ips v4 and v6)
 * `--deny-list <DENY_LIST>` — Configures the DenyList middleware to deny requests from IPs that belong to the CIDRs
   configured here. Defaults to denying no IPs
 * `--instance-id <INSTANCE_ID>` — Instance id. Used for metrics reporting

--- a/CLI.md
+++ b/CLI.md
@@ -32,7 +32,8 @@ This document contains the help content for the `unleash-edge` command-line prog
 * `-b`, `--base-path <BASE_PATH>` — Which base path should this server listen for HTTP traffic on
 
   Default value: ``
-* `-w`, `--workers <WORKERS>` — How many workers should be started to handle requests. Defaults to number of physical cpus
+* `-w`, `--workers <WORKERS>` — How many workers should be started to handle requests. Defaults to number of physical
+  cpus
 
   Default value: `<physical_cpus>`
 * `--tls-enable` — Should we bind TLS
@@ -40,21 +41,55 @@ This document contains the help content for the `unleash-edge` command-line prog
   Default value: `false`
 * `--tls-server-key <TLS_SERVER_KEY>` — Server key to use for TLS - Needs to be a path to a file
 * `--tls-server-cert <TLS_SERVER_CERT>` — Server Cert to use for TLS - Needs to be a path to a file
-* `--tls-server-port <TLS_SERVER_PORT>` — Port to listen for https connection on (will use the interfaces already defined)
+* `--tls-server-port <TLS_SERVER_PORT>` — Port to listen for https connection on (will use the interfaces already
+  defined)
 
   Default value: `3043`
+* `--cors-origin <CORS_ORIGIN>` — Sets
+  the [Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin)
+  header to this value
+* `--cors-allowed-headers <CORS_ALLOWED_HEADERS>` — Sets
+  the [Access-Control-Allow-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers)
+  header to this value
+* `--cors-max-age <CORS_MAX_AGE>` — Sets
+  the [Access-Control-Max-Age](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age) header
+  to this value
+
+  Default value: `172800`
+* `--cors-exposed-headers <CORS_EXPOSED_HEADERS>` — Sets
+  the [Access-Control-Expose-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers)
+  header to this value
+* `--cors-methods <CORS_METHODS>` — Sets
+  the [Access-Control-Allow-Methods](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods)
+  header to this value
+* `--allow-list <ALLOW_LIST>` — Configures the AllowList middleware to only accept requests from IPs that belong to the
+  CIDRs configured here. Defaults to 0.0.0.0/0 (ALL Ips)
+
+  Default value: `0.0.0.0/0`
+* `--deny-list <DENY_LIST>` — Configures the DenyList middleware to deny requests from IPs that belong to the CIDRs
+  configured here. Defaults to denying no IPs
 * `--instance-id <INSTANCE_ID>` — Instance id. Used for metrics reporting
 
-  Default value: `<random ulid>`
+  Default value: `unleash-edge@<random ulid>`
 * `-a`, `--app-name <APP_NAME>` — App name. Used for metrics reporting
 
   Default value: `unleash-edge`
-* `--trust-proxy` — By enabling the trust proxy option. Unleash Edge will have knowledge that it's sitting behind a proxy and that the X-Forward-\* header fields may be trusted, which otherwise may be easily spoofed. Edge will use this to populate its context's  remoteAddress field If you need to only trust specific ips or CIDR, enable this flag and then set `--proxy-trusted-servers`
-* `--proxy-trusted-servers <PROXY_TRUSTED_SERVERS>` — Tells Unleash Edge which servers to trust the X-Forwarded-For. Accepts explicit Ip addresses or Cidrs (127.0.0.1/16). Accepts a comma separated list or multiple instances of the flag. E.g `--proxy-trusted-servers "127.0.0.1,192.168.0.1"` and `--proxy-trusted-servers 127.0.0.1 --proxy-trusted-servers 192.168.0.1` are equivalent
-* `--disable-all-endpoint` — Set this flag to true if you want to disable /api/proxy/all and /api/frontend/all Because returning all toggles regardless of their state is a potential security vulnerability, these endpoints can be disabled
+* `--trust-proxy` — By enabling the trust proxy option. Unleash Edge will have knowledge that it's sitting behind a
+  proxy and that the X-Forward-\* header fields may be trusted, which otherwise may be easily spoofed. Edge will use
+  this to populate its context's remoteAddress field If you need to only trust specific ips or CIDR, enable this flag
+  and then set `--proxy-trusted-servers`
+* `--proxy-trusted-servers <PROXY_TRUSTED_SERVERS>` — Tells Unleash Edge which servers to trust the X-Forwarded-For.
+  Accepts explicit Ip addresses or Cidrs (127.0.0.1/16). Accepts a comma separated list or multiple instances of the
+  flag. E.g `--proxy-trusted-servers "127.0.0.1,192.168.0.1"` and
+  `--proxy-trusted-servers 127.0.0.1 --proxy-trusted-servers 192.168.0.1` are equivalent
+* `--disable-all-endpoint` — Set this flag to true if you want to disable /api/proxy/all and /api/frontend/all Because
+  returning all toggles regardless of their state is a potential security vulnerability, these endpoints can be disabled
 
   Default value: `false`
 * `--edge-request-timeout <EDGE_REQUEST_TIMEOUT>` — Timeout for requests to Edge
+
+  Default value: `5`
+* `--edge-keepalive-timeout <EDGE_KEEPALIVE_TIMEOUT>` — Keepalive timeout for requests to Edge
 
   Default value: `5`
 * `-l`, `--log-format <LOG_FORMAT>` — Which log format should Edge use
@@ -68,18 +103,19 @@ This document contains the help content for the `unleash-edge` command-line prog
   Default value: `Authorization`
 * `--disable-metrics-batch-endpoint` — Disables /internal-backstage/metricsbatch endpoint
 
-   This endpoint shows the current cached client metrics
+  This endpoint shows the current cached client metrics
 * `--disable-metrics-endpoint` — Disables /internal-backstage/metrics endpoint
 
-   Typically used for prometheus scraping metrics.
+  Typically used for prometheus scraping metrics.
 * `--disable-features-endpoint` — Disables /internal-backstage/features endpoint
 
-   Used to show current cached features across environments
+  Used to show current cached features across environments
 * `--disable-tokens-endpoint` — Disables /internal-backstage/tokens endpoint
 
-   Used to show tokens used to refresh feature caches, but also tokens already validated/invalidated against upstream
+  Used to show tokens used to refresh feature caches, but also tokens already validated/invalidated against upstream
+* `--disable-instance-data-endpoint` — Disables /internal-backstage/instancedata endpoint
 
-
+  Used to show instance data for the edge instance.
 
 ## `unleash-edge edge`
 
@@ -89,27 +125,39 @@ Run in edge mode
 
 ###### **Options:**
 
-* `-u`, `--upstream-url <UPSTREAM_URL>` — Where is your upstream URL. Remember, this is the URL to your instance, without any trailing /api suffix
-* `-b`, `--backup-folder <BACKUP_FOLDER>` — A path to a local folder. Edge will write feature and token data to disk in this folder and read this back after restart. Mutually exclusive with the --redis-url option
+* `-u`, `--upstream-url <UPSTREAM_URL>` — Where is your upstream URL. Remember, this is the URL to your instance,
+  without any trailing /api suffix
+* `-b`, `--backup-folder <BACKUP_FOLDER>` — A path to a local folder. Edge will write feature and token data to disk in
+  this folder and read this back after restart. Mutually exclusive with the --redis-url option
 * `-m`, `--metrics-interval-seconds <METRICS_INTERVAL_SECONDS>` — How often should we post metrics upstream?
 
   Default value: `60`
-* `-f`, `--features-refresh-interval-seconds <FEATURES_REFRESH_INTERVAL_SECONDS>` — How long between each refresh for a token
+* `-f`, `--features-refresh-interval-seconds <FEATURES_REFRESH_INTERVAL_SECONDS>` — How long between each refresh for a
+  token
 
   Default value: `10`
-* `--token-revalidation-interval-seconds <TOKEN_REVALIDATION_INTERVAL_SECONDS>` — How long between each revalidation of a token
+* `--token-revalidation-interval-seconds <TOKEN_REVALIDATION_INTERVAL_SECONDS>` — How long between each revalidation of
+  a token
 
   Default value: `3600`
-* `-t`, `--tokens <TOKENS>` — Get data for these client tokens at startup. Accepts comma-separated list of tokens. Hot starts your feature cache
-* `-H`, `--custom-client-headers <CUSTOM_CLIENT_HEADERS>` — Expects curl header format (-H <HEADERNAME>: <HEADERVALUE>) for instance `-H X-Api-Key: mysecretapikey`
-* `-s`, `--skip-ssl-verification` — If set to true, we will skip SSL verification when connecting to the upstream Unleash server
+* `-t`, `--tokens <TOKENS>` — Get data for these client tokens at startup. Accepts comma-separated list of tokens. Hot
+  starts your feature cache
+* `-H`, `--custom-client-headers <CUSTOM_CLIENT_HEADERS>` — Expects curl header format (-H <HEADERNAME>: <HEADERVALUE>)
+  for instance `-H X-Api-Key: mysecretapikey`
+* `-s`, `--skip-ssl-verification` — If set to true, we will skip SSL verification when connecting to the upstream
+  Unleash server
 
   Default value: `false`
-* `--pkcs8-client-certificate-file <PKCS8_CLIENT_CERTIFICATE_FILE>` — Client certificate chain in PEM encoded X509 format with the leaf certificate first. The certificate chain should contain any intermediate certificates that should be sent to clients to allow them to build a chain to a trusted root
-* `--pkcs8-client-key-file <PKCS8_CLIENT_KEY_FILE>` — Client key is a PEM encoded PKCS#8 formatted private key for the leaf certificate
-* `--pkcs12-identity-file <PKCS12_IDENTITY_FILE>` — Identity file in pkcs12 format. Typically this file has a pfx extension
+* `--pkcs8-client-certificate-file <PKCS8_CLIENT_CERTIFICATE_FILE>` — Client certificate chain in PEM encoded X509
+  format with the leaf certificate first. The certificate chain should contain any intermediate certificates that should
+  be sent to clients to allow them to build a chain to a trusted root
+* `--pkcs8-client-key-file <PKCS8_CLIENT_KEY_FILE>` — Client key is a PEM encoded PKCS#8 formatted private key for the
+  leaf certificate
+* `--pkcs12-identity-file <PKCS12_IDENTITY_FILE>` — Identity file in pkcs12 format. Typically this file has a pfx
+  extension
 * `--pkcs12-passphrase <PKCS12_PASSPHRASE>` — Passphrase used to unlock the pkcs12 file
-* `--upstream-certificate-file <UPSTREAM_CERTIFICATE_FILE>` — Extra certificate passed to the client for building its trust chain. Needs to be in PEM format (crt or pem extensions usually are)
+* `--upstream-certificate-file <UPSTREAM_CERTIFICATE_FILE>` — Extra certificate passed to the client for building its
+  trust chain. Needs to be in PEM format (crt or pem extensions usually are)
 * `--upstream-request-timeout <UPSTREAM_REQUEST_TIMEOUT>` — Timeout for requests to the upstream server
 
   Default value: `5`
@@ -136,31 +184,36 @@ Run in edge mode
 
   Possible values: `tcp`, `tls`, `redis`, `rediss`, `redis-unix`, `unix`
 
-* `--redis-read-connection-timeout-milliseconds <REDIS_READ_CONNECTION_TIMEOUT_MILLISECONDS>` — Timeout (in milliseconds) for waiting for a successful connection to redis, when restoring
+* `--redis-read-connection-timeout-milliseconds <REDIS_READ_CONNECTION_TIMEOUT_MILLISECONDS>` — Timeout (in
+  milliseconds) for waiting for a successful connection to redis, when restoring
 
   Default value: `2000`
-* `--redis-write-connection-timeout-milliseconds <REDIS_WRITE_CONNECTION_TIMEOUT_MILLISECONDS>` — Timeout (in milliseconds) for waiting for a successful connection to redis when persisting
+* `--redis-write-connection-timeout-milliseconds <REDIS_WRITE_CONNECTION_TIMEOUT_MILLISECONDS>` — Timeout (in
+  milliseconds) for waiting for a successful connection to redis when persisting
 
   Default value: `2000`
 * `--s3-bucket-name <S3_BUCKET_NAME>` — Bucket name to use for storing feature and token data
-* `--token-header <TOKEN_HEADER>` — Token header to use for both edge authorization and communication with the upstream server
+* `--token-header <TOKEN_HEADER>` — Token header to use for both edge authorization and communication with the upstream
+  server
 
   Default value: `Authorization`
-* `--strict` — If set to true, Edge starts with strict behavior. Strict behavior means that Edge will refuse tokens outside the scope of the startup tokens
+* `--strict` — If set to true, Edge starts with strict behavior. Strict behavior means that Edge will refuse tokens
+  outside the scope of the startup tokens
 
   Default value: `false`
-* `--dynamic` — If set to true, Edge starts with dynamic behavior. Dynamic behavior means that Edge will accept tokens outside the scope of the startup tokens
+* `--dynamic` — If set to true, Edge starts with dynamic behavior. Dynamic behavior means that Edge will accept tokens
+  outside the scope of the startup tokens
 
   Default value: `false`
-* `--prometheus-remote-write-url <PROMETHEUS_REMOTE_WRITE_URL>` — Sets a remote write url for prometheus metrics, if this is set, prometheus metrics will be written upstream
-* `--prometheus-push-interval <PROMETHEUS_PUSH_INTERVAL>` — Sets the interval for prometheus push metrics, only relevant if `prometheus_remote_write_url` is set. Defaults to 60 seconds
+* `--prometheus-remote-write-url <PROMETHEUS_REMOTE_WRITE_URL>` — Sets a remote write url for prometheus metrics, if
+  this is set, prometheus metrics will be written upstream
+* `--prometheus-push-interval <PROMETHEUS_PUSH_INTERVAL>` — Sets the interval for prometheus push metrics, only relevant
+  if `prometheus_remote_write_url` is set. Defaults to 60 seconds
 
   Default value: `60`
 * `--prometheus-username <PROMETHEUS_USERNAME>`
 * `--prometheus-password <PROMETHEUS_PASSWORD>`
 * `--prometheus-user-id <PROMETHEUS_USER_ID>`
-
-
 
 ## `unleash-edge offline`
 
@@ -171,14 +224,17 @@ Run in offline mode
 ###### **Options:**
 
 * `-b`, `--bootstrap-file <BOOTSTRAP_FILE>` — The file to load our features from. This data will be loaded at startup
-* `-t`, `--tokens <TOKENS>` — Tokens that should be allowed to connect to Edge. Supports a comma separated list or multiple instances of the `--tokens` argument (v19.4.0) deprecated "Please use --client-tokens | CLIENT_TOKENS instead"
-* `-c`, `--client-tokens <CLIENT_TOKENS>` — Client tokens that should be allowed to connect to Edge. Supports a comma separated list or multiple instances of the `--client-tokens` argument
-* `-f`, `--frontend-tokens <FRONTEND_TOKENS>` — Frontend tokens that should be allowed to connect to Edge. Supports a comma separated list or multiple instances of the `--frontend-tokens` argument
-* `-r`, `--reload-interval <RELOAD_INTERVAL>` — The interval in seconds between reloading the bootstrap file. Disabled if unset or 0
+* `-t`, `--tokens <TOKENS>` — Tokens that should be allowed to connect to Edge. Supports a comma separated list or
+  multiple instances of the `--tokens` argument (v19.4.0) deprecated "Please use --client-tokens | CLIENT_TOKENS
+  instead"
+* `-c`, `--client-tokens <CLIENT_TOKENS>` — Client tokens that should be allowed to connect to Edge. Supports a comma
+  separated list or multiple instances of the `--client-tokens` argument
+* `-f`, `--frontend-tokens <FRONTEND_TOKENS>` — Frontend tokens that should be allowed to connect to Edge. Supports a
+  comma separated list or multiple instances of the `--frontend-tokens` argument
+* `-r`, `--reload-interval <RELOAD_INTERVAL>` — The interval in seconds between reloading the bootstrap file. Disabled
+  if unset or 0
 
   Default value: `0`
-
-
 
 ## `unleash-edge health`
 
@@ -191,9 +247,8 @@ Perform a health check against a running edge instance
 * `-e`, `--edge-url <EDGE_URL>` — Where the instance you want to health check is running
 
   Default value: `http://localhost:3063`
-* `-c`, `--ca-certificate-file <CA_CERTIFICATE_FILE>` — If you're hosting Edge using a self-signed TLS certificate use this to tell healthcheck about your CA
-
-
+* `-c`, `--ca-certificate-file <CA_CERTIFICATE_FILE>` — If you're hosting Edge using a self-signed TLS certificate use
+  this to tell healthcheck about your CA
 
 ## `unleash-edge ready`
 
@@ -206,14 +261,13 @@ Perform a ready check against a running edge instance
 * `-e`, `--edge-url <EDGE_URL>` — Where the instance you want to health check is running
 
   Default value: `http://localhost:3063`
-* `-c`, `--ca-certificate-file <CA_CERTIFICATE_FILE>` — If you're hosting Edge using a self-signed TLS certificate use this to tell the readychecker about your CA
-
-
+* `-c`, `--ca-certificate-file <CA_CERTIFICATE_FILE>` — If you're hosting Edge using a self-signed TLS certificate use
+  this to tell the readychecker about your CA
 
 <hr/>
 
 <small><i>
-    This document was generated automatically by
-    <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
+This document was generated automatically by
+<a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
 </i></small>
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "actix-allow-deny-middleware"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442087d0c853a7adb6633c0b0a37304ca419daff8f7a1f66f81cd3c0592599f4"
+dependencies = [
+ "actix-service",
+ "actix-web",
+ "ipnet",
+ "tracing",
+]
+
+[[package]]
 name = "actix-codec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4819,6 +4831,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 name = "unleash-edge"
 version = "19.7.0"
 dependencies = [
+ "actix-allow-deny-middleware",
  "actix-cors",
  "actix-http",
  "actix-http-test",
@@ -4842,6 +4855,7 @@ dependencies = [
  "eventsource-client",
  "futures",
  "futures-core",
+ "ipnet",
  "iter_tools",
  "itertools 0.14.0",
  "json-structural-diff",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -25,6 +25,7 @@ eula = false
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
 
 [dependencies]
+actix-allow-deny-middleware = "0.1.1"
 actix-cors = "0.7.0"
 actix-http = "3.9.0"
 actix-middleware-etag = "0.4.4"
@@ -45,6 +46,7 @@ dashmap = { version = "6.1.0", features = ["serde"] }
 eventsource-client = { version = "0.14.0" }
 futures = "0.3.31"
 futures-core = "0.3.31"
+ipnet = "2.11.0"
 iter_tools = "0.24.0"
 itertools = "0.14.0"
 json-structural-diff = "0.2.0"

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -948,19 +948,16 @@ mod tests {
         let args = CliArgs::try_parse_from(args);
         assert!(args.is_ok());
         assert_eq!(
-            args.unwrap().http.allow_list.first(),
+            args.unwrap().http.allow_list.unwrap().first(),
             IpNet::from_str("192.168.0.0/16").ok().as_ref()
         );
     }
     #[test]
-    pub fn default_allow_list() {
+    pub fn default_allow_list_is_empty() {
         let args = vec!["unleash-edge", "edge", "-u http://localhost:4242"];
         let args = CliArgs::try_parse_from(args);
         assert!(args.is_ok());
-        assert_eq!(
-            args.unwrap().http.allow_list.first(),
-            IpNet::from_str("0.0.0.0/0").ok().as_ref()
-        );
+        assert!(args.unwrap().http.allow_list.is_none());
     }
 
     #[test]

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -4,12 +4,12 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
 
+use crate::error;
 use actix_cors::Cors;
 use actix_http::Method;
 use cidr::{Ipv4Cidr, Ipv6Cidr};
 use clap::{ArgGroup, Args, Parser, Subcommand, ValueEnum};
-
-use crate::error;
+use ipnet::IpNet;
 
 #[derive(Subcommand, Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
@@ -433,14 +433,19 @@ pub fn parse_http_method(value: &str) -> Result<actix_http::Method, String> {
 
 #[derive(Args, Debug, Clone)]
 pub struct CorsOptions {
+    /// Sets the [Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) header to this value
     #[clap(env, long, value_delimiter = ',')]
     pub cors_origin: Option<Vec<String>>,
+    /// Sets the [Access-Control-Allow-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) header to this value
     #[clap(env, long, value_delimiter = ',')]
     pub cors_allowed_headers: Option<Vec<String>>,
+    /// Sets the [Access-Control-Max-Age](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age) header to this value
     #[clap(env, long, default_value_t = 172800)]
     pub cors_max_age: usize,
+    /// Sets the [Access-Control-Expose-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers) header to this value
     #[clap(env, long, value_delimiter = ',')]
     pub cors_exposed_headers: Option<Vec<String>>,
+    /// Sets the [Access-Control-Allow-Methods](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods) header to this value
     #[clap(env, long, value_delimiter = ',', value_parser = parse_http_method)]
     pub cors_methods: Option<Vec<actix_http::Method>>,
 }
@@ -496,6 +501,18 @@ pub struct HttpServerArgs {
 
     #[clap(flatten)]
     pub cors: CorsOptions,
+
+    /// Configures the AllowList middleware to only accept requests from IPs that belong to the CIDRs configured here. Defaults to 0.0.0.0/0 (ALL Ips)
+    #[clap(long, env, global=true, default_value = "0.0.0.0/0", value_delimiter = ',', value_parser = ip_net_parser)]
+    pub allow_list: Vec<IpNet>,
+
+    /// Configures the DenyList middleware to deny requests from IPs that belong to the CIDRs configured here. Defaults to denying no IPs.
+    #[clap(long, env, global=true, value_parser = ip_net_parser, value_delimiter = ',')]
+    pub deny_list: Option<Vec<IpNet>>,
+}
+
+fn ip_net_parser(arg: &str) -> Result<IpNet, String> {
+    IpNet::from_str(arg).map_err(|e| format!("{e}"))
 }
 
 #[derive(Debug, Clone)]
@@ -546,6 +563,8 @@ impl HttpServerArgs {
 mod tests {
     use actix_web::http;
     use clap::Parser;
+    use ipnet::IpNet;
+    use std::str::FromStr;
     use tracing::info;
     use tracing_test::traced_test;
 
@@ -915,5 +934,73 @@ mod tests {
             .unwrap()
             .to_string()
             .contains(error::TRUST_PROXY_PARSE_ERROR));
+    }
+
+    #[test]
+    pub fn can_parse_allow_list_cidrs() {
+        let args = vec![
+            "unleash-edge",
+            "--allow-list",
+            "192.168.0.0/16",
+            "edge",
+            "-u http://localhost:4242",
+        ];
+        let args = CliArgs::try_parse_from(args);
+        assert!(args.is_ok());
+        assert_eq!(
+            args.unwrap().http.allow_list.first(),
+            IpNet::from_str("192.168.0.0/16").ok().as_ref()
+        );
+    }
+    #[test]
+    pub fn default_allow_list() {
+        let args = vec!["unleash-edge", "edge", "-u http://localhost:4242"];
+        let args = CliArgs::try_parse_from(args);
+        assert!(args.is_ok());
+        assert_eq!(
+            args.unwrap().http.allow_list.first(),
+            IpNet::from_str("0.0.0.0/0").ok().as_ref()
+        );
+    }
+
+    #[test]
+    pub fn errors_if_allow_list_is_not_a_valid_cidr() {
+        let args = vec![
+            "unleash-edge",
+            "--allow-list",
+            "192.168.0.1",
+            "edge",
+            "-u http://localhost:4242",
+        ];
+        let args = CliArgs::try_parse_from(args);
+        assert!(args.is_err());
+        if let Err(e) = args {
+            assert!(e.to_string().contains("invalid IP address syntax"));
+        }
+    }
+
+    #[test]
+    pub fn no_default_deny_list() {
+        let args = vec!["unleash-edge", "edge", "-u http://localhost:4242"];
+        let args = CliArgs::try_parse_from(args);
+        assert!(args.is_ok());
+        assert!(args.unwrap().http.deny_list.is_none())
+    }
+
+    #[test]
+    pub fn can_parse_deny_list_cidrs() {
+        let args = vec![
+            "unleash-edge",
+            "--deny-list",
+            "192.168.0.0/16",
+            "edge",
+            "-u http://localhost:4242",
+        ];
+        let args = CliArgs::try_parse_from(args);
+        assert!(args.is_ok());
+        assert_eq!(
+            args.unwrap().http.deny_list.unwrap().first(),
+            IpNet::from_str("192.168.0.0/16").ok().as_ref()
+        );
     }
 }

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -502,9 +502,9 @@ pub struct HttpServerArgs {
     #[clap(flatten)]
     pub cors: CorsOptions,
 
-    /// Configures the AllowList middleware to only accept requests from IPs that belong to the CIDRs configured here. Defaults to 0.0.0.0/0 (ALL Ips)
-    #[clap(long, env, global=true, default_value = "0.0.0.0/0", value_delimiter = ',', value_parser = ip_net_parser)]
-    pub allow_list: Vec<IpNet>,
+    /// Configures the AllowList middleware to only accept requests from IPs that belong to the CIDRs configured here. Defaults to 0.0.0.0/0, ::/0 (ALL Ips v4 and v6)
+    #[clap(long, env, global=true, value_delimiter = ',', value_parser = ip_net_parser)]
+    pub allow_list: Option<Vec<IpNet>>,
 
     /// Configures the DenyList middleware to deny requests from IPs that belong to the CIDRs configured here. Defaults to denying no IPs.
     #[clap(long, env, global=true, value_parser = ip_net_parser, value_delimiter = ',')]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,3 +1,4 @@
+use actix_allow_deny_middleware::{AllowList, DenyList};
 use actix_middleware_etag::Etag;
 use actix_web::middleware::Logger;
 use actix_web::{web, App, HttpServer};
@@ -93,7 +94,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let lazy_token_cache = token_cache.clone();
     let lazy_engine_cache = engine_cache.clone();
     let lazy_feature_refresher = feature_refresher.clone();
-
+    let http_args_for_app_setup = args.http.clone();
     let metrics_cache = Arc::new(MetricsCache::default());
     let metrics_cache_clone = metrics_cache.clone();
 
@@ -143,6 +144,15 @@ async fn main() -> Result<(), anyhow::Error> {
                 .wrap(actix_web::middleware::Compress::default())
                 .wrap(actix_web::middleware::NormalizePath::default())
                 .wrap(cors_middleware)
+                .wrap(DenyList::with_denied_ipnets(
+                    &http_args_for_app_setup
+                        .deny_list
+                        .clone()
+                        .unwrap_or_default(),
+                ))
+                .wrap(AllowList::with_allowed_ipnets(
+                    &http_args_for_app_setup.allow_list,
+                ))
                 .wrap(request_metrics.clone())
                 .wrap(Logger::default())
                 .service(web::scope("/internal-backstage").configure(|service_cfg| {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -150,9 +150,13 @@ async fn main() -> Result<(), anyhow::Error> {
                         .clone()
                         .unwrap_or_default(),
                 ))
-                .wrap(AllowList::with_allowed_ipnets(
-                    &http_args_for_app_setup.allow_list,
-                ))
+                .wrap(
+                    http_args_for_app_setup
+                        .allow_list
+                        .clone()
+                        .map(|list| AllowList::with_allowed_ipnets(&list))
+                        .unwrap_or(AllowList::default()),
+                )
                 .wrap(request_metrics.clone())
                 .wrap(Logger::default())
                 .service(web::scope("/internal-backstage").configure(|service_cfg| {


### PR DESCRIPTION
Uses https://github.com/Unleash/actix-allow-deny-middleware to configure an allow- and a deny-list for access to the server. By default configures the allow list to allow all IPs and the deny list to be empty (deny no IPs).