### PR TITLE
refactor: use result of LicenseState

### DIFF
--- a/crates/unleash-edge-client-api/src/heartbeat.rs
+++ b/crates/unleash-edge-client-api/src/heartbeat.rs
@@ -10,7 +10,7 @@ use ulid::Ulid;
 use unleash_edge_appstate::AppState;
 use unleash_edge_appstate::edge_token_extractor::{AuthState, AuthToken};
 use unleash_edge_http_client::UnleashClient;
-use unleash_edge_types::enterprise::{HeartbeatResponse, LicenseStateResponse};
+use unleash_edge_types::enterprise::{HeartbeatResponse, LicenseState};
 use utoipa::IntoParams;
 
 #[derive(Clone, Debug, Deserialize, IntoParams)]
@@ -72,7 +72,7 @@ async fn heartbeat(
 
 #[derive(Clone)]
 pub struct HeartbeatState {
-    license_state: LicenseStateResponse,
+    license_state: LicenseState,
     client: Arc<UnleashClient>,
 }
 
@@ -87,7 +87,7 @@ impl FromRef<AppState> for HeartbeatState {
 
         HeartbeatState {
             client,
-            license_state: LicenseStateResponse::Valid, //TODO: get this from either the API call or Backup. This probably needs to be set at the AppState level
+            license_state: LicenseState::Valid, //TODO: get this from either the API call or Backup. This probably needs to be set at the AppState level
         }
     }
 }
