### PR TITLE
chore: add us-west-1 to packer replicated regions

### DIFF
--- a/packer/unleash-edge-enterprise.ami.auto.pkrvars.hcl
+++ b/packer/unleash-edge-enterprise.ami.auto.pkrvars.hcl
@@ -1,6 +1,6 @@
 build_region  = "eu-north-1"
 replicate_regions = [
-  "ap-northeast-1", "ap-southeast-1", "eu-central-1", "eu-west-1", "eu-west-2", "eu-west-3", "us-east-1", "us-east-2", "us-west-2", "me-central-1"
+  "ap-northeast-1", "ap-southeast-1", "eu-central-1", "eu-west-1", "eu-west-2", "eu-west-3", "us-east-1", "us-east-2", "us-west-1", "us-west-2", "me-central-1"
 ]
 instance_type = "c7g.xlarge"
 ssh_username  = "ubuntu"


### PR DESCRIPTION
Adding us-west-1 to edge regions