### PR TITLE
fix(metrics): Edge observability now works

### DIFF
--- a/crates/unleash-edge-http-client/src/instance_data.rs
+++ b/crates/unleash-edge-http-client/src/instance_data.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::{ClientMetaInformation, UnleashClient};
-use prometheus::Registry;
 use tracing::{debug, warn};
 use unleash_edge_cli::{CliArgs, EdgeMode};
 use unleash_edge_types::errors::EdgeError;
@@ -13,7 +12,6 @@ use unleash_edge_types::metrics::instance_data::EdgeInstanceData;
 #[derive(Debug, Clone)]
 pub struct InstanceDataSender {
     pub unleash_client: Arc<UnleashClient>,
-    pub registry: Registry,
     pub token: String,
     pub base_path: String,
 }
@@ -29,7 +27,6 @@ impl InstanceDataSending {
         args: CliArgs,
         client_meta_information: &ClientMetaInformation,
         http_client: reqwest::Client,
-        registry: Registry,
     ) -> Result<Self, EdgeError> {
         match args.mode {
             EdgeMode::Edge(edge_args) => edge_args
@@ -58,7 +55,6 @@ impl InstanceDataSending {
                         unleash_client,
                         token: token.clone(),
                         base_path: args.http.base_path.clone(),
-                        registry,
                     };
                     InstanceDataSending::SendInstanceData(instance_data_sender)
                 })
@@ -75,7 +71,6 @@ pub async fn send_instance_data(
     downstream_instance_data: Arc<RwLock<Vec<EdgeInstanceData>>>,
 ) -> Result<(), EdgeError> {
     let observed_data = our_instance_data.observe(
-        &instance_data_sender.registry,
         downstream_instance_data.read().await.clone(),
         &instance_data_sender.base_path,
     );

--- a/crates/unleash-edge-types/src/metrics/instance_data.rs
+++ b/crates/unleash-edge-types/src/metrics/instance_data.rs
@@ -8,6 +8,7 @@ use crate::metrics::{
 use ahash::HashMap;
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
+use prometheus::gather;
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicU64, Ordering};
 use tracing::info;
@@ -157,12 +158,7 @@ impl EdgeInstanceData {
         }
     }
 
-    pub fn observe(
-        &self,
-        registry: &prometheus::Registry,
-        connected_instances: Vec<EdgeInstanceData>,
-        base_path: &str,
-    ) -> Self {
+    pub fn observe(&self, connected_instances: Vec<EdgeInstanceData>, base_path: &str) -> Self {
         let mut observed = self.clone();
         let mut cpu_seconds = 0;
         let mut resident_memory = 0;
@@ -171,8 +167,7 @@ impl EdgeInstanceData {
         let mut access_denied = HashMap::default();
         let mut no_change = HashMap::default();
 
-        for family in registry.gather().iter() {
-            info!("Looking at family: {}", family);
+        for family in gather().iter() {
             match family.name() {
                 crate::metrics::HTTP_REQUESTS_DURATION => {
                     family
@@ -230,7 +225,7 @@ impl EdgeInstanceData {
                                     .entry(path.to_string())
                                     .or_insert(LatencyMetrics::default()),
                             };
-                            let total = m.get_histogram().get_sample_sum(); // convert to ms
+                            let total = m.get_histogram().get_sample_sum() * 1000.0; // convert to ms
                             let count = m.get_histogram().get_sample_count() as f64;
                             let p99 = get_percentile(
                                 99,

--- a/crates/unleash-edge/src/lib.rs
+++ b/crates/unleash-edge/src/lib.rs
@@ -81,7 +81,6 @@ pub async fn configure_server(args: CliArgs) -> EdgeResult<Router> {
                 &edge_args,
                 client_meta_information,
                 edge_instance_data.clone(),
-                &metrics_middleware.registry,
                 instances_observed_for_app_context.clone(),
                 auth_headers,
                 http_client,


### PR DESCRIPTION
So, I was struggling with getting observability reporting to work. Turned out since we used the register_<metric_type> macros they got registered with the default registry. And I checked the code, our old custom registry that only loaded process metrics if running on linux os is already part of the default registry if you enable the process feature. No need to create a custom registry to have those.

This PR removes custom registries and uses the default one for everything.