### PR TITLE
fix: validation error should reflect status code

### DIFF
--- a/benchmarks/clientfeaturesendpoint.js
+++ b/benchmarks/clientfeaturesendpoint.js
@@ -1,16 +1,16 @@
 import http from 'k6/http';
 
-import { sleep } from 'k6';
+import {sleep} from 'k6';
 
 export const options = {
-  duration: '10s',
-  vus: 50,
-  thresholds: {
-    http_req_failed: ['rate<0.01'],
-    http_req_duration: ['p(95)<10'] // (95th percentile should be < 10 ms)
-  }
+    duration: '10s',
+    vus: 50,
+    thresholds: {
+        http_req_failed: ['rate<0.01'],
+        http_req_duration: ['p(95)<10'] // (95th percentile should be < 10 ms)
+    }
 };
 
 export default function () {
-  http.get('http://127.0.0.1:3063/api/client/features', { 'headers': { 'Authorization': `${__ENV.TOKEN}` } });
+    http.get(`${__ENV.URL}/api/client/features`, {'headers': {'Authorization': `${__ENV.TOKEN}`}});
 }

--- a/benchmarks/clientfeaturesendpoint.js
+++ b/benchmarks/clientfeaturesendpoint.js
@@ -12,5 +12,5 @@ export const options = {
 };
 
 export default function () {
-    http.get(`${__ENV.URL}/api/client/features`, {'headers': {'Authorization': `${__ENV.TOKEN}`}});
+    http.get(`${__ENV.URL}api/client/features`, {'headers': {'Authorization': `${__ENV.TOKEN}`}});
 }

--- a/benchmarks/keyrotation_benchmark.js
+++ b/benchmarks/keyrotation_benchmark.js
@@ -3,7 +3,7 @@ import {check, sleep} from 'k6';
 
 export const options = {
     vus: 150,
-    duration: '5s',
+    duration: '30s',
     thresholds: {
         http_req_duration: ['p(95) < 500']
     }

--- a/benchmarks/keyrotation_benchmark.js
+++ b/benchmarks/keyrotation_benchmark.js
@@ -23,11 +23,10 @@ export default function () {
         Authorization: randomToken(),
         // Authorization: TOKEN,
     };
-    const res = http.post(`${__ENV.URL}api/client/metrics`, {
+    const res = http.post(`${__ENV.URL}api/client/features`, {
         headers,
         timeout: '10s',
     });
-    console.log(`Response status: ${res.status}`);
     check(res, {
         'status is 403': (r) => r.status === 403,
     });

--- a/benchmarks/keyrotation_benchmark.js
+++ b/benchmarks/keyrotation_benchmark.js
@@ -1,28 +1,29 @@
 import http from 'k6/http';
-import { check, sleep } from 'k6';
-const URL = "https://sandbox.getunleash.io/moneybags/"
+import {check, sleep} from 'k6';
+
 export const options = {
     vus: 150,
-    duration: '30s',
+    duration: '5s',
     thresholds: {
         http_req_duration: ['p(95) < 500']
     }
 };
+
 function randomToken() {
-    const chars = 'a';
+    const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
     let hash = '';
     for (let i = 0; i < 64; i++) {
         hash += chars.charAt(Math.floor(Math.random() * chars.length));
     }
     return `*:development.${hash}`;
 }
+
 export default function () {
     const headers = {
         Authorization: randomToken(),
-        Connection: 'close'
         // Authorization: TOKEN,
     };
-    const res = http.post(`${URL}api/client/features/`, {
+    const res = http.post(`${__ENV.URL}api/client/metrics`, {
         headers,
         timeout: '10s',
     });

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -131,7 +131,7 @@ pub enum EdgeError {
     SseError(String),
     TlsError(String),
     TokenParseError(String),
-    TokenValidationError(reqwest::StatusCode),
+    TokenValidationError(StatusCode),
 }
 
 impl Error for EdgeError {}
@@ -253,7 +253,7 @@ impl ResponseError for EdgeError {
             EdgeError::JsonParseError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             EdgeError::EdgeTokenError => StatusCode::BAD_REQUEST,
             EdgeError::EdgeTokenParseError => StatusCode::BAD_REQUEST,
-            EdgeError::TokenValidationError(_) => StatusCode::BAD_REQUEST,
+            EdgeError::TokenValidationError(status_code) => status_code.clone(),
             EdgeError::AuthorizationPending => StatusCode::UNAUTHORIZED,
             EdgeError::FeatureNotFound(_) => StatusCode::NOT_FOUND,
             EdgeError::EdgeMetricsError => StatusCode::BAD_REQUEST,

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -253,7 +253,7 @@ impl ResponseError for EdgeError {
             EdgeError::JsonParseError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             EdgeError::EdgeTokenError => StatusCode::BAD_REQUEST,
             EdgeError::EdgeTokenParseError => StatusCode::BAD_REQUEST,
-            EdgeError::TokenValidationError(status_code) => status_code.clone(),
+            EdgeError::TokenValidationError(status_code) => *status_code,
             EdgeError::AuthorizationPending => StatusCode::UNAUTHORIZED,
             EdgeError::FeatureNotFound(_) => StatusCode::NOT_FOUND,
             EdgeError::EdgeMetricsError => StatusCode::BAD_REQUEST,

--- a/server/src/http/unleash_client.rs
+++ b/server/src/http/unleash_client.rs
@@ -1,11 +1,4 @@
-use std::collections::HashMap;
-use std::fs;
-use std::fs::File;
-use std::io::BufReader;
-use std::io::Read;
-use std::path::PathBuf;
-use std::str::FromStr;
-
+use actix_web::http;
 use actix_web::http::header::EntityTag;
 use chrono::Duration;
 use chrono::Utc;
@@ -15,6 +8,13 @@ use reqwest::header::{HeaderMap, HeaderName};
 use reqwest::{Client, header};
 use reqwest::{ClientBuilder, Identity, RequestBuilder, StatusCode, Url};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::fs::File;
+use std::io::BufReader;
+use std::io::Read;
+use std::path::PathBuf;
+use std::str::FromStr;
 use tracing::{debug, error};
 use tracing::{info, trace, warn};
 use unleash_types::client_features::{ClientFeatures, ClientFeaturesDelta};
@@ -809,7 +809,7 @@ impl UnleashClient {
                 );
                 check_api_suffix();
                 Err(EdgeError::TokenValidationError(
-                    reqwest::StatusCode::from_u16(s.as_u16()).unwrap(),
+                    actix_web::http::StatusCode::from_u16(s.as_u16()).unwrap(),
                 ))
             }
         }

--- a/server/src/http/unleash_client.rs
+++ b/server/src/http/unleash_client.rs
@@ -1,4 +1,3 @@
-use actix_web::http;
 use actix_web::http::header::EntityTag;
 use chrono::Duration;
 use chrono::Utc;


### PR DESCRIPTION
So, previously we forced all failed TokenValidationErrors to return Bad Data. This PR instead returns the status code that came from the upstream validation.

This means, if upstream is telling us 429, Edge will also tell downstream 429 (Too many requests).

We don't often get these errors, but we some suspicion that a certain customer's 400s is due to this.