### PR TITLE
chore(deps): Updated prometheus to 0.14.0

### DIFF
--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -36,6 +36,14 @@ jobs:
           rustup show
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
+      - name: Install required cargo packages for reporting format
+        run: cargo install clippy-sarif sarif-fmt
       - name: Run rust-clippy
         run: |
-          cargo clippy --all-features -- -D warnings
+          cargo clippy --all-features --message-format=json -- -D warnings | clippy-sarif | tee results.sarif | sarif-fmt
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'results.sarif'
+
+

--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -32,12 +32,10 @@ jobs:
       - name: Install rust
         run: |
           rustup set auto-self-update disable
-          rustup toolchain install stable --profile default
+          rustup toolchain install 1.85.0 --profile default
           rustup show
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
-      - name: Install required cargo packages for reporting format
-        run: cargo install clippy-sarif sarif-fmt
       - name: Run rust-clippy
         run: |
           cargo clippy --all-features -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3219,7 +3219,7 @@ dependencies = [
  "once_cell",
  "opentelemetry 0.29.1",
  "opentelemetry_sdk 0.29.0",
- "prometheus 0.14.0",
+ "prometheus",
  "tracing",
 ]
 
@@ -3568,42 +3568,24 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
  "bitflags 2.9.0",
  "hex",
- "lazy_static",
  "procfs-core",
  "rustix 0.38.44",
 ]
 
 [[package]]
 name = "procfs-core"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
  "bitflags 2.9.0",
  "hex",
-]
-
-[[package]]
-name = "prometheus"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
-dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
- "libc",
- "memchr",
- "parking_lot",
- "procfs",
- "protobuf 2.28.0",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3615,19 +3597,21 @@ dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
+ "libc",
  "memchr",
  "parking_lot",
