### PR TITLE
chore: better dx

### DIFF
--- a/.config/cargo.toml
+++ b/.config/cargo.toml
@@ -1,5 +1,19 @@
+cargo-features = ["codegen-backend"]
+
 [env]
 CC_aarch64_unknown_linux_musl = "aarch64-linux-gnu-gcc"
 
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
+
+# Default dev - fallback to LLVM
+[profile.dev]
+
+[profile.dev.package."*".codegen-backend.'cfg(env("CRANELIFT_BUILD", "1"))']
+codegen-backend = "cranelift"
+
+[profile.dev.codegen-backend.'cfg(env("CRANELIFT_BUILD", "1"))']
+codegen-backend = "cranelift"
+
+[profile.dev.package."*"]
+codegen-backend = "llvm"

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -17,6 +17,52 @@ cp hooks/* .git/hooks/
 * We will adhere to [Semantic versioning](https://semver.org/)
 * We use Clippy to ensure that our code follows a consistent format, you can run Clippy using `cargo clippy --fix` once it's installed
 
+### Development Toolchain Installation
+
+For a quicker build/test loop, we provide a `just` setup which takes around a tenth of the time of `cargo build`. You'll need to install a few tools for this to work correctly.
+
+#### Just
+
+Just can be installed with cargo:
+
+```shell
+cargo install just
+```
+
+#### Clang + LLD
+
+Linux (Debian/Ubuntu-based):
+```shell
+sudo apt install clang lld
+```
+
+MacOS
+```shell
+xcode-select --install
+```
+Windows
+Install the "Desktop Development with C++" workload via the Visual Studio Installer. This typically includes clang and lld.
+
+#### Cranelift
+Ensure you're using a nightly Rust toolchain
+
+```shell
+rustup default nightly
+```
+Install cranelift with rustup:
+``` shell
+rustup component add rustc-codegen-cranelift-preview --toolchain nightly
+```
+
+#### Using The Development Build
+
+The just file provides a build and a test, which use a the Cranelift backend + LLD linker. These steps skip the integration tests. This is typically about ten times faster than standard `cargo build`:
+
+``` shell
+just build
+just test
+```
+
 ### Common commands
 
  - `cargo add ...` - Add a dependency to the Cargo.toml file

--- a/justfile
+++ b/justfile
@@ -1,0 +1,10 @@
+default:
+    just test
+
+build:
+    CRANELIFT_BUILD=1 RUSTFLAGS="-C link-arg=-fuse-ld=lld" \
+    cargo +nightly build --no-default-features
+
+test:
+    CRANELIFT_BUILD=1 RUSTFLAGS="-C link-arg=-fuse-ld=lld" \
+    cargo +nightly test --lib --no-default-features


### PR DESCRIPTION
Provides a setup for a better build + test loop. This uses  [Cranelift](https://cranelift.dev/) and [LLD](https://lld.llvm.org/) to get a faster compile and skips the build + test for the integration tests. This improves the time for build + test on a hot compile from about 55 seconds to about 8 seconds on my machine. 

This is entirely opt in, so standard `cargo build` will still use the old tool chain and release builds are unaffected.

This doesn't use [Mold](https://github.com/rui314/mold), since that has some iffy support on MacOS/Windows