### PR TITLE
chore: move s3 persistence behind flag

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -24,6 +24,10 @@ eula = false
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
 
+[features]
+default = ["s3-persistence"]
+s3-persistence = ["aws-sdk-s3", "aws-config"]
+
 [dependencies]
 actix-allow-deny-middleware = "0.1.1"
 actix-cors = "0.7.1"
@@ -35,8 +39,8 @@ actix-web-lab = { version = "0.24.1" }
 ahash = "0.8.11"
 anyhow = "1.0.98"
 async-trait = "0.1.88"
-aws-config = { version = "1.6.1", features = ["behavior-version-latest"] }
-aws-sdk-s3 = { version = "1.82.0", features = ["behavior-version-latest"] }
+aws-config = { version = "1.6.1", optional = true, features = ["behavior-version-latest"] }
+aws-sdk-s3 = { version = "1.82.0", optional = true, features = ["behavior-version-latest"] }
 base64 = "0.22.1"
 chrono = { version = "0.4.40", features = ["serde"] }
 cidr = "0.3.1"

--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -19,7 +19,8 @@ use crate::offline::offline_hotload::{load_bootstrap, load_offline_engine_cache}
 use crate::persistence::EdgePersistence;
 use crate::persistence::file::FilePersister;
 use crate::persistence::redis::RedisPersister;
-use crate::persistence::s3::S3Persister;
+#[cfg(feature = "s3-persistence")]
+use crate::persistence::s3::s3_persister::S3Persister;
 use crate::{
     auth::token_validator::TokenValidator,
     cli::{CliArgs, EdgeArgs, EdgeMode, OfflineArgs},
@@ -207,7 +208,7 @@ async fn get_data_source(args: &EdgeArgs) -> Option<Arc<dyn EdgePersistence>> {
         });
         return Some(Arc::new(redis_persister));
     }
