### PR TITLE
chore: trusted token plumbing

### DIFF
--- a/server/src/auth/token_validator.rs
+++ b/server/src/auth/token_validator.rs
@@ -18,6 +18,21 @@ pub struct TokenValidator {
     pub persistence: Option<Arc<dyn EdgePersistence>>,
 }
 
+pub(crate) trait TokenRegister {
+    async fn register_token(&self, token: String) -> EdgeResult<EdgeToken>;
+}
+
+impl TokenRegister for TokenValidator {
+    async fn register_token(&self, token: String) -> EdgeResult<EdgeToken> {
+        Ok(self
+            .register_tokens(vec![token])
+            .await?
+            .first()
+            .expect("Couldn't validate token")
+            .clone())
+    }
+}
+
 impl TokenValidator {
     async fn get_unknown_and_known_tokens(
         &self,
@@ -42,15 +57,6 @@ impl TokenValidator {
             }
             tokens.into_iter().partition(|t| t.token_type.is_none())
         }
-    }
-
-    pub async fn register_token(&self, token: String) -> EdgeResult<EdgeToken> {
-        Ok(self
-            .register_tokens(vec![token])
-            .await?
-            .first()
-            .expect("Couldn't validate token")
-            .clone())
     }
 
     pub async fn register_tokens(&self, tokens: Vec<String>) -> EdgeResult<Vec<EdgeToken>> {

--- a/server/src/middleware/validate_token.rs
+++ b/server/src/middleware/validate_token.rs
@@ -231,9 +231,7 @@ mod tests {
     #[actix_web::test]
     async fn validation_allows_client_tokens_on_backend_paths() {
         let token = EdgeToken {
-            token: "*:development
-                .somesecretstring"
-                .into(),
+            token: "*:development.somesecretstring".into(),
             status: TokenValidationStatus::Validated,
             token_type: Some(TokenType::Client),
             ..Default::default()

--- a/server/src/middleware/validate_token.rs
+++ b/server/src/middleware/validate_token.rs
@@ -1,4 +1,5 @@
-use crate::auth::token_validator::TokenValidator;
+use crate::auth::token_validator::{TokenRegister, TokenValidator};
+use crate::error::EdgeError;
 use crate::types::{EdgeToken, TokenType, TokenValidationStatus};
 use actix_web::{
     HttpResponse,
@@ -20,81 +21,226 @@ pub async fn validate_token(
         .clone()
         .into_inner();
 
+    let validation_status = validate(&token, maybe_validator, &token_cache, req.path()).await;
+
+    if let Ok(_) = validation_status {
+        Ok(srv.call(req).await?.map_into_left_body())
+    } else {
+        Ok(req
+            .into_response(HttpResponse::Forbidden().finish())
+            .map_into_right_body())
+    }
+}
+
+async fn validate(
+    token: &EdgeToken,
+    maybe_validator: Option<&Data<impl TokenRegister>>,
+    token_cache: &DashMap<String, EdgeToken>,
+    path: &str,
+) -> Result<(), EdgeError> {
     if token.status == TokenValidationStatus::Trusted {
-        return Ok(srv.call(req).await?.map_into_left_body());
+        return Ok(());
     }
 
     match maybe_validator {
         Some(validator) => {
             let known_token = validator.register_token(token.token.clone()).await?;
-            let res = match known_token.status {
+            match known_token.status {
                 TokenValidationStatus::Validated => match known_token.token_type {
-                    Some(TokenType::Frontend) => {
-                        if req.path().contains("/api/frontend") || req.path().contains("/api/proxy")
-                        {
-                            srv.call(req).await?.map_into_left_body()
-                        } else {
-                            req.into_response(HttpResponse::Forbidden().finish())
-                                .map_into_right_body()
-                        }
-                    }
-                    Some(TokenType::Client) => {
-                        if req.path().contains("/api/client") {
-                            srv.call(req).await?.map_into_left_body()
-                        } else {
-                            req.into_response(HttpResponse::Forbidden().finish())
-                                .map_into_right_body()
-                        }
-                    }
-                    _ => req
-                        .into_response(HttpResponse::Forbidden().finish())
-                        .map_into_right_body(),
+                    Some(TokenType::Frontend) => check_frontend_path(path),
+                    Some(TokenType::Client) => check_backend_path(path),
+                    _ => Err(EdgeError::AuthorizationDenied),
                 },
-                TokenValidationStatus::Unknown => req
-                    .into_response(HttpResponse::Unauthorized().finish())
-                    .map_into_right_body(),
-                TokenValidationStatus::Invalid => req
-                    .into_response(HttpResponse::Forbidden().finish())
-                    .map_into_right_body(),
+                TokenValidationStatus::Unknown => Err(EdgeError::AuthorizationDenied),
+                TokenValidationStatus::Invalid => Err(EdgeError::AuthorizationDenied),
                 TokenValidationStatus::Trusted => unreachable!(),
-            };
-            Ok(res)
+            }
         }
-        None => {
-            let res = match token_cache.get(&token.token) {
-                Some(t) => {
-                    let token = t.value();
-                    match token.token_type {
-                        Some(TokenType::Client) => {
-                            if req.path().contains("/api/client") {
-                                srv.call(req).await?.map_into_left_body()
-                            } else {
-                                req.into_response(HttpResponse::Forbidden().finish())
-                                    .map_into_right_body()
-                            }
-                        }
-                        Some(TokenType::Frontend) => {
-                            if req.path().contains("/api/frontend")
-                                || req.path().contains("/api/proxy")
-                            {
-                                srv.call(req).await?.map_into_left_body()
-                            } else {
-                                req.into_response(HttpResponse::Forbidden().finish())
-                                    .map_into_right_body()
-                            }
-                        }
-                        None => srv.call(req).await?.map_into_left_body(),
-                        _ => req
-                            .into_response(HttpResponse::Forbidden().finish())
-                            .map_into_right_body(),
-                    }
+        None => match token_cache.get(&token.token) {
+            Some(t) => {
+                let token = t.value();
+                match token.token_type {
+                    Some(TokenType::Frontend) => check_frontend_path(path),
+                    Some(TokenType::Client) => check_backend_path(path),
+                    None => Ok(()),
+                    _ => Err(EdgeError::AuthorizationDenied),
                 }
-                None => req
-                    .into_response(HttpResponse::Forbidden().finish())
-                    .map_into_right_body(),
-            };
+            }
+            None => Err(EdgeError::AuthorizationDenied),
+        },
+    }
+}
 
-            Ok(res)
+fn check_frontend_path(path: &str) -> Result<(), EdgeError> {
+    if path.contains("/api/frontend") || path.contains("/api/proxy") {
+        Ok(())
+    } else {
+        Err(EdgeError::AuthorizationDenied)
+    }
+}
+
+fn check_backend_path(path: &str) -> Result<(), EdgeError> {
+    if path.contains("/api/client") {
+        Ok(())
+    } else {
+        Err(EdgeError::AuthorizationDenied)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    struct FrontendValidator {}
+
+    impl TokenRegister for FrontendValidator {
+        async fn register_token(&self, token: String) -> crate::types::EdgeResult<EdgeToken> {
+            return Ok(EdgeToken {
+                status: TokenValidationStatus::Validated,
+                token_type: Some(TokenType::Frontend),
+                ..EdgeToken::from_str(&token).unwrap()
+            });
         }
+    }
+
+    struct ClientValidator {}
+
+    impl TokenRegister for ClientValidator {
+        async fn register_token(&self, token: String) -> crate::types::EdgeResult<EdgeToken> {
+            return Ok(EdgeToken {
+                status: TokenValidationStatus::Validated,
+                token_type: Some(TokenType::Client),
+                ..EdgeToken::from_str(&token).unwrap()
+            });
+        }
+    }
+
+    struct CrashValidator {}
+
+    impl TokenRegister for CrashValidator {
+        async fn register_token(&self, _token: String) -> crate::types::EdgeResult<EdgeToken> {
+            panic!("you should never have gotten to this point")
+        }
+    }
+
+    #[actix_web::test]
+    async fn validation_always_allows_trusted_tokens() {
+        let token = EdgeToken {
+            token: "legacy-123".into(),
+            status: TokenValidationStatus::Trusted,
+            token_type: Some(TokenType::Frontend),
+            ..Default::default()
+        };
+
+        let result = validate(
+            &token,
+            Some(&Data::new(CrashValidator {})),
+            &DashMap::new(),
+            "/api/frontend/some_path",
+        )
+        .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[actix_web::test]
+    async fn validation_denies_frontend_tokens_on_backend_paths() {
+        let token = EdgeToken {
+            token: "*:development.somesecretstring".into(),
+            status: TokenValidationStatus::Validated,
+            token_type: Some(TokenType::Frontend),
+            ..Default::default()
+        };
+
+        let hit_features = validate(
+            &token,
+            Some(&Data::new(FrontendValidator {})),
+            &DashMap::new(),
+            "/api/client/features",
+        )
+        .await;
+
+        assert!(hit_features.is_err());
+    }
+
+    #[actix_web::test]
+    async fn validation_allows_frontend_tokens_on_frontend_paths() {
+        let token = EdgeToken {
+            token: "*:development.somesecretstring".into(),
+            status: TokenValidationStatus::Validated,
+            token_type: Some(TokenType::Frontend),
+            ..Default::default()
+        };
+
+        let hit_frontend = validate(
+            &token,
+            Some(&Data::new(FrontendValidator {})),
+            &DashMap::new(),
+            "/api/frontend",
+        )
+        .await;
+
+        let hit_proxy = validate(
+            &token,
+            Some(&Data::new(FrontendValidator {})),
+            &DashMap::new(),
+            "/api/proxy",
+        )
+        .await;
+
+        assert!(hit_frontend.is_ok());
+        assert!(hit_proxy.is_ok());
+    }
+
+    #[actix_web::test]
+    async fn validation_denies_client_tokens_on_frontend_paths() {
+        let token = EdgeToken {
+            token: "*:development.somesecretstring".into(),
+            status: TokenValidationStatus::Validated,
+            token_type: Some(TokenType::Client),
+            ..Default::default()
+        };
+
+        let hit_frontend = validate(
+            &token,
+            Some(&Data::new(ClientValidator {})),
+            &DashMap::new(),
+            "/api/frontend",
+        )
+        .await;
+
+        let hit_proxy = validate(
+            &token,
+            Some(&Data::new(ClientValidator {})),
+            &DashMap::new(),
+            "/api/proxy",
+        )
+        .await;
+        assert!(hit_frontend.is_err());
+        assert!(hit_proxy.is_err());
+    }
+
+    #[actix_web::test]
+    async fn validation_allows_client_tokens_on_backend_paths() {
+        let token = EdgeToken {
+            token: "*:development
+                .somesecretstring"
+                .into(),
+            status: TokenValidationStatus::Validated,
+            token_type: Some(TokenType::Client),
+            ..Default::default()
+        };
+
+        let hit_features = validate(
+            &token,
+            Some(&Data::new(ClientValidator {})),
+            &DashMap::new(),
+            "/api/client/features",
+        )
+        .await;
+
+        assert!(hit_features.is_ok());
     }
 }

--- a/server/src/middleware/validate_token.rs
+++ b/server/src/middleware/validate_token.rs
@@ -19,6 +19,11 @@ pub async fn validate_token(
         .unwrap()
         .clone()
         .into_inner();
+
+    if token.status == TokenValidationStatus::Trusted {
+        return Ok(srv.call(req).await?.map_into_left_body());
+    }
+
     match maybe_validator {
         Some(validator) => {
             let known_token = validator.register_token(token.token.clone()).await?;
@@ -51,6 +56,7 @@ pub async fn validate_token(
                 TokenValidationStatus::Invalid => req
                     .into_response(HttpResponse::Forbidden().finish())
                     .map_into_right_body(),
+                TokenValidationStatus::Trusted => unreachable!(),
             };
             Ok(res)
         }

--- a/server/src/middleware/validate_token.rs
+++ b/server/src/middleware/validate_token.rs
@@ -103,11 +103,11 @@ mod tests {
 
     impl TokenRegister for FrontendValidator {
         async fn register_token(&self, token: String) -> crate::types::EdgeResult<EdgeToken> {
-            return Ok(EdgeToken {
+            Ok(EdgeToken {
                 status: TokenValidationStatus::Validated,
                 token_type: Some(TokenType::Frontend),
                 ..EdgeToken::from_str(&token).unwrap()
-            });
+            })
         }
     }
 
@@ -115,11 +115,11 @@ mod tests {
 
     impl TokenRegister for ClientValidator {
         async fn register_token(&self, token: String) -> crate::types::EdgeResult<EdgeToken> {
-            return Ok(EdgeToken {
+            Ok(EdgeToken {
                 status: TokenValidationStatus::Validated,
                 token_type: Some(TokenType::Client),
                 ..EdgeToken::from_str(&token).unwrap()
-            });
+            })
         }
     }
 

--- a/server/src/tokens.rs
+++ b/server/src/tokens.rs
@@ -124,7 +124,9 @@ impl FromRequest for EdgeToken {
             (value, req.app_data::<Data<DashMap<String, EdgeToken>>>())
         {
             if let Some(token) = token_cache.get(value.to_str().unwrap_or_default()) {
-                return ready(Ok(token.value().clone()));
+                if token.status == TokenValidationStatus::Trusted {
+                    return ready(Ok(token.value().clone()));
+                }
             }
         }
 

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -107,6 +107,7 @@ pub enum TokenValidationStatus {
     Invalid,
     #[default]
     Unknown,
+    Trusted,
     Validated,
 }
 

--- a/server/tests/streaming_test.rs
+++ b/server/tests/streaming_test.rs
@@ -3,7 +3,7 @@ mod streaming_test {
     use eventsource_client::Client;
     use futures::StreamExt;
     use std::{
-        process::{Command, Stdio},
+        process::Command,
         str::FromStr,
         sync::Arc,
     };


### PR DESCRIPTION
Adds a pathway to create trusted tokens in Unleash Edge. These tokens are allowed to entirely skip validation so you can have tokens that look like "haha-I'm-totally-a-valid-token-bro-trust-me". This PR does nothing on its own, it's purely the plumbing layer but this allows us to inject these tokens on startup (coming in a future PR) into the cache and use Proxy style tokens