### PR TITLE
docs: fix formatting issue in cli.md

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -120,7 +120,7 @@ Run in edge mode
 
   Default value: `3600`
 * `-t`, `--tokens <TOKENS>` — Get data for these client tokens at startup. Accepts comma-separated list of tokens. Hot starts your feature cache
-* `-H`, `--custom-client-headers <CUSTOM_CLIENT_HEADERS>` — Expects curl header format (-H <HEADERNAME>: <HEADERVALUE>) for instance `-H X-Api-Key: mysecretapikey`
+* `-H`, `--custom-client-headers <CUSTOM_CLIENT_HEADERS>` — Expects curl header format (`-H <HEADERNAME>: <HEADERVALUE>`) for instance `-H X-Api-Key: mysecretapikey`
 * `-s`, `--skip-ssl-verification` — If set to true, we will skip SSL verification when connecting to the upstream Unleash server
 
   Default value: `false`


### PR DESCRIPTION
Fixing a pair of unescaped < and > in CLI.md. Without code formatting, they are treated as the start and end of HTML tags and break the rendering. The MDX parser is also unhappy and throws an error in the docs.
