### PR TITLE
fix: unprocessable error on instance data with daisy chaining

### DIFF
--- a/crates/oss/unleash-edge-types/src/metrics/mod.rs
+++ b/crates/oss/unleash-edge-types/src/metrics/mod.rs
@@ -345,3 +345,27 @@ pub struct MetricsCache {
     pub metrics: DashMap<MetricsKey, ClientMetricsEnv>,
     pub impact_metrics: DashMap<ImpactMetricsKey, Vec<ImpactMetricEnv>>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_consumption_data_has_symmetrical_serialization() {
+        let request_data = RequestConsumptionData::default();
+        request_data.increment_requests("default");
+        request_data.increment_requests("default");
+        request_data.increment_requests("premium");
+
+        let serialized = serde_json::to_value(&request_data).expect("Failed to serialize");
+
+        let deserialized: Result<RequestConsumptionData, _> =
+            serde_json::from_value(serialized.clone());
+
+        assert!(
+            deserialized.is_ok(),
+            "Deserialization failed: {:?}",
+            deserialized.err()
+        );
+    }
+}

--- a/crates/oss/unleash-edge-types/src/metrics/mod.rs
+++ b/crates/oss/unleash-edge-types/src/metrics/mod.rs
@@ -228,6 +228,7 @@ impl<'de> Deserialize<'de> for RequestConsumptionData {
         D: serde::Deserializer<'de>,
     {
         #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
         struct GroupData {
             metered_group: String,
             requests: u64,


### PR DESCRIPTION
Fixes an issue where daisy chaining doesn't work correctly with instance data. This occurs because the serialization and deserialization isn't symmetric. It didn't get noticed because it only occurs when a frontend SDK is connected to a daisy chained Edge setup and because we no longer have proper e2e tests on this after the Axum port 