### PR TITLE
chore: remove license notes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,3 @@
-**Note**: This MIT license applies only to the open-source crates in this repository.
-
-Enterprise-specific crates (located under `crates/enterprise/`) are licensed separately under the terms found in `LICENSE-ENTERPRISE.md`.
-
----
-
 MIT License
 
 Copyright (c) 2023 Unleash

--- a/LICENSE-ENTERPRISE.md
+++ b/LICENSE-ENTERPRISE.md
@@ -1,9 +1,3 @@
-**Note**: This commercial license applies only to the enterprise-specific crates in this repository (located under `crates/enterprise/`). These crates are licensed under the terms described in this document.
-
-The open-source crates are licensed separately under the MIT license, as found in `LICENSE`.
-
----
-
 **Commercial Software License Agreement**
 
 This Commercial Software License Agreement ("Agreement") is a legal agreement between you ("Licensee") and Bricks Software AS. ("Licensor") governing the use of the Unleash Enterprise ("Software"). By downloading, installing, or using the Software, you agree to be bound by the terms of this Agreement.


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3969/add-new-code-license-to-enterprise-edge

GH license detection didn't like our notes at the top of the licenses, so maybe we should just remove them and rely on the information on the README.

Follow-up to: #1307 

<img width="780" height="258" alt="image" src="https://github.com/user-attachments/assets/14e27181-d1c8-458e-8e7f-df108b71fcd3" />
