### PR TITLE
chore: fix expect log to show correct url

### DIFF
--- a/crates/oss/unleash-edge-types/src/urls.rs
+++ b/crates/oss/unleash-edge-types/src/urls.rs
@@ -105,7 +105,7 @@ impl UnleashUrls {
         let mut edge_instance_data_url = client_metrics_url.clone();
         edge_instance_data_url
             .path_segments_mut()
-            .expect("Could not create /api/client/metrics/instance-data")
+            .expect("Could not create /api/client/metrics/edge")
             .push("edge");
 
         let mut heartbeat_url = client_api_url.clone();


### PR DESCRIPTION
fixes an issue where we `expect`ed the wrong URL for edge instance data. Should hopefully clear up some confusion if someone saw this and thought the actual url was `/instance-data`.

Did a grep through the repo, couldn't find any other instances that should be fixed.