@@ -129,7 +129,7 @@ mod tests {
     impl FromRef<TestState> for HeartbeatState {
         fn from_ref(app: &TestState) -> Self {
             HeartbeatState {
-                license_state: LicenseStateResponse::Valid,
+                license_state: LicenseState::Valid,
                 client: app.client.clone(),
             }
         }
@@ -206,7 +206,7 @@ mod tests {
                             (
                                 StatusCode::ACCEPTED,
                                 Json(HeartbeatResponse {
-                                    edge_license_state: LicenseStateResponse::Valid,
+                                    edge_license_state: LicenseState::Valid,
                                 }),
                             )
                         }
@@ -261,7 +261,7 @@ mod tests {
 
         response.assert_status(StatusCode::ACCEPTED);
         response.assert_json(&HeartbeatResponse {
-            edge_license_state: LicenseStateResponse::Valid,
+            edge_license_state: LicenseState::Valid,
         });
     }
 }

--- a/crates/unleash-edge-enterprise-integration-tests/src/lib.rs
+++ b/crates/unleash-edge-enterprise-integration-tests/src/lib.rs
@@ -13,7 +13,7 @@ mod tests {
     use ulid::Ulid;
     use unleash_edge::edge_builder::{EdgeStateArgs, build_edge_state};
     use unleash_edge_cli::{AuthHeaders, CliArgs, EdgeArgs, HttpServerArgs};
-    use unleash_edge_types::enterprise::LicenseStateResponse;
+    use unleash_edge_types::enterprise::LicenseState;
     use unleash_edge_types::errors::EdgeError;
     use unleash_edge_types::metrics::instance_data::{EdgeInstanceData, Hosting};
 
@@ -23,7 +23,7 @@ mod tests {
 
     #[derive(Clone)]
     struct MockState {
-        license_result: EdgeResult<LicenseStateResponse>,
+        license_result: EdgeResult<LicenseState>,
     }
 
     pub struct UpstreamMock {
@@ -31,7 +31,7 @@ mod tests {
     }
 
     impl UpstreamMock {
-        pub async fn new(initial: EdgeResult<LicenseStateResponse>) -> Self {
+        pub async fn new(initial: EdgeResult<LicenseState>) -> Self {
             let state = MockState {
                 license_result: initial,
             };
@@ -73,7 +73,7 @@ mod tests {
                 Json(json!({
                     "edgeLicenseState": match s.license_result {
                         Ok(license_state) => license_state,
-                        Err(_) => LicenseStateResponse::Invalid,
+                        Err(_) => LicenseState::Invalid,
                     }
                 })),
             );
@@ -213,7 +213,7 @@ mod tests {
 
     #[tokio::test]
     async fn enterprise_edge_state_startup_succeeds_if_license_can_be_verified() {
-        let upstream = UpstreamMock::new(Ok(LicenseStateResponse::Valid)).await;
+        let upstream = UpstreamMock::new(Ok(LicenseState::Valid)).await;
         let (http_client, client_meta_information, instances_observed_for_app_context) =
             build_edge_state_data();
 

--- a/crates/unleash-edge-enterprise/src/lib.rs
+++ b/crates/unleash-edge-enterprise/src/lib.rs
@@ -3,7 +3,7 @@ use tokio::sync::watch::Sender;
 use tracing::{debug, warn};
 use ulid::Ulid;
 use unleash_edge_http_client::UnleashClient;
-use unleash_edge_types::{RefreshState, enterprise::LicenseStateResponse, tokens::EdgeToken};
+use unleash_edge_types::{RefreshState, enterprise::LicenseState, tokens::EdgeToken};
 
 async fn send_heartbeat(
     unleash_client: Arc<UnleashClient>,
@@ -13,17 +13,17 @@ async fn send_heartbeat(
 ) {
     match unleash_client.send_heartbeat(&token, connection_id).await {
         Ok(response) => match response {
-            LicenseStateResponse::Valid => {
+            LicenseState::Valid => {
                 debug!("License check succeeded: Heartbeat sent successfully");
                 let _ = refresh_state_tx.send(RefreshState::Running);
             }
-            LicenseStateResponse::Expired => {
+            LicenseState::Expired => {
                 warn!(
                     "License check failed: Upstream reports the Enterprise Edge license is expired"
                 );
                 let _ = refresh_state_tx.send(RefreshState::Running);
             }
-            LicenseStateResponse::Invalid => {
+            LicenseState::Invalid => {
                 warn!(
                     "License check failed: Upstream reports the Enterprise Edge license is invalid"
                 );

--- a/crates/unleash-edge-http-client/src/lib.rs
+++ b/crates/unleash-edge-http-client/src/lib.rs
@@ -16,7 +16,7 @@ use std::str::FromStr;
 use tracing::{debug, error, info, trace, warn};
 use ulid::Ulid;
 use unleash_edge_cli::ClientIdentity;
-use unleash_edge_types::enterprise::{HeartbeatResponse, LicenseStateResponse};
+use unleash_edge_types::enterprise::{HeartbeatResponse, LicenseState};
 use unleash_edge_types::errors::EdgeError::EdgeMetricsRequestError;
 use unleash_edge_types::errors::{CertificateError, EdgeError, FeatureError};
 use unleash_edge_types::headers::{
@@ -617,7 +617,7 @@ impl UnleashClient {
         &self,
         api_key: &EdgeToken,
         connection_id: &Ulid,
-    ) -> EdgeResult<LicenseStateResponse> {
+    ) -> EdgeResult<LicenseState> {
         let response = self
             .backing_client
             .post(self.urls.heartbeat_url.to_string())

--- a/crates/unleash-edge-persistence/src/lib.rs
+++ b/crates/unleash-edge-persistence/src/lib.rs
@@ -21,7 +21,7 @@ pub trait EdgePersistence: Send + Sync {
     async fn save_tokens(&self, tokens: Vec<EdgeToken>) -> EdgeResult<()>;
     async fn load_features(&self) -> EdgeResult<HashMap<String, ClientFeatures>>;
     async fn save_features(&self, features: Vec<(String, ClientFeatures)>) -> EdgeResult<()>;
-    async fn load_license_state(&self) -> LicenseState;
+    async fn load_license_state(&self) -> EdgeResult<LicenseState>;
     async fn save_license_state(&self, license: &LicenseState) -> EdgeResult<()>;
 }
 
@@ -135,7 +135,7 @@ pub mod tests {
             panic!("Not expected to be called");
         }
 
-        async fn load_license_state(&self) -> LicenseState {
+        async fn load_license_state(&self) -> EdgeResult<LicenseState> {
             panic!("Not expected to be called");
         }
 

--- a/crates/unleash-edge-types/src/enterprise/mod.rs
+++ b/crates/unleash-edge-types/src/enterprise/mod.rs
@@ -1,36 +1,15 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::EdgeResult;
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
-pub enum LicenseStateResponse {
-    Valid,
-    Invalid,
-    Expired,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum LicenseState {
     Valid,
     Invalid,
     Expired,
-    Undetermined,
-}
-
-impl From<EdgeResult<LicenseStateResponse>> for LicenseState {
-    fn from(result: EdgeResult<LicenseStateResponse>) -> Self {
-        match result {
-            Ok(LicenseStateResponse::Valid) => LicenseState::Valid,
-            Ok(LicenseStateResponse::Invalid) => LicenseState::Invalid,
-            Ok(LicenseStateResponse::Expired) => LicenseState::Expired,
-            Err(_) => LicenseState::Undetermined,
-        }
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct HeartbeatResponse {
-    pub edge_license_state: LicenseStateResponse,
+    pub edge_license_state: LicenseState,
 }


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3996/use-persisted-license-state-in-edge

First step in using the persisted license state is doing a small refactor around our license state.

Instead of having `LicenseState` and `LicenseStateResponse` we're able to simplify our logic to a `EdgeResult<LicenseState>`.