### PR TITLE
chore: let streaming test output any issues to stdout

### DIFF
--- a/server/tests/streaming_test.rs
+++ b/server/tests/streaming_test.rs
@@ -65,8 +65,6 @@ mod streaming_test {
             .arg("--delta")
             .arg("-t")
             .arg(&upstream_known_token.token)
-            .stdout(Stdio::null()) // Suppress stdout
-            .stderr(Stdio::null()) // Suppress stderr
             .spawn()
             .expect("Failed to start the app");
 


### PR DESCRIPTION
Removing the suppressing of stdout/in as it made debugging a failing test harder