### PR TITLE
feat: add an option for setting upstream keep alive timeout

### DIFF
--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -354,7 +354,7 @@ mod tests {
     use crate::{
         builder::{build_edge, build_offline},
         cli::{AuthHeaders, EdgeArgs, OfflineArgs},
-        http::unleash_client::{ClientMetaInformation, new_reqwest_client},
+        http::unleash_client::{ClientMetaInformation, HttpClientArgs, new_reqwest_client},
     };
 
     #[test]
@@ -378,32 +378,9 @@ mod tests {
     #[tokio::test]
     async fn should_fail_with_empty_tokens_when_strict() {
         let args = EdgeArgs {
-            upstream_url: Default::default(),
-            backup_folder: None,
-            metrics_interval_seconds: Default::default(),
-            features_refresh_interval_seconds: Default::default(),
             strict: true,
-            dynamic: false,
             tokens: vec![],
-            pretrusted_tokens: None,
-            redis: None,
-            s3: None,
-            client_identity: Default::default(),
-            skip_ssl_verification: false,
-            upstream_request_timeout: Default::default(),
-            upstream_socket_timeout: Default::default(),
-            custom_client_headers: Default::default(),
-            upstream_certificate_file: Default::default(),
-            token_revalidation_interval_seconds: Default::default(),
-            prometheus_push_interval: 60,
-            prometheus_remote_write_url: None,
-            prometheus_user_id: None,
-            prometheus_password: None,
-            prometheus_username: None,
-            streaming: false,
-            delta: false,
-            delta_diff: false,
-            consumption: false,
+            ..Default::default()
         };
 
         let client_meta_information = ClientMetaInformation {
@@ -412,15 +389,7 @@ mod tests {
             connection_id: "test-connection-id".into(),
         };
 
-        let client = new_reqwest_client(
-            args.skip_ssl_verification,
-            args.client_identity.clone(),
-            args.upstream_certificate_file.clone(),
-            Duration::seconds(args.upstream_request_timeout),
-            Duration::seconds(args.upstream_socket_timeout),
-            client_meta_information.clone(),
-        )
-        .unwrap();
+        let client = new_reqwest_client(HttpClientArgs::default()).unwrap();
 
         let result = build_edge(
             &args,

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -233,7 +233,7 @@ pub struct EdgeArgs {
     pub consumption: bool,
 
     /// Sets the keep-alive timeout for connections from Edge to upstream
-    #[clap(long, env, default_value_t = 15, requires = "strict")]
+    #[clap(long, env, default_value_t = 15)]
     pub client_keepalive_timeout: i64,
 
     /// If set to true, it compares features payload with delta payload and logs diff. This flag is for internal testing only. Do not turn this on for production configurations

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -148,7 +148,7 @@ pub enum PromAuth {
     Basic(String, String),
 }
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Debug, Clone, Default)]
 #[command(group(
     ArgGroup::new("data-provider")
         .args(["redis_url", "backup_folder", "s3_bucket_name"]),
@@ -231,6 +231,10 @@ pub struct EdgeArgs {
     /// If set to true, Edge will track and report consumption metrics. This is an experimental feature and may change. Changes to this feature may not follow semantic versioning. Requires strict mode
     #[clap(long, env, default_value_t = false, requires = "strict", hide = true)]
     pub consumption: bool,
+
+    /// Sets the keep-alive timeout for connections from Edge to upstream
+    #[clap(long, env, default_value_t = 15, requires = "strict")]
+    pub client_keepalive_timeout: i64,
 
     /// If set to true, it compares features payload with delta payload and logs diff. This flag is for internal testing only. Do not turn this on for production configurations
     #[clap(

--- a/server/src/http/refresher/feature_refresher.rs
+++ b/server/src/http/refresher/feature_refresher.rs
@@ -693,7 +693,7 @@ mod tests {
 
     use crate::feature_cache::{FeatureCache, update_projects_from_feature_update};
     use crate::filters::{FeatureFilterSet, project_filter};
-    use crate::http::unleash_client::{new_reqwest_client, ClientMetaInformation, HttpClientArgs};
+    use crate::http::unleash_client::{ClientMetaInformation, HttpClientArgs, new_reqwest_client};
     use crate::tests::features_from_disk;
     use crate::tokens::cache_key;
     use crate::types::TokenValidationStatus::Validated;
@@ -715,12 +715,10 @@ mod tests {
     }
 
     fn create_test_client() -> UnleashClient {
-        let http_client = new_reqwest_client(
-            HttpClientArgs {
-                client_meta_information: ClientMetaInformation::test_config(),
-                ..Default::default()
-            }
-        )
+        let http_client = new_reqwest_client(HttpClientArgs {
+            client_meta_information: ClientMetaInformation::test_config(),
+            ..Default::default()
+        })
         .expect("Failed to create client");
 
         UnleashClient::from_url(

--- a/server/src/http/refresher/feature_refresher.rs
+++ b/server/src/http/refresher/feature_refresher.rs
@@ -693,7 +693,7 @@ mod tests {
 
     use crate::feature_cache::{FeatureCache, update_projects_from_feature_update};
     use crate::filters::{FeatureFilterSet, project_filter};
-    use crate::http::unleash_client::{ClientMetaInformation, new_reqwest_client};
+    use crate::http::unleash_client::{new_reqwest_client, ClientMetaInformation, HttpClientArgs};
     use crate::tests::features_from_disk;
     use crate::tokens::cache_key;
     use crate::types::TokenValidationStatus::Validated;
@@ -716,12 +716,10 @@ mod tests {
 
     fn create_test_client() -> UnleashClient {
         let http_client = new_reqwest_client(
-            false,
-            None,
-            None,
-            Duration::seconds(5),
-            Duration::seconds(5),
-            ClientMetaInformation::test_config(),
+            HttpClientArgs {
+                client_meta_information: ClientMetaInformation::test_config(),
+                ..Default::default()
+            }
         )
         .expect("Failed to create client");
 

--- a/server/src/middleware/client_token_from_frontend_token.rs
+++ b/server/src/middleware/client_token_from_frontend_token.rs
@@ -66,7 +66,7 @@ mod tests {
     use crate::delta_cache_manager::DeltaCacheManager;
     use crate::feature_cache::FeatureCache;
     use crate::http::refresher::feature_refresher::FeatureRefresher;
-    use crate::http::unleash_client::{new_reqwest_client, HttpClientArgs, UnleashClient};
+    use crate::http::unleash_client::{HttpClientArgs, UnleashClient, new_reqwest_client};
     use crate::tests::upstream_server;
     use crate::types::{EdgeToken, TokenType, TokenValidationStatus};
 
@@ -136,12 +136,10 @@ mod tests {
         .await;
 
         let meta_information = crate::http::unleash_client::ClientMetaInformation::test_config();
-        let http_client = new_reqwest_client(
-            HttpClientArgs {
-                client_meta_information: meta_information.clone(),
-                ..Default::default()
-            }
-        )
+        let http_client = new_reqwest_client(HttpClientArgs {
+            client_meta_information: meta_information.clone(),
+            ..Default::default()
+        })
         .expect("Failed to create client");
 
         let unleash_client = UnleashClient::from_url(

--- a/server/src/middleware/client_token_from_frontend_token.rs
+++ b/server/src/middleware/client_token_from_frontend_token.rs
@@ -66,7 +66,7 @@ mod tests {
     use crate::delta_cache_manager::DeltaCacheManager;
     use crate::feature_cache::FeatureCache;
     use crate::http::refresher::feature_refresher::FeatureRefresher;
-    use crate::http::unleash_client::{UnleashClient, new_reqwest_client};
+    use crate::http::unleash_client::{new_reqwest_client, HttpClientArgs, UnleashClient};
     use crate::tests::upstream_server;
     use crate::types::{EdgeToken, TokenType, TokenValidationStatus};
 
@@ -137,12 +137,10 @@ mod tests {
 
         let meta_information = crate::http::unleash_client::ClientMetaInformation::test_config();
         let http_client = new_reqwest_client(
-            false,
-            None,
-            None,
-            Duration::seconds(5),
-            Duration::seconds(5),
-            meta_information.clone(),
+            HttpClientArgs {
+                client_meta_information: meta_information.clone(),
+                ..Default::default()
+            }
         )
         .expect("Failed to create client");
 

--- a/server/tests/streaming_test.rs
+++ b/server/tests/streaming_test.rs
@@ -206,30 +206,7 @@ mod streaming_test {
             let edge_mode = EdgeMode::Edge(EdgeArgs {
                 streaming: true,
                 upstream_url: "".into(),
-                backup_folder: None,
-                metrics_interval_seconds: 60,
-                features_refresh_interval_seconds: 60,
-                token_revalidation_interval_seconds: 60,
-                tokens: vec!["".into()],
-                pretrusted_tokens: None,
-                custom_client_headers: vec![],
-                skip_ssl_verification: false,
-                client_identity: None,
-                upstream_certificate_file: None,
-                upstream_request_timeout: 5,
-                upstream_socket_timeout: 5,
-                redis: None,
-                s3: None,
-                strict: true,
-                dynamic: false,
-                delta: false,
-                delta_diff: false,
-                consumption: false,
-                prometheus_remote_write_url: None,
-                prometheus_push_interval: 60,
-                prometheus_username: None,
-                prometheus_password: None,
-                prometheus_user_id: None,
+                ..Default::default()
             });
 
             let config = serde_qs::actix::QsQueryConfig::default()


### PR DESCRIPTION
Adds an option for setting keep alive timeout for connections between Edge and upstream. Defaults this to Unleash's interval - 15 seconds.

Also does a bunch of surgery to fix tests :cry: 