### PR TITLE
Revert "chore: remove license notes (#1308)"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-**Note**: This MIT license applies only to the open-source crates in this repository.
+**Note**: This MIT license applies to all files in this repository except the enterprise-specific crates located under `crates/enterprise/`.
 
-Enterprise-specific crates (located under `crates/enterprise/`) are licensed separately under the terms found in `LICENSE-ENTERPRISE.md`.
+Enterprise-specific crates are licensed separately under the terms found in `LICENSE-ENTERPRISE.md`.
 
 ---
 

--- a/LICENSE-ENTERPRISE.md
+++ b/LICENSE-ENTERPRISE.md
@@ -1,6 +1,6 @@
 **Note**: This commercial license applies only to the enterprise-specific crates in this repository (located under `crates/enterprise/`). These crates are licensed under the terms described in this document.
 
-The open-source crates are licensed separately under the MIT license, as found in `LICENSE`.
+All other files in this repository, including the open-source crates, are licensed separately under the MIT license, as found in `LICENSE`.
 
 ---
 
@@ -62,6 +62,4 @@ Provisions regarding warranties, liabilities, and indemnification will be govern
 
 7.4 Severability: If any provision of this Agreement is held invalid, the remaining provisions shall remain in full force and effect.
 
-
-
-*By using the Software, you acknowledge that you have read, understood, and agree to the terms of this Commercial Software License Agreement.*
+_By using the Software, you acknowledge that you have read, understood, and agree to the terms of this Commercial Software License Agreement._


### PR DESCRIPTION
https://linear.app/unleash/issue/2-4067/revert-the-software-license-notes

Reverts #1308, bringing back specific notes inside our licenses explaining how they apply.