### PR TITLE
refactor: clean up main

### DIFF
--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -35,7 +35,8 @@ type CacheContainer = (
     Arc<DeltaCacheManager>,
     Arc<DashMap<String, EngineState>>,
 );
-type EdgeInfo = (
+
+pub type EdgeInfo = (
     CacheContainer,
     Option<Arc<TokenValidator>>,
     Option<Arc<FeatureRefresher>>,

--- a/server/src/http/unleash_client.rs
+++ b/server/src/http/unleash_client.rs
@@ -311,6 +311,7 @@ impl UnleashClient {
         }
     }
 
+    #[cfg(test)]
     pub fn new(server_url: &str, instance_id_opt: Option<String>) -> Result<Self, EdgeError> {
         use ulid::Ulid;
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -121,7 +121,7 @@ fn setup_server(
                                 .allow_list
                                 .clone()
                                 .map(|list| AllowList::with_allowed_ipnets(&list))
-                                .unwrap_or(AllowList::default()),
+                                .unwrap_or_default(),
                         ),
                 )
                 .service(
@@ -136,7 +136,7 @@ fn setup_server(
                                 .allow_list
                                 .clone()
                                 .map(|list| AllowList::with_allowed_ipnets(&list))
-                                .unwrap_or(AllowList::default()),
+                                .unwrap_or_default(),
                         ),
                 )
                 .service(

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,5 +1,6 @@
 use actix_allow_deny_middleware::{AllowList, DenyList};
 use actix_middleware_etag::Etag;
+use actix_web::dev::Server;
 use actix_web::middleware::Logger;
 use actix_web::{App, HttpServer, web};
 use clap::Parser;
@@ -7,13 +8,15 @@ use dashmap::DashMap;
 use futures::future::join_all;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use ulid::Ulid;
+use unleash_edge::metrics::actix_web_prometheus_metrics::PrometheusMetrics;
 use unleash_types::client_features::ClientFeatures;
 use unleash_types::client_metrics::ConnectVia;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
 use tracing::info;
-use unleash_edge::builder::build_caches_and_refreshers;
+use unleash_edge::builder::{EdgeInfo, build_caches_and_refreshers};
 use unleash_edge::cli::{AuthHeaders, CliArgs, EdgeMode};
 use unleash_edge::feature_cache::FeatureCache;
 use unleash_edge::http::background_send_metrics::send_metrics_one_shot;
@@ -27,111 +30,54 @@ use unleash_edge::persistence::{EdgePersistence, persist_data};
 use unleash_edge::types::{EdgeToken, TokenValidationStatus};
 use unleash_edge::{client_api, frontend_api, health_checker, openapi, ready_checker};
 use unleash_edge::{edge_api, prom_metrics};
+use unleash_edge::{http::unleash_client::ClientMetaInformation, metrics::metrics_pusher};
 use unleash_edge::{internal_backstage, tls};
 
-#[cfg(not(tarpaulin_include))]
-#[actix_web::main]
-async fn main() -> Result<(), anyhow::Error> {
-    use unleash_edge::{
-        http::{instance_data::InstanceDataSending, unleash_client::ClientMetaInformation},
-        metrics::metrics_pusher,
-    };
-
-    let args = CliArgs::parse();
-    let disable_all_endpoint = args.disable_all_endpoint;
-    if args.markdown_help {
-        clap_markdown::print_help_markdown::<CliArgs>();
-        return Ok(());
-    }
-    if let EdgeMode::Health(args) = args.mode {
-        return health_checker::check_health(args)
-            .await
-            .map_err(|e| e.into());
-    };
-    if let EdgeMode::Ready(args) = args.mode {
-        return ready_checker::check_ready(args).await.map_err(|e| e.into());
-    }
-    let schedule_args = args.clone();
-    let app_name = args.app_name.clone();
-    let mode_arg = args.clone().mode;
+fn setup_server(
+    args: CliArgs,
+    edge_info: EdgeInfo,
+    metrics_middleware: PrometheusMetrics,
+    instance_data_sender_for_app_context: Arc<InstanceDataSending>,
+    metrics_cache: Arc<MetricsCache>,
+    our_instance_data_for_app_context: Arc<EdgeInstanceData>,
+    instances_observed_for_app_context: Arc<RwLock<Vec<EdgeInstanceData>>>,
+) -> Result<Server, anyhow::Error> {
     let http_args = args.clone().http;
-    let cors_arg = http_args.cors.clone();
-    let token_header = args.clone().token_header;
     let request_timeout = args.edge_request_timeout;
     let keepalive_timeout = args.edge_keepalive_timeout;
-    let trust_proxy = args.clone().trust_proxy;
-    let base_path = http_args.base_path.clone();
-    let our_instance_data_for_app_context = Arc::new(EdgeInstanceData::new(&app_name));
-    let connect_via = ConnectVia {
-        app_name: args.clone().app_name,
-        instance_id: our_instance_data_for_app_context.identifier.clone(),
-    };
-    let our_instance_data = our_instance_data_for_app_context.clone();
-    let identifier = our_instance_data_for_app_context.identifier.clone();
-    let metrics_middleware = prom_metrics::instantiate(
-        None,
-        args.internal_backstage.disable_metrics_endpoint,
-        &args.log_format,
-        &our_instance_data,
-    );
-    let custom_headers = match args.mode {
-        EdgeMode::Edge(ref edge) => edge.custom_client_headers.clone(),
-        _ => vec![],
-    };
-    let custom_auth_header = Arc::new(AuthHeaders::from(&args));
-    let internal_backstage_args = args.internal_backstage.clone();
 
     let (
         (token_cache, features_cache, delta_cache_manager, engine_cache),
         token_validator,
         feature_refresher,
-        persistence,
-    ) = build_caches_and_refreshers(args.clone(), identifier.clone())
-        .await
-        .unwrap();
-
-    let instance_data_sender: Arc<InstanceDataSending> = Arc::new(InstanceDataSending::from_args(
-        args.clone(),
-        our_instance_data.clone(),
-        metrics_middleware.registry.clone(),
-    )?);
-    let instance_data_sender_for_app_context = instance_data_sender.clone();
-    let token_validator_schedule = token_validator.clone();
-    let lazy_feature_cache = features_cache.clone();
-    let lazy_token_cache = token_cache.clone();
-    let lazy_engine_cache = engine_cache.clone();
-    let lazy_feature_refresher = feature_refresher.clone();
-    let http_args_for_app_setup = args.http.clone();
-    let metrics_cache = Arc::new(MetricsCache::default());
-    let metrics_cache_clone = metrics_cache.clone();
-
-    let openapi = openapi::ApiDoc::openapi();
-    let refresher_for_app_data = feature_refresher.clone();
-    let prom_registry_for_write = metrics_middleware.registry.clone();
-    let instances_observed_for_app_context: Arc<RwLock<Vec<EdgeInstanceData>>> =
-        Arc::new(RwLock::new(Vec::new()));
-    let downstream_instance_data = instances_observed_for_app_context.clone();
-
-    let broadcaster = Broadcaster::new(delta_cache_manager.clone());
+        _,
+    ) = edge_info;
 
     let server = HttpServer::new(move || {
         let qs_config =
             serde_qs::actix::QsQueryConfig::default().qs_config(serde_qs::Config::new(5, false));
 
-        let cors_middleware = cors_arg.middleware();
+        let connect_via = ConnectVia {
+            app_name: args.app_name.clone(),
+            instance_id: our_instance_data_for_app_context.identifier.clone(),
+        };
+
+        let cors_middleware = args.http.cors.middleware();
         let mut app = App::new()
             .app_data(qs_config)
-            .app_data(web::Data::new(token_header.clone()))
-            .app_data(web::Data::new(trust_proxy.clone()))
-            .app_data(web::Data::new(mode_arg.clone()))
-            .app_data(web::Data::new(connect_via.clone()))
+            .app_data(web::Data::new(args.token_header.clone()))
+            .app_data(web::Data::new(args.trust_proxy.clone()))
+            .app_data(web::Data::new(args.mode.clone()))
+            .app_data(web::Data::new(connect_via))
             .app_data(web::Data::from(metrics_cache.clone()))
             .app_data(web::Data::from(token_cache.clone()))
             .app_data(web::Data::from(delta_cache_manager.clone()))
             .app_data(web::Data::from(features_cache.clone()))
             .app_data(web::Data::from(engine_cache.clone()))
-            .app_data(web::Data::from(broadcaster.clone()))
-            .app_data(web::Data::from(custom_auth_header.clone()))
+            .app_data(web::Data::from(Broadcaster::new(
+                delta_cache_manager.clone(),
+            )))
+            .app_data(web::Data::from(Arc::new(AuthHeaders::from(&args))))
             .app_data(web::Data::from(
                 instance_data_sender_for_app_context.clone(),
             ))
@@ -142,12 +88,12 @@ async fn main() -> Result<(), anyhow::Error> {
             Some(v) => app.app_data(web::Data::from(v)),
             None => app,
         };
-        app = match refresher_for_app_data.clone() {
+        app = match feature_refresher.clone() {
             Some(refresher) => app.app_data(web::Data::from(refresher)),
             None => app,
         };
         app.service(
-            web::scope(&base_path)
+            web::scope(&args.http.base_path)
                 .wrap(Etag)
                 .wrap(actix_web::middleware::Compress::default())
                 .wrap(actix_web::middleware::NormalizePath::default())
@@ -157,23 +103,21 @@ async fn main() -> Result<(), anyhow::Error> {
                 .service(web::scope("/internal-backstage").configure(|service_cfg| {
                     internal_backstage::configure_internal_backstage(
                         service_cfg,
-                        internal_backstage_args.clone(),
+                        args.internal_backstage.clone(),
                     )
                 }))
                 .service(
                     web::scope("/api")
                         .configure(client_api::configure_client_api)
                         .configure(|cfg| {
-                            frontend_api::configure_frontend_api(cfg, disable_all_endpoint)
+                            frontend_api::configure_frontend_api(cfg, args.disable_all_endpoint)
                         })
                         .wrap(DenyList::with_denied_ipnets(
-                            &http_args_for_app_setup
-                                .deny_list
-                                .clone()
-                                .unwrap_or_default(),
+                            &args.http.clone().deny_list.clone().unwrap_or_default(),
                         ))
                         .wrap(
-                            http_args_for_app_setup
+                            args.http
+                                .clone()
                                 .allow_list
                                 .clone()
                                 .map(|list| AllowList::with_allowed_ipnets(&list))
@@ -184,13 +128,11 @@ async fn main() -> Result<(), anyhow::Error> {
                     web::scope("/edge")
                         .configure(edge_api::configure_edge_api)
                         .wrap(DenyList::with_denied_ipnets(
-                            &http_args_for_app_setup
-                                .deny_list
-                                .clone()
-                                .unwrap_or_default(),
+                            &args.http.clone().deny_list.clone().unwrap_or_default(),
                         ))
                         .wrap(
-                            http_args_for_app_setup
+                            args.http
+                                .clone()
                                 .allow_list
                                 .clone()
                                 .map(|list| AllowList::with_allowed_ipnets(&list))
@@ -199,7 +141,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 )
                 .service(
                     SwaggerUi::new("/swagger-ui/{_:.*}")
-                        .url("/api-doc/openapi.json", openapi.clone()),
+                        .url("/api-doc/openapi.json", openapi::ApiDoc::openapi()),
                 ),
         )
     });
@@ -217,22 +159,99 @@ async fn main() -> Result<(), anyhow::Error> {
         .shutdown_timeout(5)
         .keep_alive(std::time::Duration::from_secs(keepalive_timeout))
         .client_request_timeout(std::time::Duration::from_secs(request_timeout));
+    Ok(server.run())
+}
 
-    match schedule_args.mode {
+#[cfg(not(tarpaulin_include))]
+#[actix_web::main]
+async fn main() -> Result<(), anyhow::Error> {
+    let args = CliArgs::parse();
+    if args.markdown_help {
+        clap_markdown::print_help_markdown::<CliArgs>();
+        return Ok(());
+    }
+    if let EdgeMode::Health(args) = args.mode {
+        return health_checker::check_health(args)
+            .await
+            .map_err(|e| e.into());
+    };
+    if let EdgeMode::Ready(args) = args.mode {
+        return ready_checker::check_ready(args).await.map_err(|e| e.into());
+    }
+
+    run_server(args).await
+}
+
+async fn run_server(args: CliArgs) -> Result<(), anyhow::Error> {
+    let app_name = args.app_name.clone();
+    let app_id = Ulid::new();
+    let edge_instance_data = Arc::new(EdgeInstanceData::new(&args.app_name, &app_id));
+    let client_meta_information = ClientMetaInformation {
+        app_name: args.app_name.clone(),
+        instance_id: app_id.to_string(),
+        connection_id: app_id.to_string(),
+    };
+
+    let metrics_middleware = prom_metrics::instantiate(
+        None,
+        args.internal_backstage.disable_metrics_endpoint,
+        &args.log_format,
+        &edge_instance_data.clone(),
+    );
+
+    let custom_headers = if let EdgeMode::Edge(edge) = &args.mode {
+        edge.custom_client_headers.clone()
+    } else {
+        vec![]
+    };
+
+    let edge_info = build_caches_and_refreshers(args.clone(), app_id.to_string())
+        .await
+        .unwrap();
+
+    let (
+        (token_cache, features_cache, _, engine_cache),
+        token_validator,
+        feature_refresher,
+        persistence,
+    ) = edge_info.clone();
+
+    let instance_data_sender: Arc<InstanceDataSending> = Arc::new(InstanceDataSending::from_args(
+        args.clone(),
+        edge_instance_data.clone(),
+        metrics_middleware.registry.clone(),
+    )?);
+    let instance_data_sender_for_app_context = instance_data_sender.clone();
+    let lazy_feature_cache = features_cache.clone();
+    let lazy_token_cache = token_cache.clone();
+    let lazy_engine_cache = engine_cache.clone();
+    let lazy_feature_refresher = feature_refresher.clone();
+    let metrics_cache = Arc::new(MetricsCache::default());
+    let metrics_cache_clone = metrics_cache.clone();
+
+    let instances_observed_for_app_context: Arc<RwLock<Vec<EdgeInstanceData>>> =
+        Arc::new(RwLock::new(Vec::new()));
+
+    let server = setup_server(
+        args.clone(),
+        edge_info,
+        metrics_middleware.clone(),
+        instance_data_sender_for_app_context,
+        metrics_cache.clone(),
+        edge_instance_data.clone(),
+        instances_observed_for_app_context.clone(),
+    )?;
+
+    match &args.mode {
         EdgeMode::Edge(edge) => {
             let refresher_for_background = feature_refresher.clone().unwrap();
             if edge.streaming {
-                let app_name = app_name.clone();
                 let custom_headers = custom_headers.clone();
                 if edge.delta {
                     tokio::spawn(async move {
                         let _ = refresher_for_background
                             .start_streaming_delta_background_task(
-                                ClientMetaInformation {
-                                    app_name,
-                                    instance_id: identifier.clone(),
-                                    connection_id: identifier,
-                                },
+                                client_meta_information,
                                 custom_headers,
                             )
                             .await;
@@ -241,11 +260,7 @@ async fn main() -> Result<(), anyhow::Error> {
                     tokio::spawn(async move {
                         let _ = refresher_for_background
                             .start_streaming_features_background_task(
-                                ClientMetaInformation {
-                                    app_name,
-                                    instance_id: identifier.clone(),
-                                    connection_id: identifier,
-                                },
+                                client_meta_information,
                                 custom_headers,
                             )
                             .await;
@@ -254,13 +269,12 @@ async fn main() -> Result<(), anyhow::Error> {
             }
 
             let refresher = feature_refresher.clone().unwrap();
-
-            let validator = token_validator_schedule.clone().unwrap();
+            let validator = token_validator.clone().unwrap();
 
             tokio::select! {
-                _ = server.run() => {
+                _ = server => {
                     info!("Actix is shutting down. Persisting data");
-                    clean_shutdown(persistence, lazy_feature_cache.clone(), lazy_token_cache.clone(), metrics_cache_clone.clone(), feature_refresher.clone(), InstanceDataShutdownArgs { instance_data_sending: instance_data_sender.clone(), our_instance_data, downstream_instance_data }).await;
+                    clean_shutdown(persistence, lazy_feature_cache.clone(), lazy_token_cache.clone(), metrics_cache_clone.clone(), feature_refresher.clone(), InstanceDataShutdownArgs { instance_data_sending: instance_data_sender.clone(), our_instance_data: edge_instance_data.clone(), downstream_instance_data: instances_observed_for_app_context.clone() }).await;
                                         info!("Actix was shutdown properly");
                 },
                 _ = refresher.start_refresh_features_background_task() => {
@@ -275,31 +289,31 @@ async fn main() -> Result<(), anyhow::Error> {
                 _ = validator.schedule_validation_of_known_tokens(edge.token_revalidation_interval_seconds) => {
                     info!("Token validator validation of known tokens was unexpectedly shut down");
                 }
-                _ = validator.schedule_revalidation_of_startup_tokens(edge.tokens, lazy_feature_refresher.clone()) => {
+                _ = validator.schedule_revalidation_of_startup_tokens(edge.tokens.clone(), lazy_feature_refresher.clone()) => {
                     info!("Token validator validation of startup tokens was unexpectedly shut down");
                 }
-                _ = metrics_pusher::prometheus_remote_write(prom_registry_for_write.clone(), edge.prometheus_remote_write_url, edge.prometheus_push_interval, edge.prometheus_username, edge.prometheus_password, app_name) => {
+                _ = metrics_pusher::prometheus_remote_write(metrics_middleware.registry.clone(), edge.prometheus_remote_write_url.clone(), edge.prometheus_push_interval, edge.prometheus_username.clone(), edge.prometheus_password.clone(), app_name) => {
                     info!("Prometheus push unexpectedly shut down");
                 }
-                _ = unleash_edge::http::instance_data::loop_send_instance_data(instance_data_sender.clone(), our_instance_data.clone(), downstream_instance_data.clone()) => {
+                _ = unleash_edge::http::instance_data::loop_send_instance_data(instance_data_sender.clone(), edge_instance_data.clone(), instances_observed_for_app_context.clone()) => {
                     info!("Instance data pusher unexpectedly quit");
                 }
             }
         }
         EdgeMode::Offline(offline_args) if offline_args.reload_interval > 0 => {
             tokio::select! {
-                _ = offline_hotload::start_hotload_loop(lazy_feature_cache, lazy_engine_cache, offline_args) => {
+                _ = offline_hotload::start_hotload_loop(lazy_feature_cache, lazy_engine_cache, offline_args.clone()) => {
                     info!("Hotloader unexpectedly shut down.");
                 },
-                _ = server.run() => {
+                _ = server => {
                     info!("Actix is shutting down. No pending tasks.");
                 },
             }
         }
         _ => tokio::select! {
-            _ = server.run() => {
+            _ = server => {
                 info!("Actix is shutting down. Persisting data");
-                clean_shutdown(persistence, lazy_feature_cache.clone(), lazy_token_cache.clone(), metrics_cache_clone.clone(), feature_refresher.clone(), InstanceDataShutdownArgs { instance_data_sending: instance_data_sender.clone(), our_instance_data, downstream_instance_data }).await;
+                clean_shutdown(persistence, lazy_feature_cache.clone(), lazy_token_cache.clone(), metrics_cache_clone.clone(), feature_refresher.clone(), InstanceDataShutdownArgs { instance_data_sending: instance_data_sender.clone(), our_instance_data: edge_instance_data.clone(), downstream_instance_data: instances_observed_for_app_context.clone() }).await;
                 info!("Actix was shutdown properly");
 
             }

--- a/server/src/metrics/client_impact_metrics.rs
+++ b/server/src/metrics/client_impact_metrics.rs
@@ -158,7 +158,7 @@ mod test {
     ) -> ImpactMetric {
         ImpactMetric {
             name: name.into(),
-            help: format!("Test {} metric", r#type).into(),
+            help: format!("Test {} metric", r#type),
             r#type: r#type.into(),
             samples,
         }

--- a/server/src/metrics/edge_metrics.rs
+++ b/server/src/metrics/edge_metrics.rs
@@ -310,10 +310,10 @@ pub struct EdgeInstanceData {
 }
 
 impl EdgeInstanceData {
-    pub fn new(app_name: &str) -> Self {
+    pub fn new(app_name: &str, identifier: &Ulid) -> Self {
         let build_info = BuildInfo::default();
         Self {
-            identifier: Ulid::new().to_string(),
+            identifier: identifier.to_string(),
             app_name: app_name.to_string(),
             region: std::env::var("AWS_REGION").ok(),
             edge_version: build_info.package_version.clone(),
@@ -693,7 +693,7 @@ mod tests {
 
     #[test]
     fn can_observe_request_consumption_and_clear_consumption_metrics() {
-        let instance_data = EdgeInstanceData::new("test");
+        let instance_data = EdgeInstanceData::new("test", &Ulid::new());
 
         instance_data.observe_request_consumption();
         instance_data.observe_request_consumption();
@@ -727,7 +727,7 @@ mod tests {
 
     #[test]
     fn can_observe_connection_consumption_with_data_points() {
-        let instance_data = EdgeInstanceData::new("test");
+        let instance_data = EdgeInstanceData::new("test", &Ulid::new());
 
         instance_data.observe_connection_consumption("/api/client/features", Some(0));
         instance_data.observe_connection_consumption("/api/client/features", Some(0));

--- a/server/src/metrics/metric_batching.rs
+++ b/server/src/metrics/metric_batching.rs
@@ -220,10 +220,10 @@ mod tests {
     #[test_case(5000, 1, 20; "5000 apps 1 metric will be split")]
     fn splits_successfully_into_sendable_chunks(apps: u64, toggles: u64, batch_count: usize) {
         let apps: Vec<ClientApplication> =
-            (1..=apps).map(|app_id| make_client_app(app_id)).collect();
+            (1..=apps).map(make_client_app).collect();
 
         let toggles: Vec<ClientMetricsEnv> = (1..=toggles)
-            .map(|toggle_id| make_metrics_env(toggle_id))
+            .map(make_metrics_env)
             .collect();
 
         let cache = MetricsCache::default();
@@ -256,11 +256,11 @@ mod tests {
         impacts: Vec<String>,
         batch_size: usize,
     ) {
-        let apps = apps.into_iter().map(|s| make_client_app(s)).collect();
-        let metrics = metrics.into_iter().map(|s| make_metrics_env(s)).collect();
+        let apps = apps.into_iter().map(make_client_app).collect();
+        let metrics = metrics.into_iter().map(make_metrics_env).collect();
         let impacts = impacts
             .into_iter()
-            .map(|s| make_impact_metric_env(s))
+            .map(make_impact_metric_env)
             .collect();
 
         let batch = MetricsBatch {

--- a/server/src/metrics/metric_batching.rs
+++ b/server/src/metrics/metric_batching.rs
@@ -219,12 +219,9 @@ mod tests {
     #[test_case(500, 5000, 15; "500 apps 5000 toggles, will be split into 15 batches")]
     #[test_case(5000, 1, 20; "5000 apps 1 metric will be split")]
     fn splits_successfully_into_sendable_chunks(apps: u64, toggles: u64, batch_count: usize) {
-        let apps: Vec<ClientApplication> =
-            (1..=apps).map(make_client_app).collect();
+        let apps: Vec<ClientApplication> = (1..=apps).map(make_client_app).collect();
 
-        let toggles: Vec<ClientMetricsEnv> = (1..=toggles)
-            .map(make_metrics_env)
-            .collect();
+        let toggles: Vec<ClientMetricsEnv> = (1..=toggles).map(make_metrics_env).collect();
 
         let cache = MetricsCache::default();
         for app in apps.clone() {
@@ -258,10 +255,7 @@ mod tests {
     ) {
         let apps = apps.into_iter().map(make_client_app).collect();
         let metrics = metrics.into_iter().map(make_metrics_env).collect();
-        let impacts = impacts
-            .into_iter()
-            .map(make_impact_metric_env)
-            .collect();
+        let impacts = impacts.into_iter().map(make_impact_metric_env).collect();
 
         let batch = MetricsBatch {
             applications: apps,

--- a/server/src/middleware/consumption.rs
+++ b/server/src/middleware/consumption.rs
@@ -100,10 +100,11 @@ mod tests {
     use crate::metrics::edge_metrics::EdgeInstanceData;
     use crate::middleware::as_async_middleware::as_async_middleware;
     use actix_web::{App, HttpResponse, test};
+    use ulid::Ulid;
 
     #[test]
     async fn test_backend_consumption() {
-        let instance_data = EdgeInstanceData::new("test");
+        let instance_data = EdgeInstanceData::new("test", &Ulid::new());
         let app = test::init_service(
             App::new()
                 .app_data(Data::new(instance_data.clone()))
@@ -124,7 +125,7 @@ mod tests {
 
     #[test]
     async fn test_frontend_consumption() {
-        let instance_data = EdgeInstanceData::new("test");
+        let instance_data = EdgeInstanceData::new("test", &Ulid::new());
         let app = test::init_service(
             App::new()
                 .app_data(Data::new(instance_data.clone()))

--- a/server/src/prom_metrics.rs
+++ b/server/src/prom_metrics.rs
@@ -170,5 +170,9 @@ pub fn test_instantiate_without_tracing_and_logging(
 
     let registry = registry.unwrap_or_else(instantiate_registry);
     register_custom_metrics(&registry);
-    instantiate_prometheus_metrics_handler(registry, false, &EdgeInstanceData::new("test app", &Ulid::new()))
+    instantiate_prometheus_metrics_handler(
+        registry,
+        false,
+        &EdgeInstanceData::new("test app", &Ulid::new()),
+    )
 }

--- a/server/src/prom_metrics.rs
+++ b/server/src/prom_metrics.rs
@@ -166,7 +166,9 @@ fn register_custom_metrics(registry: &prometheus::Registry) {
 pub fn test_instantiate_without_tracing_and_logging(
     registry: Option<prometheus::Registry>,
 ) -> PrometheusMetrics {
+    use ulid::Ulid;
+
     let registry = registry.unwrap_or_else(instantiate_registry);
     register_custom_metrics(&registry);
-    instantiate_prometheus_metrics_handler(registry, false, &EdgeInstanceData::new("test app"))
+    instantiate_prometheus_metrics_handler(registry, false, &EdgeInstanceData::new("test app", &Ulid::new()))
 }


### PR DESCRIPTION
Extracted and refactored Actix app initialization into a dedicated setup_server function. This change removes inline setup logic from main.rs, reduces duplication, and centralizes App configuration. Mostly it makes it saner to read and reduces the 300 line main to a bunch of smaller functions that limit the amount of state sharing.

No functional changes. All runtime behavior, endpoints, and tasks remain identical.