### PR TITLE
experiment: Use axum_server instead of axum::serve

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread", "tracing"
 tokio-rustls = { version = "0.26.3" }
 tokio-stream = { version = "0.1.17", features = ["sync"] }
 tower = { version = "0.5.2" }
-tower-http = { version = "0.6.6", features = ["cors", "normalize-path", "tracing", "compression-gzip", "compression-zstd"] }
+tower-http = { version = "0.6.6", features = ["cors", "normalize-path", "trace", "compression-gzip", "compression-zstd"] }
 tracing = { version = "0.1.41" }
 tracing-opentelemetry = { version = "0.31.0", features = ["metrics"] }
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "json"] }

--- a/crates/unleash-edge/src/middleware/validate_token.rs
+++ b/crates/unleash-edge/src/middleware/validate_token.rs
@@ -3,6 +3,7 @@ use axum::extract::{Request, State};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use reqwest::StatusCode;
+use tracing::info;
 use unleash_edge_appstate::AppState;
 use unleash_edge_auth::token_validator::{TokenRegister, TokenValidator};
 use unleash_edge_types::errors::EdgeError;
@@ -77,6 +78,7 @@ async fn validate_with_validator(
 }
 
 fn check_frontend_path(path: &str) -> Result<(), EdgeError> {
+    info!("Checking frontend path: {}", path);
     if path.contains("/frontend") || path.contains("/proxy") {
         Ok(())
     } else {
@@ -85,6 +87,7 @@ fn check_frontend_path(path: &str) -> Result<(), EdgeError> {
 }
 
 fn check_backend_path(path: &str) -> Result<(), EdgeError> {
+    info!("Checking backend path: {}", path);
     if path.contains("client/") {
         Ok(())
     } else {

--- a/crates/unleash-edge/src/middleware/validate_token.rs
+++ b/crates/unleash-edge/src/middleware/validate_token.rs
@@ -3,7 +3,6 @@ use axum::extract::{Request, State};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use reqwest::StatusCode;
-use tracing::info;
 use unleash_edge_appstate::AppState;
 use unleash_edge_auth::token_validator::{TokenRegister, TokenValidator};
 use unleash_edge_types::errors::EdgeError;
@@ -78,7 +77,6 @@ async fn validate_with_validator(
 }
 
 fn check_frontend_path(path: &str) -> Result<(), EdgeError> {
-    info!("Checking frontend path: {}", path);
     if path.contains("/frontend") || path.contains("/proxy") {
         Ok(())
     } else {
@@ -87,7 +85,6 @@ fn check_frontend_path(path: &str) -> Result<(), EdgeError> {
 }
 
 fn check_backend_path(path: &str) -> Result<(), EdgeError> {
-    info!("Checking backend path: {}", path);
     if path.contains("client/") {
         Ok(())
     } else {


### PR DESCRIPTION
since it's the thing we use if you happen to terminate TLS, it makes sense to use it when only hosting http as well.