### PR TITLE
chore: add in build configs for when lld won't work

### DIFF
--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -56,11 +56,18 @@ rustup component add rustc-codegen-cranelift-preview --toolchain nightly
 
 #### Using The Development Build
 
-The just file provides a build and a test, which use a the Cranelift backend + LLD linker. These steps skip the integration tests. This is typically about ten times faster than standard `cargo build`:
+The just file provides fast build and test commands using the Cranelift backend and LLD linker. These steps skip integration tests and are typically ~10x faster than a full cargo build.
 
 ``` shell
 just build
 just test
+```
+
+If you're unable to use LLD (due to system configuration, linker errors, or platform limitations), use the system linker instead:
+
+```shell
+just sysbuild
+just systest
 ```
 
 ### Common commands

--- a/justfile
+++ b/justfile
@@ -5,6 +5,12 @@ build:
     CRANELIFT_BUILD=1 RUSTFLAGS="-C link-arg=-fuse-ld=lld" \
     cargo +nightly build --no-default-features
 
-test:
+test *ARGS:
     CRANELIFT_BUILD=1 RUSTFLAGS="-C link-arg=-fuse-ld=lld" \
-    cargo +nightly test --lib --no-default-features
+    cargo +nightly test --lib --no-default-features -- {{ARGS}}
+
+sysbuild:
+    CRANELIFT_BUILD=1 cargo +nightly build --no-default-features
+
+systest *ARGS:
+    CRANELIFT_BUILD=1 cargo +nightly test --lib --no-default-features -- --test-threads=1 {{ARGS}}


### PR DESCRIPTION
Few small maintenance things for the just build

- Passes through options to the test runner so it works the same as `cargo test`, this lets you target single tests or enable features, etc.
- Adds two new just tasks that will use the default system linker instead, which is friendlier for folks who cannot use LLD
- Updates the dev docs 