### PR TITLE
fix: make instance-id cli arg a global argument

### DIFF
--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -383,7 +383,7 @@ pub struct CliArgs {
     pub mode: EdgeMode,
 
     /// Instance id. Used for metrics reporting.
-    #[clap(long, env, default_value_t = format!("unleash-edge@{}", ulid::Ulid::new()))]
+    #[clap(long, env, global = true, default_value_t = format!("unleash-edge@{}", ulid::Ulid::new()))]
     pub instance_id: String,
 
     /// App name. Used for metrics reporting.


### PR DESCRIPTION
Before this patch, instance-id arg had to come before subcommands `edge | offline`. With this patch, instance-id is now a global argument and come anywhere in the launch command.


fixes #913