### PR TITLE
chore: add a constructor to token validator

### DIFF
--- a/server/src/auth/token_validator.rs
+++ b/server/src/auth/token_validator.rs
@@ -13,9 +13,9 @@ use crate::types::{
 
 #[derive(Clone)]
 pub struct TokenValidator {
-    pub unleash_client: Arc<UnleashClient>,
+    unleash_client: Arc<UnleashClient>,
     pub token_cache: Arc<DashMap<String, EdgeToken>>,
-    pub persistence: Option<Arc<dyn EdgePersistence>>,
+    persistence: Option<Arc<dyn EdgePersistence>>,
 }
 
 pub(crate) trait TokenRegister {
@@ -34,6 +34,18 @@ impl TokenRegister for TokenValidator {
 }
 
 impl TokenValidator {
+    pub fn new(
+        unleash_client: Arc<UnleashClient>,
+        token_cache: Arc<DashMap<String, EdgeToken>>,
+        persistence: Option<Arc<dyn EdgePersistence>>,
+    ) -> Self {
+        TokenValidator {
+            unleash_client,
+            token_cache,
+            persistence,
+        }
+    }
+
     async fn get_unknown_and_known_tokens(
         &self,
         tokens: Vec<String>,

--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -279,11 +279,11 @@ pub async fn build_edge(
         }
     }
 
-    let token_validator = Arc::new(TokenValidator {
-        token_cache: token_cache.clone(),
-        unleash_client: unleash_client.clone(),
-        persistence: persistence.clone(),
-    });
+    let token_validator = Arc::new(TokenValidator::new(
+        unleash_client.clone(),
+        token_cache.clone(),
+        persistence.clone(),
+    ));
     let refresher_mode = match (args.strict, args.streaming) {
         (_, true) => FeatureRefresherMode::Streaming,
         (true, _) => FeatureRefresherMode::Strict,

--- a/server/src/client_api.rs
+++ b/server/src/client_api.rs
@@ -1243,11 +1243,11 @@ mod tests {
             delta: false,
             delta_diff: false,
         });
-        let token_validator = Arc::new(TokenValidator {
-            unleash_client: unleash_client.clone(),
-            token_cache: token_cache.clone(),
-            persistence: None,
-        });
+        let token_validator = Arc::new(TokenValidator::new(
+            unleash_client.clone(),
+            token_cache.clone(),
+            None,
+        ));
         let local_app = test::init_service(
             App::new()
                 .app_data(Data::from(token_validator.clone()))
@@ -1304,11 +1304,11 @@ mod tests {
             refresh_interval: Duration::seconds(6000),
             ..Default::default()
         });
-        let token_validator = Arc::new(TokenValidator {
-            unleash_client: unleash_client.clone(),
-            token_cache: token_cache.clone(),
-            persistence: None,
-        });
+        let token_validator = Arc::new(TokenValidator::new(
+            unleash_client.clone(),
+            token_cache.clone(),
+            None,
+        ));
         let local_app = test::init_service(
             App::new()
                 .app_data(Data::from(token_validator.clone()))
@@ -1431,11 +1431,11 @@ mod tests {
             strict: false,
             ..Default::default()
         });
-        let token_validator = Arc::new(TokenValidator {
-            unleash_client: unleash_client.clone(),
-            token_cache: token_cache.clone(),
-            persistence: None,
-        });
+        let token_validator = Arc::new(TokenValidator::new(
+            unleash_client.clone(),
+            token_cache.clone(),
+            None,
+        ));
         let local_app = test::init_service(
             App::new()
                 .app_data(Data::from(token_validator.clone()))

--- a/server/src/edge_api.rs
+++ b/server/src/edge_api.rs
@@ -128,11 +128,8 @@ mod tests {
     #[tokio::test]
     pub async fn adding_a_token_validator_filters_so_only_validated_tokens_are_returned() {
         let token_cache: Arc<DashMap<String, EdgeToken>> = Arc::new(DashMap::default());
-        let token_validator = TokenValidator {
-            unleash_client: Arc::new(Default::default()),
-            token_cache: token_cache.clone(),
-            persistence: None,
-        };
+        let token_validator =
+            TokenValidator::new(Arc::new(Default::default()), token_cache.clone(), None);
         let app = test::init_service(
             App::new()
                 .app_data(web::Data::from(token_cache.clone()))

--- a/server/src/internal_backstage.rs
+++ b/server/src/internal_backstage.rs
@@ -345,11 +345,11 @@ mod tests {
             unleash_client: arc_unleash_client.clone(),
             ..Default::default()
         };
-        let token_validator = TokenValidator {
-            unleash_client: arc_unleash_client.clone(),
-            token_cache: Arc::new(DashMap::default()),
-            persistence: None,
-        };
+        let token_validator = TokenValidator::new(
+            arc_unleash_client.clone(),
+            Arc::new(DashMap::default()),
+            None,
+        );
         let token_cache: DashMap<String, EdgeToken> = DashMap::default();
         let app = test::init_service(
             App::new()
@@ -405,11 +405,11 @@ mod tests {
             strict: false,
             ..Default::default()
         });
-        let token_validator = Arc::new(TokenValidator {
-            unleash_client: unleash_client.clone(),
-            token_cache: token_cache.clone(),
-            persistence: None,
-        });
+        let token_validator = Arc::new(TokenValidator::new(
+            unleash_client.clone(),
+            token_cache.clone(),
+            None,
+        ));
         let local_app = test::init_service(
             App::new()
                 .app_data(web::Data::from(token_validator.clone()))
@@ -478,11 +478,11 @@ mod tests {
             refresh_interval: Duration::seconds(6000),
             ..Default::default()
         });
-        let token_validator = Arc::new(TokenValidator {
-            unleash_client: unleash_client.clone(),
-            token_cache: token_cache.clone(),
-            persistence: None,
-        });
+        let token_validator = Arc::new(TokenValidator::new(
+            unleash_client,
+            token_cache.clone(),
+            None,
+        ));
         let local_app = test::init_service(
             App::new()
                 .app_data(web::Data::from(token_validator.clone()))

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -67,11 +67,11 @@ mod tests {
         upstream_delta_cache_manager: Arc<DeltaCacheManager>,
         upstream_engine_cache: Arc<DashMap<String, EngineState>>,
     ) -> TestServer {
-        let token_validator = Arc::new(TokenValidator {
-            unleash_client: Arc::new(Default::default()),
-            token_cache: upstream_token_cache.clone(),
-            persistence: None,
-        });
+        let token_validator = Arc::new(TokenValidator::new(
+            Arc::new(Default::default()),
+            upstream_token_cache.clone(),
+            None,
+        ));
 
         test_server(move || {
             let config = serde_qs::actix::QsQueryConfig::default()

--- a/server/src/middleware/client_token_from_frontend_token.rs
+++ b/server/src/middleware/client_token_from_frontend_token.rs
@@ -76,11 +76,11 @@ mod tests {
         local_features_cache: Arc<FeatureCache>,
         local_engine_cache: Arc<DashMap<String, EngineState>>,
     ) -> TestServer {
-        let token_validator = Arc::new(TokenValidator {
-            unleash_client: unleash_client.clone(),
-            token_cache: local_token_cache.clone(),
-            persistence: None,
-        });
+        let token_validator = Arc::new(TokenValidator::new(
+            unleash_client.clone(),
+            local_token_cache.clone(),
+            None,
+        ));
         let feature_refresher = Arc::new(FeatureRefresher {
             unleash_client: unleash_client.clone(),
             features_cache: local_features_cache.clone(),

--- a/server/tests/streaming_test.rs
+++ b/server/tests/streaming_test.rs
@@ -195,11 +195,11 @@ mod streaming_test {
         upstream_engine_cache: Arc<DashMap<String, EngineState>>,
         upstream_broadcaster: Arc<Broadcaster>,
     ) -> TestServer {
-        let token_validator = Arc::new(TokenValidator {
-            unleash_client: Arc::new(Default::default()),
-            token_cache: upstream_token_cache.clone(),
-            persistence: None,
-        });
+        let token_validator = Arc::new(TokenValidator::new(
+            Arc::new(Default::default()),
+            upstream_token_cache.clone(),
+            None,
+        ));
 
         test_server(move || {
             // the streaming endpoint doesn't work unless app data contains an EdgeMode::Edge with streaming: true


### PR DESCRIPTION
This does nothing useful, it just adds a constructor function to the token validator so that we can make some invasive internal changes without touching the entire application