### PR TITLE
chore: adding ap-southeast-1 to ami replication regions

### DIFF
--- a/packer/unleash-edge-enterprise.ami.auto.pkrvars.hcl
+++ b/packer/unleash-edge-enterprise.ami.auto.pkrvars.hcl
@@ -1,6 +1,6 @@
 build_region  = "eu-north-1"
 replicate_regions = [
-  "ap-northeast-1", "eu-central-1", "eu-west-1", "eu-west-2", "us-east-1", "us-east-2", "us-west-2", "me-central-1"
+  "ap-northeast-1", "ap-southeast-1", "eu-central-1", "eu-west-1", "eu-west-2", "us-east-1", "us-east-2", "us-west-2", "me-central-1"
 ]
 instance_type = "c7g.xlarge"
 ssh_username  = "ubuntu"


### PR DESCRIPTION
Replicating ami to ap-southeast-1 as well