- "protobuf 3.7.2",
+ "procfs",
+ "protobuf",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "prometheus-reqwest-remote-write"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6e2ce8050d6fa726a743195f2b9afb3d29facc49eb90988617b378a674c2f6"
+checksum = "59e855784e07cfc6abf2f89fe04e4c5fe00a17f1ac739838cbddb801cd653dda"
 dependencies = [
- "prometheus 0.13.4",
+ "prometheus",
  "prost",
  "reqwest",
  "snap",
@@ -3668,12 +3652,6 @@ dependencies = [
  "quote",
  "syn 2.0.101",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "protobuf"
@@ -3929,9 +3907,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.18"
+version = "0.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98ff6b0dbbe4d5a37318f433d4fc82babd21631f194d370409ceb2e40b2f0b5"
+checksum = "a2f8e5513d63f2e5b386eb5106dc67eaf3f84e95258e210489136b8b92ad6119"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4951,9 +4929,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
+checksum = "5cc2d9e086a412a451384326f521c8123a99a466b329941a9403696bff9b0da2"
 dependencies = [
  "bitflags 2.9.0",
  "bytes",
@@ -5194,7 +5172,7 @@ dependencies = [
  "p12-keystore",
  "pin-project-lite",
  "pkix",
- "prometheus 0.13.4",
+ "prometheus",
  "prometheus-reqwest-remote-write",
  "prometheus-static-metric",
  "rand 0.9.1",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -67,8 +67,8 @@ opentelemetry_sdk = { version = "0.30.0", features = [
 p12-keystore = "0.1.5"
 pin-project-lite = "0.2.16"
 pkix = "0.2.4"
-prometheus = { version = "0.13.4", features = ["process"] }
-prometheus-reqwest-remote-write = { version = "0.3.0" }
+prometheus = { version = "0.14.0", features = ["process"] }
+prometheus-reqwest-remote-write = { version = "0.4.0" }
 prometheus-static-metric = "0.5.1"
 rand = "0.9.1"
 redis = { version = "0.31.0", features = [
@@ -76,7 +76,7 @@ redis = { version = "0.31.0", features = [
     "tokio-rustls-comp",
     "cluster",
 ] }
-reqwest = { version = "0.12.18", default-features = false, features = [
+reqwest = { version = "0.12.19", default-features = false, features = [
     "json",
     "rustls-tls"
 ] }

--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -452,10 +452,10 @@ mod tests {
     use unleash_types::client_features::{
         ClientFeature, Constraint, DeltaEvent, Operator, Strategy, StrategyVariant,
     };
+    use unleash_types::client_metrics::SdkType::Backend;
     use unleash_types::client_metrics::{
         ClientMetricsEnv, ConnectViaBuilder, MetricBucket, MetricsMetadata, ToggleStats,
     };
-    use unleash_types::client_metrics::SdkType::Backend;
     use unleash_yggdrasil::EngineState;
 
     async fn make_metrics_post_request() -> Request {

--- a/server/src/frontend_api.rs
+++ b/server/src/frontend_api.rs
@@ -4,7 +4,7 @@ use actix_service::ServiceFactory;
 use itertools::Itertools;
 use std::collections::HashMap;
 
-use actix_web::dev::{ServiceRequest, ServiceResponse, Payload};
+use actix_web::dev::{Payload, ServiceRequest, ServiceResponse};
 use actix_web::{
     HttpRequest, HttpResponse, Scope, get, post,
     web::{self, Data, Json, Path},
@@ -30,7 +30,7 @@ use crate::{
 };
 
 use actix_web::FromRequest;
-use std::future::{ready, Ready};
+use std::future::{Ready, ready};
 
 #[derive(Debug, Clone)]
 pub struct UnleashSdkHeader(pub Option<String>);

--- a/server/src/metrics/client_metrics.rs
+++ b/server/src/metrics/client_metrics.rs
@@ -11,8 +11,10 @@ use std::{
     hash::{Hash, Hasher},
 };
 use tracing::{debug, instrument};
-use unleash_types::client_metrics::{ClientApplication, ClientMetrics, ClientMetricsEnv, ConnectVia, MetricsMetadata};
 use unleash_types::client_metrics::SdkType::Backend;
+use unleash_types::client_metrics::{
+    ClientApplication, ClientMetrics, ClientMetricsEnv, ConnectVia, MetricsMetadata,
+};
 use utoipa::ToSchema;
 
 pub const UPSTREAM_MAX_BODY_SIZE: usize = 100 * 1024;
@@ -343,10 +345,18 @@ impl MetricsCache {
         debug!("Sinking {} metrics", metrics.len());
         for metric in metrics.iter() {
             FEATURE_TOGGLE_USAGE_TOTAL
-                .with_label_values(&[&metric.app_name, &metric.feature_name, "true"])
+                .with_label_values(&[
+                    metric.app_name.clone(),
+                    metric.feature_name.clone(),
+                    "true".to_string(),
+                ])
                 .inc_by(metric.yes as u64);
             FEATURE_TOGGLE_USAGE_TOTAL
-                .with_label_values(&[&metric.app_name, &metric.feature_name, "false"])
+                .with_label_values(&[
+                    metric.app_name.clone(),
+                    metric.feature_name.clone(),
+                    "false".to_string(),
+                ])
                 .inc_by(metric.no as u64);
             self.metrics
                 .entry(MetricsKey {
@@ -381,10 +391,10 @@ mod test {
     use std::collections::HashMap;
     use std::str::FromStr;
     use test_case::test_case;
+    use unleash_types::client_metrics::SdkType::Backend;
     use unleash_types::client_metrics::{
         ClientMetricsEnv, ConnectVia, ConnectViaBuilder, MetricsMetadata,
     };
-    use unleash_types::client_metrics::SdkType::Backend;
 
     #[test]
     fn cache_aggregates_data_correctly() {

--- a/server/src/metrics/edge_metrics.rs
+++ b/server/src/metrics/edge_metrics.rs
@@ -450,46 +450,46 @@ impl EdgeInstanceData {
         let mut no_change = HashMap::default();
 
         for family in registry.gather().iter() {
-            match family.get_name() {
+            match family.name() {
                 crate::metrics::actix_web_prometheus_metrics::HTTP_REQUESTS_DURATION => {
                     family
                         .get_metric()
                         .iter()
                         .filter(|m| {
-                            m.has_histogram() && m.get_label().iter().any(|l| {
-                                l.get_name()
+                            m.get_label().iter().any(|l| {
+                                l.name()
                                     == crate::metrics::actix_web_prometheus_metrics::ENDPOINT_LABEL
                                     && DESIRED_URLS
                                         .iter()
-                                        .any(|desired| l.get_value().ends_with(desired))
+                                        .any(|desired| l.value().ends_with(desired))
                             }) && m.get_label().iter().any(|l| {
-                                l.get_name()
+                                l.name()
                                     == crate::metrics::actix_web_prometheus_metrics::STATUS_LABEL
-                                    && l.get_value() == "200"
-                                    || l.get_value() == "202"
-                                    || l.get_value() == "304"
-                                    || l.get_value() == "403"
+                                    && l.value() == "200"
+                                    || l.value() == "202"
+                                    || l.value() == "304"
+                                    || l.value() == "403"
                             })
                         })
                         .for_each(|m| {
                             let labels = m.get_label();
                             let path = labels
                                 .iter()
-                                .find(|l| l.get_name() == crate::metrics::actix_web_prometheus_metrics::ENDPOINT_LABEL)
+                                .find(|l| l.name() == crate::metrics::actix_web_prometheus_metrics::ENDPOINT_LABEL)
                                 .unwrap()
-                                .get_value()
+                                .value()
                                 .strip_prefix(base_path)
                                 .unwrap();
                             let method = labels
                                 .iter()
-                                .find(|l| l.get_name() == crate::metrics::actix_web_prometheus_metrics::METHOD_LABEL)
+                                .find(|l| l.name() == crate::metrics::actix_web_prometheus_metrics::METHOD_LABEL)
                                 .unwrap()
-                                .get_value();
+                                .value();
                             let status = labels
                                 .iter()
-                                .find(|l| l.get_name() == crate::metrics::actix_web_prometheus_metrics::STATUS_LABEL)
+                                .find(|l| l.name() == crate::metrics::actix_web_prometheus_metrics::STATUS_LABEL)
                                 .unwrap()
-                                .get_value();
+                                .value();
                             let latency = match status {
                                 "200" | "202" => {
                                     if method == "GET" {
@@ -529,12 +529,12 @@ impl EdgeInstanceData {
                 }
                 "process_cpu_seconds_total" => {
                     if let Some(cpu_second_metric) = family.get_metric().last() {
-                        cpu_seconds = cpu_second_metric.get_counter().get_value() as u64;
+                        cpu_seconds = cpu_second_metric.get_counter().value() as u64;
                     }
                 }
                 "process_resident_memory_bytes" => {
                     if let Some(resident_memory_metric) = family.get_metric().last() {
-                        resident_memory = resident_memory_metric.get_gauge().get_value() as u64;
+                        resident_memory = resident_memory_metric.get_gauge().value() as u64;
                     }
                 }
                 "client_metrics_upload" => {
@@ -596,7 +596,7 @@ impl EdgeInstanceData {
                 "connected_streaming_clients" => {
                     if let Some(connected_streaming_clients) = family.get_metric().last() {
                         observed.connected_streaming_clients =
-                            connected_streaming_clients.get_gauge().get_value() as u64;
+                            connected_streaming_clients.get_gauge().value() as u64;
                     }
                 }
                 _ => {}
@@ -624,17 +624,17 @@ fn get_percentile(percentile: u64, count: u64, buckets: &[prometheus::proto::Buc
     let mut previous_upper_bound = 0.0;
     let mut previous_count = 0;
     for bucket in buckets {
-        if bucket.get_cumulative_count() as f64 >= target {
-            let nth_count = bucket.get_cumulative_count() - previous_count;
+        if bucket.cumulative_count() as f64 >= target {
+            let nth_count = bucket.cumulative_count() - previous_count;
             let observation_in_range = target - previous_count as f64;
             return round_to_3_decimals(
                 previous_upper_bound
                     + ((observation_in_range / nth_count as f64)
-                        * (bucket.get_upper_bound() - previous_upper_bound)),
+                        * (bucket.upper_bound() - previous_upper_bound)),
             );
         }
-        previous_upper_bound = bucket.get_upper_bound();
-        previous_count = bucket.get_cumulative_count();
+        previous_upper_bound = bucket.upper_bound();
+        previous_count = bucket.cumulative_count();
     }
     0.0
 }
@@ -665,7 +665,7 @@ mod tests {
         fifty_ms.set_cumulative_count(5000);
         fifty_ms.set_upper_bound(50.0);
         let buckets = vec![one_ms, five_ms, ten_ms, twenty_ms, fifty_ms];
-        let result = super::get_percentile(99, 5000, &buckets);
+        let result = get_percentile(99, 5000, &buckets);
         assert_eq!(result, 48.5);
     }
 
@@ -687,7 +687,7 @@ mod tests {
         fifty_ms.set_cumulative_count(5000);
         fifty_ms.set_upper_bound(50.0);
         let buckets = vec![one_ms, five_ms, ten_ms, twenty_ms, fifty_ms];
-        let result = super::get_percentile(50, 5000, &buckets);
+        let result = get_percentile(50, 5000, &buckets);
         assert_eq!(result, 7.5);
     }
 

--- a/server/src/metrics/edge_metrics.rs
+++ b/server/src/metrics/edge_metrics.rs
@@ -465,10 +465,10 @@ impl EdgeInstanceData {
                             }) && m.get_label().iter().any(|l| {
                                 l.name()
                                     == crate::metrics::actix_web_prometheus_metrics::STATUS_LABEL
-                                    && l.value() == "200"
-                                    || l.value() == "202"
-                                    || l.value() == "304"
-                                    || l.value() == "403"
+                                    && (l.value() == "200"
+                                        || l.value() == "202"
+                                        || l.value() == "304"
+                                        || l.value() == "403")
                             })
                         })
                         .for_each(|m| {

--- a/server/src/tokens.rs
+++ b/server/src/tokens.rs
@@ -266,8 +266,8 @@ fn parse_legacy_token(token_string: &str) -> EdgeResult<(String, EdgeToken)> {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
     use super::*;
+    use std::str::FromStr;
 
     use actix_http::header::AUTHORIZATION;
     use actix_web::{

--- a/server/tests/streaming_test.rs
+++ b/server/tests/streaming_test.rs
@@ -2,11 +2,7 @@ mod streaming_test {
     use dashmap::DashMap;
     use eventsource_client::Client;
     use futures::StreamExt;
-    use std::{
-        process::Command,
-        str::FromStr,
-        sync::Arc,
-    };
+    use std::{process::Command, str::FromStr, sync::Arc};
     use unleash_edge::{
         cli::{EdgeArgs, EdgeMode, TokenHeader},
         feature_cache::FeatureCache,


### PR DESCRIPTION
As a security upgrade, this PR updates prometheus to 0.14.0 which bumps protobuf to fix https://github.com/Unleash/unleash-edge/security/dependabot/27