### PR TITLE
fix: make sure we sort the list of frontend results by feature name

### DIFF
--- a/examples/frontend-stable-sort.json
+++ b/examples/frontend-stable-sort.json
@@ -1,0 +1,76 @@
+{
+  "version": 2,
+  "features": [
+    {
+      "name": "my-projects",
+      "type": "release",
+      "enabled": true,
+      "stale": false,
+      "impressionData": false,
+      "project": "default",
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "constraints": [],
+          "parameters": {
+            "groupId": "my-projects",
+            "rollout": "100",
+            "stickiness": "default"
+          },
+          "variants": []
+        }
+      ],
+      "variants": []
+    },
+    {
+      "name": "ssp.escalations",
+      "type": "release",
+      "enabled": true,
+      "stale": false,
+      "impressionData": false,
+      "project": "default",
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "constraints": [],
+          "parameters": {
+            "groupId": "ssp.escalations",
+            "rollout": "100",
+            "stickiness": "default"
+          },
+          "variants": []
+        }
+      ],
+      "variants": []
+    },
+    {
+      "name": "ssp.user-management",
+      "type": "release",
+      "enabled": true,
+      "stale": false,
+      "impressionData": false,
+      "project": "default",
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "constraints": [],
+          "parameters": {
+            "groupId": "ssp.user-management",
+            "rollout": "100",
+            "stickiness": "default"
+          },
+          "variants": []
+        }
+      ],
+      "variants": []
+    }
+  ],
+  "segments": [],
+  "query": {
+    "projects": [
+      "*"
+    ],
+    "environment": "development",
+    "inlineSegmentConstraints": false
+  }
+}


### PR DESCRIPTION
With a great example in #797 for why they get 200 on their frontend.

We figured out that we didn't have a stable sort for our feature flags with the frontend API. 

This PR adds sorted_by_key to the list of frontend_results and a test to verify that we get 304 for multiple requests, removing the sorted_by_key causes the test to fail. 

fixes #797