### PR TITLE
fix(internal-backstage): make sure /metrics obeys disable flag

### DIFF
--- a/crates/unleash-edge/src/lib.rs
+++ b/crates/unleash-edge/src/lib.rs
@@ -120,15 +120,20 @@ pub async fn configure_server(args: CliArgs) -> EdgeResult<(Router, Vec<Backgrou
                 .layer(from_fn(middleware::etag::etag_middleware)),
         );
 
+    let backstage_router = if args.internal_backstage.disable_metrics_endpoint {
+        unleash_edge_backstage::router(args.internal_backstage.clone())
+    } else {
+        Router::new()
+            .route("/metrics", get(render_prometheus_metrics))
+            .merge(unleash_edge_backstage::router(
+                args.internal_backstage.clone(),
+            ))
+    };
+
     let top_router: Router = Router::new()
         .nest("/api", api_router)
         .nest("/edge", unleash_edge_edge_api::router())
-        .nest(
-            "/internal-backstage",
-            Router::new()
-                .route("/metrics", get(render_prometheus_metrics))
-                .merge(unleash_edge_backstage::router(args.internal_backstage)),
-        )
+        .nest("/internal-backstage", backstage_router)
         .layer(
             ServiceBuilder::new()
                 .layer(CompressionLayer::new())


### PR DESCRIPTION
As the title says, due to the way our /internal-backstage/metrics endpoint was setup, we did not obey the disable_metrics_endpoint flag. This PR changes that, so we again obey this flag as well.