### PR TITLE
chore: immediately persist license state

### DIFF
--- a/crates/oss/unleash-edge/src/edge_builder.rs
+++ b/crates/oss/unleash-edge/src/edge_builder.rs
@@ -698,11 +698,16 @@ pub async fn resolve_license(
         )
         .await
     {
-        Ok(license) => Ok(license),
+        Ok(license) => {
+            if let Some(persistence) = persistence {
+                let _ = persistence.save_license_state(&license).await;
+            }
+            Ok(license)
+        }
 
         Err(_) => {
-            if let Some(p) = persistence {
-                p.load_license_state().await.map_err(|_| {
+            if let Some(persistence) = persistence {
+                persistence.load_license_state().await.map_err(|_| {
                     EdgeError::HeartbeatError(
                         "Could not load license from either persistence or API".into(),
                         StatusCode::SERVICE_UNAVAILABLE,


### PR DESCRIPTION
Just a little quality of life thing - immediately persist a license state on startup so that you don't have to wait 90 seconds for your Edge cluster to be resilient