### PR TITLE
feat: count connected streaming clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4961,6 +4961,7 @@ name = "unleash-edge-delta"
 version = "20.0.0"
 dependencies = [
  "dashmap",
+ "prometheus",
  "tokio",
  "tracing",
  "unleash-edge-types",

--- a/crates/unleash-edge-delta/Cargo.toml
+++ b/crates/unleash-edge-delta/Cargo.toml
@@ -8,8 +8,9 @@ edition.workspace = true
 
 [dependencies]
 dashmap = { workspace = true }
+prometheus = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 unleash-edge-types = { path = "../unleash-edge-types" }
 unleash-types = { workspace = true }
-unleash-yggdrasil = { workspace = true}
-tracing = { workspace = true}
+unleash-yggdrasil = { workspace = true }

--- a/crates/unleash-edge-http-client/src/instance_data.rs
+++ b/crates/unleash-edge-http-client/src/instance_data.rs
@@ -1,11 +1,11 @@
 use reqwest::{StatusCode, Url};
-use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::{ClientMetaInformation, UnleashClient};
 use tracing::{debug, warn};
 use unleash_edge_cli::{CliArgs, EdgeMode};
+use unleash_edge_types::BackgroundTask;
 use unleash_edge_types::errors::EdgeError;
 use unleash_edge_types::metrics::instance_data::EdgeInstanceData;
 
@@ -127,7 +127,7 @@ pub fn create_once_off_send_instance_data(
     instance_data_sender: Arc<InstanceDataSending>,
     our_instance_data: Arc<EdgeInstanceData>,
     downstream_instance_data: Arc<RwLock<Vec<EdgeInstanceData>>>,
-) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+) -> BackgroundTask {
     let instance_data_sender = instance_data_sender.clone();
     let our_instance_data = our_instance_data.clone();
     let downstream_instance_data = downstream_instance_data.clone();
@@ -150,7 +150,7 @@ pub fn create_send_instance_data_task(
     instance_data_sender: Arc<InstanceDataSending>,
     our_instance_data: Arc<EdgeInstanceData>,
     downstream_instance_data: Arc<RwLock<Vec<EdgeInstanceData>>>,
-) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+) -> BackgroundTask {
     let mut errors = 0;
     let delay = std::time::Duration::from_secs(60);
     Box::pin(async move {

--- a/crates/unleash-edge-integration-tests/src/feature_refresher.rs
+++ b/crates/unleash-edge-integration-tests/src/feature_refresher.rs
@@ -62,7 +62,7 @@ mod tests {
         };
         let mut token = EdgeToken::try_from("*:development.secret123".to_string()).unwrap();
         token.status = Validated;
-        token.token_type = Some(TokenType::Client);
+        token.token_type = Some(TokenType::Backend);
         feature_refresher
             .register_token_for_refresh(token, None)
             .await;
@@ -80,7 +80,7 @@ mod tests {
         let upstream_token_cache: Arc<DashMap<String, EdgeToken>> = Arc::new(DashMap::default());
         let token_cache_to_modify = upstream_token_cache.clone();
         let mut valid_token = EdgeToken::try_from("*:development.secret123".to_string()).unwrap();
-        valid_token.token_type = Some(TokenType::Client);
+        valid_token.token_type = Some(TokenType::Backend);
         valid_token.status = Validated;
         upstream_token_cache.insert(valid_token.token.clone(), valid_token.clone());
         let example_features = features_from_disk("../../examples/features.json");
@@ -123,11 +123,11 @@ mod tests {
         let upstream_token_cache: Arc<DashMap<String, EdgeToken>> = Arc::new(DashMap::default());
         let token_cache_to_modify = upstream_token_cache.clone();
         let mut dx_token = EdgeToken::try_from("dx:development.secret123".to_string()).unwrap();
-        dx_token.token_type = Some(TokenType::Client);
+        dx_token.token_type = Some(TokenType::Backend);
         dx_token.status = Validated;
         upstream_token_cache.insert(dx_token.token.clone(), dx_token.clone());
         let mut eg_token = EdgeToken::try_from("eg:development.secret123".to_string()).unwrap();
-        eg_token.token_type = Some(TokenType::Client);
+        eg_token.token_type = Some(TokenType::Backend);
         eg_token.status = Validated;
         upstream_token_cache.insert(eg_token.token.clone(), eg_token.clone());
         let example_features = features_from_disk("../../examples/hostedexample.json");
@@ -207,7 +207,7 @@ mod tests {
         let upstream_engine_cache: Arc<DashMap<String, EngineState>> = Arc::new(DashMap::default());
         let upstream_token_cache: Arc<DashMap<String, EdgeToken>> = Arc::new(DashMap::default());
         let mut eg_token = EdgeToken::from_str("eg:development.devsecret").unwrap();
-        eg_token.token_type = Some(TokenType::Client);
+        eg_token.token_type = Some(TokenType::Backend);
         eg_token.status = Validated;
         upstream_token_cache.insert(eg_token.token.clone(), eg_token.clone());
         let example_features = features_from_disk("../../examples/hostedexample.json");
@@ -311,7 +311,7 @@ mod tests {
         dx_data.extend(eg_data);
         let edge_token = EdgeToken {
             token: "".to_string(),
-            token_type: Some(TokenType::Client),
+            token_type: Some(TokenType::Backend),
             environment: None,
             projects: vec![String::from("dx"), String::from("eg")],
             status: Validated,
@@ -326,7 +326,7 @@ mod tests {
         let features = features_from_disk("../../examples/hostedexample.json").features;
         let edge_token = EdgeToken {
             token: "".to_string(),
-            token_type: Some(TokenType::Client),
+            token_type: Some(TokenType::Backend),
             environment: None,
             projects: vec![String::from("dx"), String::from("eg")],
             status: Validated,
@@ -344,7 +344,7 @@ mod tests {
         let features = features_from_disk("../../examples/hostedexample.json").features;
         let edge_token = EdgeToken {
             token: "".to_string(),
-            token_type: Some(TokenType::Client),
+            token_type: Some(TokenType::Backend),
             environment: None,
             projects: vec![String::from("dx"), String::from("eg")],
             status: Validated,
@@ -398,7 +398,7 @@ mod tests {
         ];
         let edge_token = EdgeToken {
             token: "".to_string(),
-            token_type: Some(TokenType::Client),
+            token_type: Some(TokenType::Backend),
             environment: None,
             projects: vec![String::from("*")],
             status: Validated,
@@ -451,7 +451,7 @@ mod tests {
         let empty_features = vec![];
         let unrelated_token_to_existing_features = EdgeToken {
             token: "someotherproject:dev.myextralongsecretstringwithfeatures".to_string(),
-            token_type: Some(TokenType::Client),
+            token_type: Some(TokenType::Backend),
             environment: Some("dev".into()),
             projects: vec![String::from("someother")],
             status: Validated,
@@ -500,7 +500,7 @@ mod tests {
         let empty_features = vec![];
         let token_with_access_to_both_empty_and_full_project = EdgeToken {
             token: "[]:dev.myextralongsecretstringwithfeatures".to_string(),
-            token_type: Some(TokenType::Client),
+            token_type: Some(TokenType::Backend),
             environment: Some("dev".into()),
             projects: vec![String::from("testproject"), String::from("someother")],
             status: Validated,

--- a/crates/unleash-edge-integration-tests/src/streaming_refresher.rs
+++ b/crates/unleash-edge-integration-tests/src/streaming_refresher.rs
@@ -45,7 +45,7 @@ mod tests {
     pub async fn streaming_compresses_multiple_updates_into_hydration_event() {
         let token = EdgeToken {
             token: "*:development.hashhasin".into(),
-            token_type: Some(TokenType::Client),
+            token_type: Some(TokenType::Backend),
             environment: Some("development".into()),
             projects: vec!["*".into()],
             status: TokenValidationStatus::Validated,
@@ -206,7 +206,7 @@ mod tests {
     pub async fn streaming_sends_multiple_messages() {
         let token = EdgeToken {
             token: "*:development.hashhasin".into(),
-            token_type: Some(TokenType::Client),
+            token_type: Some(TokenType::Backend),
             environment: Some("development".into()),
             projects: vec!["*".into()],
             status: TokenValidationStatus::Validated,
@@ -376,7 +376,7 @@ mod tests {
     async fn streaming_is_terminated_if_token_becomes_invalidated() {
         let token = EdgeToken {
             token: "*:development.hashhasin".into(),
-            token_type: Some(TokenType::Client),
+            token_type: Some(TokenType::Backend),
             environment: Some("development".into()),
             projects: vec!["*".into()],
             status: TokenValidationStatus::Validated,

--- a/crates/unleash-edge-integration-tests/src/token_validator.rs
+++ b/crates/unleash-edge-integration-tests/src/token_validator.rs
@@ -30,7 +30,7 @@ mod tests {
             token: "*:development.1d38eefdd7bf72676122b008dcf330f2f2aa2f3031438e1b7e8f0d1f".into(),
             projects: vec!["*".into()],
             environment: Some("development".into()),
-            token_type: Some(TokenType::Client),
+            token_type: Some(TokenType::Backend),
             status: TokenValidationStatus::Validated,
         }]
     }
@@ -122,7 +122,7 @@ mod tests {
         let mut valid_token_development =
             EdgeToken::try_from("*:development.secret123".to_string()).expect("Bad Test Data");
         valid_token_development.status = TokenValidationStatus::Validated;
-        valid_token_development.token_type = Some(TokenType::Client);
+        valid_token_development.token_type = Some(TokenType::Backend);
         upstream_tokens.insert(
             valid_token_development.token.clone(),
             valid_token_development.clone(),
@@ -130,7 +130,7 @@ mod tests {
         let mut no_longer_valid_token = EdgeToken::try_from("*:production.123secret".to_string())
             .expect("Bad test production token");
         no_longer_valid_token.status = TokenValidationStatus::Invalid;
-        no_longer_valid_token.token_type = Some(TokenType::Client);
+        no_longer_valid_token.token_type = Some(TokenType::Backend);
         upstream_tokens.insert(
             no_longer_valid_token.token.clone(),
             no_longer_valid_token.clone(),
@@ -168,7 +168,7 @@ mod tests {
         let mut valid_token_development =
             EdgeToken::try_from("*:development.secret123".to_string()).expect("Bad Test Data");
         valid_token_development.status = TokenValidationStatus::Validated;
-        valid_token_development.token_type = Some(TokenType::Client);
+        valid_token_development.token_type = Some(TokenType::Backend);
         let mut valid_token_production =
             EdgeToken::try_from("*:production.magic123".to_string()).expect("Bad Test Data");
         valid_token_production.status = TokenValidationStatus::Validated;
@@ -215,7 +215,7 @@ mod tests {
         let mut valid_token_development =
             EdgeToken::try_from("*:development.secret123".to_string()).expect("Bad Test Data");
         valid_token_development.status = TokenValidationStatus::Validated;
-        valid_token_development.token_type = Some(TokenType::Client);
+        valid_token_development.token_type = Some(TokenType::Backend);
         upstream_tokens.insert(
             valid_token_development.token.clone(),
             valid_token_development.clone(),
@@ -241,7 +241,7 @@ mod tests {
             token: "*:development.token".into(),
             projects: vec!["*".into()],
             environment: Some("test".into()),
-            token_type: Some(TokenType::Client),
+            token_type: Some(TokenType::Backend),
             status: TokenValidationStatus::Unknown,
         };
 

--- a/crates/unleash-edge-persistence/src/file.rs
+++ b/crates/unleash-edge-persistence/src/file.rs
@@ -199,7 +199,7 @@ mod tests {
         let tokens = vec![
             EdgeToken {
                 token: "default:development:ajsdkajnsdlsan".into(),
-                token_type: Some(TokenType::Client),
+                token_type: Some(TokenType::Backend),
                 environment: Some("development".into()),
                 projects: vec!["default".into()],
                 status: TokenValidationStatus::Validated,

--- a/crates/unleash-edge-types/src/lib.rs
+++ b/crates/unleash-edge-types/src/lib.rs
@@ -115,8 +115,8 @@ impl From<PostContext> for Context {
 pub enum TokenType {
     #[serde(alias = "FRONTEND")]
     Frontend,
-    #[serde(alias = "CLIENT")]
-    Client,
+    #[serde(alias = "CLIENT", alias = "client", alias = "BACKEND")]
+    Backend,
     #[serde(alias = "ADMIN")]
     Admin,
     Invalid,

--- a/crates/unleash-edge-types/src/metrics/instance_data.rs
+++ b/crates/unleash-edge-types/src/metrics/instance_data.rs
@@ -13,6 +13,8 @@ use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicU64, Ordering};
 use ulid::Ulid;
 
+pub const CONNECTED_STREAMING_CLIENTS: &str = "connected_streaming_clients";
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EdgeInstanceData {
@@ -308,7 +310,7 @@ impl EdgeInstanceData {
                         }
                     }
                 }
-                "connected_streaming_clients" => {
+                CONNECTED_STREAMING_CLIENTS => {
                     if let Some(connected_streaming_clients) = family.get_metric().last() {
                         observed.connected_streaming_clients =
                             connected_streaming_clients.get_gauge().value() as u64;

--- a/crates/unleash-edge-types/src/tokens.rs
+++ b/crates/unleash-edge-types/src/tokens.rs
@@ -107,7 +107,7 @@ impl EdgeToken {
                 "edge_data_token_{}",
                 self.environment.clone().unwrap_or("default".into())
             ),
-            token_type: TokenType::Client,
+            token_type: TokenType::Backend,
             projects: self.projects.clone(),
             environment: self.environment.clone().unwrap_or("default".into()),
             expires_at: Utc::now() + Duration::weeks(4),
@@ -128,7 +128,7 @@ impl EdgeToken {
         EdgeToken::from_str(token)
             .map(|mut t| {
                 t.status = TokenValidationStatus::Validated;
-                t.token_type = Some(TokenType::Client);
+                t.token_type = Some(TokenType::Backend);
                 t
             })
             .unwrap()

--- a/crates/unleash-edge/src/edge_builder.rs
+++ b/crates/unleash-edge/src/edge_builder.rs
@@ -231,7 +231,7 @@ pub async fn build_edge(
     }
     for validated_token in token_cache
         .iter()
-        .filter(|candidate| candidate.value().token_type == Some(TokenType::Client))
+        .filter(|candidate| candidate.value().token_type == Some(TokenType::Backend))
     {
         hydrator_type
             .register_token_for_refresh(validated_token.clone(), None)

--- a/crates/unleash-edge/src/middleware/validate_token.rs
+++ b/crates/unleash-edge/src/middleware/validate_token.rs
@@ -46,7 +46,7 @@ fn validate_without_validator(
             let token = t.value();
             match token.token_type {
                 Some(TokenType::Frontend) => check_frontend_path(path),
-                Some(TokenType::Client) => check_backend_path(path),
+                Some(TokenType::Backend) => check_backend_path(path),
                 None => Ok(()),
                 _ => Err(EdgeError::Forbidden("Unknown token type".into())),
             }
@@ -64,7 +64,7 @@ async fn validate_with_validator(
     match known_token.status {
         TokenValidationStatus::Validated => match known_token.token_type {
             Some(TokenType::Frontend) => check_frontend_path(path),
-            Some(TokenType::Client) => check_backend_path(path),
+            Some(TokenType::Backend) => check_backend_path(path),
             _ => Err(EdgeError::Forbidden("".into())),
         },
         TokenValidationStatus::Unknown => Err(EdgeError::AuthorizationDenied),

--- a/crates/unleash-edge/src/offline_builder.rs
+++ b/crates/unleash-edge/src/offline_builder.rs
@@ -36,7 +36,7 @@ pub(crate) fn build_offline_mode(
         .iter()
         .map(|token| EdgeToken::from_str(token).unwrap_or_else(|_| EdgeToken::offline_token(token)))
         .map(|mut token| {
-            token.token_type = Some(TokenType::Client);
+            token.token_type = Some(TokenType::Backend);
             token
         })
         .collect();


### PR DESCRIPTION
 - One that counts live connections, updated on each event being sent out.
 - One that counts connections made, incremented on each connection
    
 In addition this PR adds a shutdown task for our DeltaCacheManager, sending a
 PoisonPill in the form of a Delete message.