### PR TITLE
feat: Enable consumption metrics by default

### DIFF
--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -228,8 +228,8 @@ pub struct EdgeArgs {
     #[clap(long, env, default_value_t = false, requires = "strict", hide = true)]
     pub delta: bool,
 
-    /// If set to true, Edge will track and report consumption metrics. This is an experimental feature and may change. Changes to this feature may not follow semantic versioning. Requires strict mode
-    #[clap(long, env, default_value_t = false, requires = "strict", hide = true)]
+    /// When true, Edge will track and report consumption metrics. This is an experimental feature and may change. Changes to this feature may not follow semantic versioning. Requires strict mode
+    #[clap(long, env, default_value_t = true, requires = "strict", hide = true)]
     pub consumption: bool,
 
     /// Sets the keep-alive timeout for connections from Edge to upstream


### PR DESCRIPTION
Flips the default value of the `consumption` flag to `true` instead of `false`.

In theory, this would be a breaking change, but there was a docstring that said that changes to this feature _may_ not be breaking (which is about as useless as it gets).

Still need to figure out whether this messes with Edge when you don't run strict.

Also not sure whether this makes the feature stable or whether it's still experimental.
