### PR TITLE
chore: make hosting non-optional

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -30,7 +30,7 @@ use unleash_edge::http::broadcaster::Broadcaster;
 use unleash_edge::http::instance_data::InstanceDataSending;
 use unleash_edge::http::refresher::feature_refresher::FeatureRefresher;
 use unleash_edge::metrics::client_metrics::MetricsCache;
-use unleash_edge::metrics::edge_metrics::EdgeInstanceData;
+use unleash_edge::metrics::edge_metrics::{EdgeInstanceData, Hosting};
 use unleash_edge::offline::offline_hotload;
 use unleash_edge::persistence::{EdgePersistence, persist_data};
 use unleash_edge::types::{EdgeResult, EdgeToken, TokenValidationStatus};
@@ -199,7 +199,9 @@ async fn main() -> Result<(), anyhow::Error> {
 async fn run_server(args: CliArgs) -> EdgeResult<()> {
     let app_name = args.app_name.clone();
     let app_id = Ulid::new();
-    let hosting_strategy = std::env::var("EDGE_HOSTING").map(Into::into).ok();
+    let hosting_strategy = std::env::var("EDGE_HOSTING")
+        .map(Into::into)
+        .unwrap_or(Hosting::SelfHosted);
     let edge_instance_data = Arc::new(EdgeInstanceData::new(
         &args.app_name,
         &app_id,

--- a/server/src/middleware/consumption.rs
+++ b/server/src/middleware/consumption.rs
@@ -80,14 +80,14 @@ pub async fn request_consumption(
 mod tests {
     use super::*;
 
-    use crate::metrics::edge_metrics::EdgeInstanceData;
+    use crate::metrics::edge_metrics::{EdgeInstanceData, Hosting};
     use crate::middleware::as_async_middleware::as_async_middleware;
     use actix_web::{App, HttpResponse, test};
     use ulid::Ulid;
 
     #[test]
     async fn test_backend_consumption() {
-        let instance_data = EdgeInstanceData::new("test", &Ulid::new(), None);
+        let instance_data = EdgeInstanceData::new("test", &Ulid::new(), Hosting::SelfHosted);
         let app = test::init_service(
             App::new()
                 .app_data(Data::new(instance_data.clone()))
@@ -108,7 +108,7 @@ mod tests {
 
     #[test]
     async fn test_frontend_consumption() {
-        let instance_data = EdgeInstanceData::new("test", &Ulid::new(), None);
+        let instance_data = EdgeInstanceData::new("test", &Ulid::new(), Hosting::SelfHosted);
         let app = test::init_service(
             App::new()
                 .app_data(Data::new(instance_data.clone()))

--- a/server/src/prom_metrics.rs
+++ b/server/src/prom_metrics.rs
@@ -168,11 +168,13 @@ pub fn test_instantiate_without_tracing_and_logging(
 ) -> PrometheusMetrics {
     use ulid::Ulid;
 
+    use crate::metrics::edge_metrics::Hosting;
+
     let registry = registry.unwrap_or_else(instantiate_registry);
     register_custom_metrics(&registry);
     instantiate_prometheus_metrics_handler(
         registry,
         false,
-        &EdgeInstanceData::new("test app", &Ulid::new(), None),
+        &EdgeInstanceData::new("test app", &Ulid::new(), Hosting::SelfHosted),
     )
 }


### PR DESCRIPTION
Makes the hosting variable non-optional in setting. The variable is still optional in the data schema because Edge needs to accept incoming data from other edges that may not have this property set.