-
+    #[cfg(feature = "s3-persistence")]
     if let Some(s3_args) = args.s3.clone() {
         let s3_persister = S3Persister::new_from_env(
             &s3_args

--- a/server/src/persistence/s3.rs
+++ b/server/src/persistence/s3.rs
@@ -1,138 +1,146 @@
-use std::collections::HashMap;
+#![cfg(feature = "s3-persistence")]
+pub mod s3_persister {
 
-use async_trait::async_trait;
-use unleash_types::client_features::ClientFeatures;
+    use std::collections::HashMap;
 
-use super::EdgePersistence;
-use crate::{
-    error::EdgeError,
-    types::{EdgeResult, EdgeToken},
-};
-use aws_sdk_s3::{
-    self as s3,
-    error::SdkError,
-    operation::{get_object::GetObjectError, put_object::PutObjectError},
-    primitives::{ByteStream, SdkBody},
-};
+    use async_trait::async_trait;
+    use unleash_types::client_features::ClientFeatures;
 
-pub const FEATURES_KEY: &str = "/unleash-features.json";
-pub const TOKENS_KEY: &str = "/unleash-tokens.json";
+    use crate::persistence::EdgePersistence;
+    use crate::{
+        error::EdgeError,
+        types::{EdgeResult, EdgeToken},
+    };
+    use aws_sdk_s3::{
+        self as s3,
+        error::SdkError,
+        operation::{get_object::GetObjectError, put_object::PutObjectError},
+        primitives::{ByteStream, SdkBody},
+    };
 
-pub struct S3Persister {
-    client: s3::Client,
-    bucket: String,
-}
+    pub const FEATURES_KEY: &str = "/unleash-features.json";
+    pub const TOKENS_KEY: &str = "/unleash-tokens.json";
 
-impl S3Persister {
-    pub fn new_with_config(bucket_name: &str, config: s3::config::Config) -> Self {
-        let client = s3::Client::from_conf(config);
-        Self {
-            client,
-            bucket: bucket_name.to_string(),
-        }
-    }
-    pub async fn new_from_env(bucket_name: &str) -> Self {
-        let shared_config = aws_config::load_from_env().await;
-        let client = s3::Client::new(&shared_config);
-        Self {
-            client,
-            bucket: bucket_name.to_string(),
-        }
-    }
-}
-
-impl From<SdkError<GetObjectError>> for EdgeError {
-    fn from(err: SdkError<GetObjectError>) -> Self {
-        EdgeError::PersistenceError(format!("failed to get object {}", err))
-    }
-}
-
-impl From<SdkError<PutObjectError>> for EdgeError {
-    fn from(err: SdkError<PutObjectError>) -> Self {
-        EdgeError::PersistenceError(format!("failed to put object {}", err))
-    }
-}
-
-#[async_trait]
-impl EdgePersistence for S3Persister {
-    async fn load_tokens(&self) -> EdgeResult<Vec<EdgeToken>> {
-        let response = self
-            .client
-            .get_object()
-            .bucket(self.bucket.clone())
-            .key(TOKENS_KEY)
-            .response_content_type("application/json")
-            .send()
-            .await?;
-        let data = response.body.collect().await.expect("Failed data");
-        serde_json::from_slice(&data.to_vec())
-            .map_err(|_| EdgeError::PersistenceError("Failed to deserialize tokens".to_string()))
+    pub struct S3Persister {
+        client: s3::Client,
+        bucket: String,
     }
 
-    async fn save_tokens(&self, tokens: Vec<EdgeToken>) -> EdgeResult<()> {
-        let body_data = serde_json::to_vec(&tokens)
-            .map_err(|_| EdgeError::PersistenceError("Failed to serialize tokens".to_string()))
-            .map(SdkBody::from)?;
-        let byte_stream = aws_sdk_s3::primitives::ByteStream::new(body_data);
-        self.client
-            .put_object()
-            .bucket(self.bucket.clone())
-            .key(TOKENS_KEY)
-            .body(byte_stream)
-            .send()
-            .await
-            .map(|_| ())
-            .map_err(|_err| EdgeError::PersistenceError("Failed to save tokens".to_string()))
-    }
-
-    async fn load_features(&self) -> EdgeResult<HashMap<String, ClientFeatures>> {
-        let query = self
-            .client
-            .get_object()
-            .bucket(self.bucket.clone())
-            .key(FEATURES_KEY)
-            .response_content_type("application/json")
-            .send()
-            .await
-            .map_err(|err| {
-                if err.to_string().contains("NoSuchKey") {
-                    return EdgeError::PersistenceError("No features found".to_string());
-                }
-                EdgeError::PersistenceError("Failed to load features".to_string())
-            });
-        match query {
-            Ok(response) => {
-                let data = response.body.collect().await.expect("Failed data");
-                let deser: Vec<(String, ClientFeatures)> = serde_json::from_slice(&data.to_vec())
-                    .map_err(|_| {
-                    EdgeError::PersistenceError("Failed to deserialize features".to_string())
-                })?;
-                Ok(deser
-                    .iter()
-                    .cloned()
-                    .collect::<HashMap<String, ClientFeatures>>())
+    impl S3Persister {
+        pub fn new_with_config(bucket_name: &str, config: s3::config::Config) -> Self {
+            let client = s3::Client::from_conf(config);
+            Self {
+                client,
+                bucket: bucket_name.to_string(),
             }
-            Err(_e) => Ok(HashMap::new()),
+        }
+        pub async fn new_from_env(bucket_name: &str) -> Self {
+            let shared_config = aws_config::load_from_env().await;
+            let client = s3::Client::new(&shared_config);
+            Self {
+                client,
+                bucket: bucket_name.to_string(),
+            }
         }
     }
 
-    async fn save_features(&self, features: Vec<(String, ClientFeatures)>) -> EdgeResult<()> {
-        let body_data = serde_json::to_vec(&features)
-            .map_err(|_| EdgeError::PersistenceError("Failed to serialize features".to_string()))?;
-        let byte_stream = ByteStream::new(SdkBody::from(body_data));
-        match self
-            .client
-            .put_object()
-            .bucket(self.bucket.clone())
-            .key(FEATURES_KEY)
-            .body(byte_stream)
-            .send()
-            .await
-        {
-            Ok(_) => Ok(()),
-            Err(_s3_err) => Err(EdgeError::PersistenceError(
-                "Failed to save features".to_string(),
-            )),
+    impl From<SdkError<GetObjectError>> for EdgeError {
+        fn from(err: SdkError<GetObjectError>) -> Self {
+            EdgeError::PersistenceError(format!("failed to get object {}", err))
+        }
+    }
+
+    impl From<SdkError<PutObjectError>> for EdgeError {
+        fn from(err: SdkError<PutObjectError>) -> Self {
+            EdgeError::PersistenceError(format!("failed to put object {}", err))
+        }
+    }
+
+    #[async_trait]
+    impl EdgePersistence for S3Persister {
+        async fn load_tokens(&self) -> EdgeResult<Vec<EdgeToken>> {
+            let response = self
+                .client
+                .get_object()
+                .bucket(self.bucket.clone())
+                .key(TOKENS_KEY)
+                .response_content_type("application/json")
+                .send()
+                .await?;
+            let data = response.body.collect().await.expect("Failed data");
+            serde_json::from_slice(&data.to_vec()).map_err(|_| {
+                EdgeError::PersistenceError("Failed to deserialize tokens".to_string())
+            })
+        }
+
+        async fn save_tokens(&self, tokens: Vec<EdgeToken>) -> EdgeResult<()> {
+            let body_data = serde_json::to_vec(&tokens)
+                .map_err(|_| EdgeError::PersistenceError("Failed to serialize tokens".to_string()))
+                .map(SdkBody::from)?;
+            let byte_stream = aws_sdk_s3::primitives::ByteStream::new(body_data);
+            self.client
+                .put_object()
+                .bucket(self.bucket.clone())
+                .key(TOKENS_KEY)
+                .body(byte_stream)
+                .send()
+                .await
+                .map(|_| ())
+                .map_err(|_err| EdgeError::PersistenceError("Failed to save tokens".to_string()))
+        }
+
+        async fn load_features(&self) -> EdgeResult<HashMap<String, ClientFeatures>> {
+            let query = self
+                .client
+                .get_object()
+                .bucket(self.bucket.clone())
+                .key(FEATURES_KEY)
+                .response_content_type("application/json")
+                .send()
+                .await
+                .map_err(|err| {
+                    if err.to_string().contains("NoSuchKey") {
+                        return EdgeError::PersistenceError("No features found".to_string());
+                    }
+                    EdgeError::PersistenceError("Failed to load features".to_string())
+                });
+            match query {
+                Ok(response) => {
+                    let data = response.body.collect().await.expect("Failed data");
+                    let deser: Vec<(String, ClientFeatures)> =
+                        serde_json::from_slice(&data.to_vec()).map_err(|_| {
+                            EdgeError::PersistenceError(
+                                "Failed to deserialize features".to_string(),
+                            )
+                        })?;
+                    Ok(deser
+                        .iter()
+                        .cloned()
+                        .collect::<HashMap<String, ClientFeatures>>())
+                }
+                Err(_e) => Ok(HashMap::new()),
+            }
+        }
+
+        async fn save_features(&self, features: Vec<(String, ClientFeatures)>) -> EdgeResult<()> {
+            let body_data = serde_json::to_vec(&features).map_err(|_| {
+                EdgeError::PersistenceError("Failed to serialize features".to_string())
+            })?;
+            let byte_stream = ByteStream::new(SdkBody::from(body_data));
+            match self
+                .client
+                .put_object()
+                .bucket(self.bucket.clone())
+                .key(FEATURES_KEY)
+                .body(byte_stream)
+                .send()
+                .await
+            {
+                Ok(_) => Ok(()),
+                Err(_s3_err) => Err(EdgeError::PersistenceError(
+                    "Failed to save features".to_string(),
+                )),
+            }
         }
     }
 }

--- a/server/tests/s3_tests.rs
+++ b/server/tests/s3_tests.rs
@@ -1,4 +1,4 @@
-#[cfg(test)]
+#[cfg(all(test, feature = "s3-persistence"))]
 mod s3_tests {
 
     use std::collections::HashMap;
@@ -11,7 +11,7 @@ mod s3_tests {
     use testcontainers::{ImageExt, runners::AsyncRunner};
     use testcontainers_modules::localstack::LocalStack;
     use unleash_edge::persistence::EdgePersistence;
-    use unleash_edge::persistence::s3::S3Persister;
+    use unleash_edge::persistence::s3::s3_persister::S3Persister;
     use unleash_edge::types::EdgeToken;
     use unleash_types::client_features::ClientFeature;
     use unleash_types::client_features::ClientFeatures;


### PR DESCRIPTION
Moves the S3 persister behind a flag so we can optionally not compile the AWS SDK stuff because it's really really heavy. This lets us run builds with --no-default-features. That's about 30-40% faster

Left this on by default so it's opt out