### PR TITLE
feat: sync refresh-interval with other SDKs

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -96,7 +96,7 @@ Run in edge mode
   Default value: `60`
 * `-f`, `--features-refresh-interval-seconds <FEATURES_REFRESH_INTERVAL_SECONDS>` — How long between each refresh for a token
 
-  Default value: `10`
+  Default value: `15`
 * `--token-revalidation-interval-seconds <TOKEN_REVALIDATION_INTERVAL_SECONDS>` — How long between each revalidation of a token
 
   Default value: `3600`

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -162,7 +162,7 @@ pub struct EdgeArgs {
     #[clap(short, long, env, default_value_t = 60)]
     pub metrics_interval_seconds: u64,
     /// How long between each refresh for a token
-    #[clap(short, long, env, default_value_t = 10)]
+    #[clap(short, long, env, default_value_t = 15)]
     pub features_refresh_interval_seconds: u64,
 
     /// How long between each revalidation of a token

--- a/server/src/http/refresher/feature_refresher.rs
+++ b/server/src/http/refresher/feature_refresher.rs
@@ -61,7 +61,7 @@ pub struct FeatureRefresher {
 impl Default for FeatureRefresher {
     fn default() -> Self {
         Self {
-            refresh_interval: chrono::Duration::seconds(10),
+            refresh_interval: chrono::Duration::seconds(15),
             unleash_client: Default::default(),
             tokens_to_refresh: Arc::new(DashMap::default()),
             features_cache: Arc::new(Default::default()),


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

We have an ongoing initiative to sync refresh intervals across SDKs. This PR sets fetch flags refresh interval to 15 seconds instead of 10. Also updated README

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
