### PR TITLE
fix: install crypto provider for redis as well

### DIFF
--- a/server/src/persistence/redis.rs
+++ b/server/src/persistence/redis.rs
@@ -42,6 +42,12 @@ impl RedisPersister {
     ) -> Result<RedisPersister, EdgeError> {
         let client = Client::open(url)?;
         let addr = client.get_connection_info().addr.clone();
+        if let Err(err) = rustls::crypto::ring::default_provider().install_default() {
+            info!(
+                "Failed to install default crypto provider, this is likely because another system has already installed it: {:?}",
+                err
+            );
+        }
         info!("[REDIS Persister]: Configured single node client {addr:?}");
         Ok(Self {
             redis_client: Arc::new(RwLock::new(Single(client))),


### PR DESCRIPTION
Confirmed the reports in #980, we no longer successfully connect to redis-secure. This PR installs the crypto provider (logging at info level if it was already installed (not an error)).

