### PR TITLE
feat: allow explicit * in CORS origin

### DIFF
--- a/crates/unleash-edge-cli/src/lib.rs
+++ b/crates/unleash-edge-cli/src/lib.rs
@@ -545,8 +545,7 @@ impl CorsOptions {
                 let list = origins
                     .iter()
                     .map(|s| s.trim())
-                    .filter_map(|origin| HeaderValue::from_str(origin).ok())
-                    .collect::<Vec<_>>();
+                    .filter_map(|origin| HeaderValue::from_str(origin).ok());
                 AllowOrigin::list(list)
             }
             _ => AllowOrigin::any(),

--- a/crates/unleash-edge-cli/src/lib.rs
+++ b/crates/unleash-edge-cli/src/lib.rs
@@ -9,9 +9,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
-use tower_http::cors::{
-    AllowHeaders, AllowMethods, AllowOrigin, CorsLayer, ExposeHeaders, MaxAge,
-};
+use tower_http::cors::{AllowHeaders, AllowMethods, AllowOrigin, CorsLayer, ExposeHeaders, MaxAge};
 use unleash_edge_types::errors::{EdgeError, TRUST_PROXY_PARSE_ERROR};
 use unleash_edge_types::{tokens::EdgeToken, tokens::parse_trusted_token_pair};
 

--- a/crates/unleash-edge-cli/src/lib.rs
+++ b/crates/unleash-edge-cli/src/lib.rs
@@ -540,16 +540,19 @@ impl CorsOptions {
     }
 
     fn origins(&self) -> AllowOrigin {
-        match &self.cors_origin {
-            Some(origins) if !origins.iter().any(|o| o.trim() == "*") => {
-                let list = origins
-                    .iter()
-                    .map(|s| s.trim())
-                    .filter_map(|origin| HeaderValue::from_str(origin).ok());
-                AllowOrigin::list(list)
-            }
-            _ => AllowOrigin::any(),
+        let Some(origins) = &self.cors_origin else {
+            return AllowOrigin::any();
+        };
+
+        if origins.iter().any(|o| o.trim() == "*") {
+            return AllowOrigin::any();
         }
+
+        let list = origins
+            .iter()
+            .map(|s| s.trim())
+            .filter_map(|origin| HeaderValue::from_str(origin).ok());
+        AllowOrigin::list(list)
     }
 
     fn methods(&self) -> AllowMethods {


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3886/allow-explicit-cors-origin-in-edge

Allows explicit `*` in CORS origin.

This should make CORS configuration more intuitive, as users can now safely specify `*` for origins without crashing on startup.

Includes some scouting.

Related: https://github.com/Unleash/unleash-edge/issues/1167