### PR TITLE
feat: allow backup to persist and restore streaming ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5531,6 +5531,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 name = "unleash-edge"
 version = "20.2.2"
 dependencies = [
+ "ahash",
  "anyhow",
  "aws-config",
  "aws-sdk-s3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5715,6 +5715,7 @@ dependencies = [
 name = "unleash-edge-delta"
 version = "20.2.2"
 dependencies = [
+ "ahash",
  "dashmap",
  "prometheus",
  "tokio",
@@ -5865,7 +5866,6 @@ dependencies = [
  "unleash-edge-feature-filters",
  "unleash-edge-feature-refresh",
  "unleash-edge-http-client",
- "unleash-edge-persistence",
  "unleash-edge-types",
  "unleash-types",
  "unleash-yggdrasil",
@@ -6048,6 +6048,7 @@ dependencies = [
  "tokio",
  "tracing",
  "ulid",
+ "unleash-edge-delta",
  "unleash-edge-feature-cache",
  "unleash-edge-types",
  "unleash-types",

--- a/crates/enterprise/unleash-edge-delta/Cargo.toml
+++ b/crates/enterprise/unleash-edge-delta/Cargo.toml
@@ -9,6 +9,7 @@ publish = true
 license-file = "../../../LICENSE-ENTERPRISE.md"
 
 [dependencies]
+ahash = { workspace = true }
 dashmap = { workspace = true }
 prometheus = { workspace = true }
 tokio = { workspace = true }

--- a/crates/enterprise/unleash-edge-delta/src/cache.rs
+++ b/crates/enterprise/unleash-edge-delta/src/cache.rs
@@ -47,6 +47,13 @@ impl DeltaCache {
             .any(|e| e.get_event_id() == revision)
     }
 
+    pub fn latest_revision(&self) -> u32 {
+        self.get_events()
+            .last()
+            .map(|e| e.get_event_id())
+            .unwrap_or(self.hydration_event.event_id)
+    }
+
     pub fn add_events(&mut self, events: &[DeltaEvent]) {
         for event in events.iter() {
             self.events.push(event.clone());

--- a/crates/enterprise/unleash-edge-delta/src/cache_manager.rs
+++ b/crates/enterprise/unleash-edge-delta/src/cache_manager.rs
@@ -1,4 +1,5 @@
 use crate::cache::DeltaCache;
+use ahash::HashMap;
 use dashmap::DashMap;
 use prometheus::{IntCounter, IntGauge, register_int_counter, register_int_gauge};
 use std::sync::{Arc, LazyLock};
@@ -87,6 +88,13 @@ impl DeltaCacheManager {
         let _ = self
             .update_sender
             .send(DeltaCacheUpdate::Deletion(env.to_string()));
+    }
+
+    pub fn get_last_event_ids(&self) -> HashMap<String, u32> {
+        self.caches
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().latest_revision()))
+            .collect()
     }
 }
 

--- a/crates/enterprise/unleash-edge-enterprise-integration-tests/src/lib.rs
+++ b/crates/enterprise/unleash-edge-enterprise-integration-tests/src/lib.rs
@@ -163,11 +163,11 @@ mod tests {
             unimplemented!()
         }
 
-        async fn save_last_event_id(&self, _event_id: u64) -> EdgeResult<()> {
+        async fn save_last_event_ids(&self, _event_id: HashMap<String, u64>) -> EdgeResult<()> {
             unimplemented!()
         }
 
-        async fn load_last_event_id(&self) -> EdgeResult<u64> {
+        async fn load_last_event_ids(&self) -> EdgeResult<HashMap<String, u64>> {
             unimplemented!()
         }
     }

--- a/crates/enterprise/unleash-edge-enterprise-integration-tests/src/lib.rs
+++ b/crates/enterprise/unleash-edge-enterprise-integration-tests/src/lib.rs
@@ -162,6 +162,14 @@ mod tests {
         async fn save_features(&self, _features: Vec<(String, ClientFeatures)>) -> EdgeResult<()> {
             unimplemented!()
         }
+
+        async fn save_last_event_id(&self, _event_id: u64) -> EdgeResult<()> {
+            unimplemented!()
+        }
+
+        async fn load_last_event_id(&self) -> EdgeResult<u64> {
+            unimplemented!()
+        }
     }
 
     #[tokio::test]

--- a/crates/enterprise/unleash-edge-enterprise-integration-tests/src/lib.rs
+++ b/crates/enterprise/unleash-edge-enterprise-integration-tests/src/lib.rs
@@ -163,11 +163,11 @@ mod tests {
             unimplemented!()
         }
 
-        async fn save_last_event_ids(&self, _event_id: HashMap<String, u64>) -> EdgeResult<()> {
+        async fn save_last_event_ids(&self, _event_id: HashMap<String, u32>) -> EdgeResult<()> {
             unimplemented!()
         }
 
-        async fn load_last_event_ids(&self) -> EdgeResult<HashMap<String, u64>> {
+        async fn load_last_event_ids(&self) -> EdgeResult<HashMap<String, u32>> {
             unimplemented!()
         }
     }

--- a/crates/oss/unleash-edge-feature-refresh/Cargo.toml
+++ b/crates/oss/unleash-edge-feature-refresh/Cargo.toml
@@ -28,7 +28,6 @@ unleash-edge-delta = { workspace = true }
 unleash-edge-feature-cache = { workspace = true }
 unleash-edge-feature-filters = { workspace = true }
 unleash-edge-http-client = { workspace = true }
-unleash-edge-persistence = { workspace = true }
 unleash-edge-types = { workspace = true }
 unleash-yggdrasil = { workspace = true }
 

--- a/crates/oss/unleash-edge-feature-refresh/src/delta_refresh.rs
+++ b/crates/oss/unleash-edge-feature-refresh/src/delta_refresh.rs
@@ -36,7 +36,7 @@ use unleash_yggdrasil::EngineState;
 
 pub type Environment = String;
 
-const DELTA_CACHE_LIMIT: usize = 100;
+pub const DELTA_CACHE_LIMIT: usize = 100;
 const SDK_TYPE_HEADER: &str = "Unleash-Sdk-Type";
 const SSE_IDLE_TIMEOUT: Duration = Duration::from_secs(90);
 const SSE_IDLE_RECONNECT_DELAY: Duration = Duration::from_secs(5);

--- a/crates/oss/unleash-edge-feature-refresh/src/delta_refresh.rs
+++ b/crates/oss/unleash-edge-feature-refresh/src/delta_refresh.rs
@@ -20,7 +20,6 @@ use unleash_edge_feature_cache::FeatureCache;
 use unleash_edge_feature_filters::FeatureFilterSet;
 use unleash_edge_feature_filters::delta_filters::{DeltaFilterSet, filter_delta_events};
 use unleash_edge_http_client::{ClientMetaInformation, UnleashClient};
-use unleash_edge_persistence::EdgePersistence;
 use unleash_edge_types::errors::{EdgeError, FeatureError};
 use unleash_edge_types::headers::{
     UNLEASH_APPNAME_HEADER, UNLEASH_CLIENT_SPEC_HEADER, UNLEASH_CONNECTION_ID_HEADER,
@@ -352,7 +351,6 @@ pub struct DeltaRefresher {
     pub delta_cache_manager: Arc<DeltaCacheManager>,
     pub engine_cache: Arc<DashMap<String, EngineState>>,
     pub refresh_interval: chrono::Duration,
-    pub persistence: Option<Arc<dyn EdgePersistence>>,
     pub streaming: bool,
     pub client_meta_information: ClientMetaInformation,
     pub edge_instance_data: Arc<EdgeInstanceData>,
@@ -710,7 +708,6 @@ mod tests {
             features_cache: features_cache.clone(),
             engine_cache: engine_cache.clone(),
             refresh_interval: Duration::seconds(6000),
-            persistence: None,
             streaming: false,
             client_meta_information: ClientMetaInformation::test_config(),
             edge_instance_data: Arc::new(edge_instance_data_for_delta_refresher_test()),
@@ -876,7 +873,6 @@ mod tests {
             features_cache,
             engine_cache,
             refresh_interval: Duration::seconds(6000),
-            persistence: None,
             streaming: true,
             client_meta_information: ClientMetaInformation::test_config(),
             edge_instance_data: Arc::new(edge_instance_data_for_delta_refresher_test()),

--- a/crates/oss/unleash-edge-feature-refresh/src/lib.rs
+++ b/crates/oss/unleash-edge-feature-refresh/src/lib.rs
@@ -16,7 +16,6 @@ use unleash_edge_delta::cache_manager::DeltaCacheManager;
 use unleash_edge_feature_cache::FeatureCache;
 use unleash_edge_feature_filters::{FeatureFilterSet, filter_client_features};
 use unleash_edge_http_client::{ClientMetaInformation, UnleashClient};
-use unleash_edge_persistence::EdgePersistence;
 use unleash_edge_types::errors::{EdgeError, FeatureError};
 use unleash_edge_types::metrics::instance_data::EdgeInstanceData;
 use unleash_edge_types::tokens::{EdgeToken, cache_key, simplify};
@@ -173,7 +172,6 @@ pub struct FeatureRefresher {
     pub delta_cache_manager: Arc<DeltaCacheManager>,
     pub engine_cache: Arc<DashMap<String, EngineState>>,
     pub refresh_interval: chrono::Duration,
-    pub persistence: Option<Arc<dyn EdgePersistence>>,
     pub client_meta_information: ClientMetaInformation,
     pub edge_instance_data: Arc<EdgeInstanceData>,
 }
@@ -271,7 +269,6 @@ impl FeatureRefresher {
         features_cache: Arc<FeatureCache>,
         delta_cache_manager: Arc<DeltaCacheManager>,
         engines: Arc<DashMap<String, EngineState>>,
-        persistence: Option<Arc<dyn EdgePersistence>>,
         config: FeatureRefreshConfig,
         edge_instance_data: Arc<EdgeInstanceData>,
     ) -> Self {
@@ -282,7 +279,6 @@ impl FeatureRefresher {
             delta_cache_manager,
             engine_cache: engines,
             refresh_interval: config.features_refresh_interval,
-            persistence,
             client_meta_information: config.client_meta_information,
             edge_instance_data,
         }
@@ -521,7 +517,6 @@ mod tests {
                 features_cache: Arc::new(Default::default()),
                 delta_cache_manager: Arc::new(DeltaCacheManager::new()),
                 engine_cache: Default::default(),
-                persistence: None,
                 client_meta_information: ClientMetaInformation {
                     app_name: "test-application".to_string(),
                     instance_id: Ulid::new(),

--- a/crates/oss/unleash-edge-persistence/Cargo.toml
+++ b/crates/oss/unleash-edge-persistence/Cargo.toml
@@ -27,6 +27,7 @@ tracing = { workspace = true }
 ulid = { workspace = true }
 unleash-edge-feature-cache = { workspace = true }
 unleash-edge-types = { workspace = true }
+unleash-edge-delta = { workspace = true }
 unleash-types = { workspace = true }
 rustls = { workspace = true }
 

--- a/crates/oss/unleash-edge-persistence/src/file.rs
+++ b/crates/oss/unleash-edge-persistence/src/file.rs
@@ -53,6 +53,12 @@ impl FilePersister {
         license_path
     }
 
+    pub fn last_event_id_path(&self) -> PathBuf {
+        let mut last_event_id_path = self.storage_path.clone();
+        last_event_id_path.push("unleash_last_event_id.json");
+        last_event_id_path
+    }
+
     pub fn new(storage_path: &Path) -> Self {
         let _ = std::fs::create_dir_all(storage_path);
         FilePersister {
@@ -193,6 +199,51 @@ impl EdgePersistence for FilePersister {
         })
         .map(|_| ())
     }
+
+    async fn save_last_event_id(&self, event_id: u64) -> EdgeResult<()> {
+        let mut file = tokio::fs::File::create(self.last_event_id_path())
+            .await
+            .map_err(|_| {
+                EdgeError::PersistenceError(
+                    "Cannot write last event id to backup. Opening backup file for writing failed"
+                        .to_string(),
+                )
+            })?;
+        file.write_all(&serde_json::to_vec(&event_id).map_err(|_| {
+            EdgeError::PersistenceError("Failed to serialize last event id".to_string())
+        })?)
+        .await
+        .map_err(|_| {
+            EdgeError::PersistenceError("Could not serialize last event id to disc".to_string())
+        })
+        .map(|_| ())
+    }
+
+    async fn load_last_event_id(&self) -> EdgeResult<u64> {
+        let mut file = tokio::fs::File::open(self.last_event_id_path())
+            .await
+            .map_err(|_| {
+                EdgeError::PersistenceError(
+                    "Cannot load last event id from backup, opening backup file failed".to_string(),
+                )
+            })?;
+
+        let mut contents = vec![];
+
+        file.read_to_end(&mut contents).await.map_err(|_| {
+            EdgeError::PersistenceError(
+                "Cannot load last event id from backup, reading backup file failed".to_string(),
+            )
+        })?;
+
+        let contents: u64 = serde_json::from_slice(&contents).map_err(|_| {
+            EdgeError::PersistenceError(
+                "Cannot load last event id from backup, parsing backup file failed".to_string(),
+            )
+        })?;
+
+        Ok(contents)
+    }
 }
 
 #[cfg(test)]
@@ -292,5 +343,14 @@ mod tests {
         let persister = FilePersister::try_from(get_test_dir().as_str()).unwrap();
         let reloaded = persister.load_license_state().await;
         assert!(matches!(reloaded, Err(EdgeError::PersistenceError(_))));
+    }
+
+    #[tokio::test]
+    async fn file_persister_can_save_and_load_last_event_id() {
+        let persister = FilePersister::try_from(get_test_dir().as_str()).unwrap();
+        let event_id = 42;
+        persister.save_last_event_id(event_id).await.unwrap();
+        let reloaded = persister.load_last_event_id().await;
+        assert_eq!(reloaded.unwrap(), event_id);
     }
 }

--- a/crates/oss/unleash-edge-persistence/src/file.rs
+++ b/crates/oss/unleash-edge-persistence/src/file.rs
@@ -55,7 +55,7 @@ impl FilePersister {
 
     pub fn last_event_id_path(&self) -> PathBuf {
         let mut last_event_id_path = self.storage_path.clone();
-        last_event_id_path.push("unleash_last_event_id.json");
+        last_event_id_path.push("unleash_last_event_ids.json");
         last_event_id_path
     }
 
@@ -200,7 +200,7 @@ impl EdgePersistence for FilePersister {
         .map(|_| ())
     }
 
-    async fn save_last_event_id(&self, event_id: u64) -> EdgeResult<()> {
+    async fn save_last_event_ids(&self, event_id: HashMap<String, u64>) -> EdgeResult<()> {
         let mut file = tokio::fs::File::create(self.last_event_id_path())
             .await
             .map_err(|_| {
@@ -219,7 +219,7 @@ impl EdgePersistence for FilePersister {
         .map(|_| ())
     }
 
-    async fn load_last_event_id(&self) -> EdgeResult<u64> {
+    async fn load_last_event_ids(&self) -> EdgeResult<HashMap<String, u64>> {
         let mut file = tokio::fs::File::open(self.last_event_id_path())
             .await
             .map_err(|_| {
@@ -236,7 +236,7 @@ impl EdgePersistence for FilePersister {
             )
         })?;
 
-        let contents: u64 = serde_json::from_slice(&contents).map_err(|_| {
+        let contents: HashMap<String, u64> = serde_json::from_slice(&contents).map_err(|_| {
             EdgeError::PersistenceError(
                 "Cannot load last event id from backup, parsing backup file failed".to_string(),
             )
@@ -252,6 +252,7 @@ mod tests {
 
     use crate::EdgePersistence;
     use crate::file::FilePersister;
+    use ahash::{HashMap, HashMapExt};
     use ulid::Ulid;
     use unleash_edge_types::errors::EdgeError;
     use unleash_edge_types::tokens::EdgeToken;
@@ -348,9 +349,10 @@ mod tests {
     #[tokio::test]
     async fn file_persister_can_save_and_load_last_event_id() {
         let persister = FilePersister::try_from(get_test_dir().as_str()).unwrap();
-        let event_id = 42;
-        persister.save_last_event_id(event_id).await.unwrap();
-        let reloaded = persister.load_last_event_id().await;
-        assert_eq!(reloaded.unwrap(), event_id);
+        let mut event_ids = HashMap::new();
+        event_ids.insert("development".to_string(), 42);
+        persister.save_last_event_ids(event_ids.clone()).await.unwrap();
+        let reloaded = persister.load_last_event_ids().await;
+        assert_eq!(reloaded.unwrap(), event_ids);
     }
 }

--- a/crates/oss/unleash-edge-persistence/src/file.rs
+++ b/crates/oss/unleash-edge-persistence/src/file.rs
@@ -53,7 +53,7 @@ impl FilePersister {
         license_path
     }
 
-    pub fn last_event_id_path(&self) -> PathBuf {
+    pub fn last_event_ids_path(&self) -> PathBuf {
         let mut last_event_id_path = self.storage_path.clone();
         last_event_id_path.push("unleash_last_event_ids.json");
         last_event_id_path
@@ -200,8 +200,8 @@ impl EdgePersistence for FilePersister {
         .map(|_| ())
     }
 
-    async fn save_last_event_ids(&self, event_id: HashMap<String, u64>) -> EdgeResult<()> {
-        let mut file = tokio::fs::File::create(self.last_event_id_path())
+    async fn save_last_event_ids(&self, event_ids: HashMap<String, u64>) -> EdgeResult<()> {
+        let mut file = tokio::fs::File::create(self.last_event_ids_path())
             .await
             .map_err(|_| {
                 EdgeError::PersistenceError(
@@ -209,7 +209,7 @@ impl EdgePersistence for FilePersister {
                         .to_string(),
                 )
             })?;
-        file.write_all(&serde_json::to_vec(&event_id).map_err(|_| {
+        file.write_all(&serde_json::to_vec(&event_ids).map_err(|_| {
             EdgeError::PersistenceError("Failed to serialize last event id".to_string())
         })?)
         .await
@@ -220,7 +220,7 @@ impl EdgePersistence for FilePersister {
     }
 
     async fn load_last_event_ids(&self) -> EdgeResult<HashMap<String, u64>> {
-        let mut file = tokio::fs::File::open(self.last_event_id_path())
+        let mut file = tokio::fs::File::open(self.last_event_ids_path())
             .await
             .map_err(|_| {
                 EdgeError::PersistenceError(
@@ -351,7 +351,10 @@ mod tests {
         let persister = FilePersister::try_from(get_test_dir().as_str()).unwrap();
         let mut event_ids = HashMap::new();
         event_ids.insert("development".to_string(), 42);
-        persister.save_last_event_ids(event_ids.clone()).await.unwrap();
+        persister
+            .save_last_event_ids(event_ids.clone())
+            .await
+            .unwrap();
         let reloaded = persister.load_last_event_ids().await;
         assert_eq!(reloaded.unwrap(), event_ids);
     }

--- a/crates/oss/unleash-edge-persistence/src/file.rs
+++ b/crates/oss/unleash-edge-persistence/src/file.rs
@@ -200,7 +200,7 @@ impl EdgePersistence for FilePersister {
         .map(|_| ())
     }
 
-    async fn save_last_event_ids(&self, event_ids: HashMap<String, u64>) -> EdgeResult<()> {
+    async fn save_last_event_ids(&self, event_ids: HashMap<String, u32>) -> EdgeResult<()> {
         let mut file = tokio::fs::File::create(self.last_event_ids_path())
             .await
             .map_err(|_| {
@@ -219,7 +219,7 @@ impl EdgePersistence for FilePersister {
         .map(|_| ())
     }
 
-    async fn load_last_event_ids(&self) -> EdgeResult<HashMap<String, u64>> {
+    async fn load_last_event_ids(&self) -> EdgeResult<HashMap<String, u32>> {
         let mut file = tokio::fs::File::open(self.last_event_ids_path())
             .await
             .map_err(|_| {
@@ -236,7 +236,7 @@ impl EdgePersistence for FilePersister {
             )
         })?;
 
-        let contents: HashMap<String, u64> = serde_json::from_slice(&contents).map_err(|_| {
+        let contents: HashMap<String, u32> = serde_json::from_slice(&contents).map_err(|_| {
             EdgeError::PersistenceError(
                 "Cannot load last event id from backup, parsing backup file failed".to_string(),
             )

--- a/crates/oss/unleash-edge-persistence/src/lib.rs
+++ b/crates/oss/unleash-edge-persistence/src/lib.rs
@@ -23,8 +23,8 @@ pub trait EdgePersistence: Send + Sync {
     async fn save_features(&self, features: Vec<(String, ClientFeatures)>) -> EdgeResult<()>;
     async fn load_license_state(&self) -> EdgeResult<LicenseState>;
     async fn save_license_state(&self, license: &LicenseState) -> EdgeResult<()>;
-    async fn save_last_event_id(&self, event_id: u64) -> EdgeResult<()>;
-    async fn load_last_event_id(&self) -> EdgeResult<u64>;
+    async fn save_last_event_ids(&self, event_id: HashMap<String, u64>) -> EdgeResult<()>;
+    async fn load_last_event_ids(&self) -> EdgeResult<HashMap<String, u64>>;
 }
 
 async fn persist(
@@ -145,11 +145,11 @@ pub mod tests {
             panic!("Not expected to be called");
         }
 
-        async fn save_last_event_id(&self, _: u64) -> EdgeResult<()> {
+        async fn save_last_event_ids(&self, _: HashMap<String, u64>) -> EdgeResult<()> {
             panic!("Not expected to be called");
         }
 
-        async fn load_last_event_id(&self) -> EdgeResult<u64> {
+        async fn load_last_event_ids(&self) -> EdgeResult<HashMap<String, u64>> {
             panic!("Not expected to be called");
         }
     }

--- a/crates/oss/unleash-edge-persistence/src/lib.rs
+++ b/crates/oss/unleash-edge-persistence/src/lib.rs
@@ -5,6 +5,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, warn};
+use unleash_edge_delta::cache_manager::DeltaCacheManager;
 use unleash_edge_feature_cache::FeatureCache;
 use unleash_edge_types::enterprise::LicenseState;
 use unleash_edge_types::tokens::EdgeToken;
@@ -23,8 +24,8 @@ pub trait EdgePersistence: Send + Sync {
     async fn save_features(&self, features: Vec<(String, ClientFeatures)>) -> EdgeResult<()>;
     async fn load_license_state(&self) -> EdgeResult<LicenseState>;
     async fn save_license_state(&self, license: &LicenseState) -> EdgeResult<()>;
-    async fn save_last_event_ids(&self, event_id: HashMap<String, u64>) -> EdgeResult<()>;
-    async fn load_last_event_ids(&self) -> EdgeResult<HashMap<String, u64>>;
+    async fn save_last_event_ids(&self, event_id: HashMap<String, u32>) -> EdgeResult<()>;
+    async fn load_last_event_ids(&self) -> EdgeResult<HashMap<String, u32>>;
 }
 
 async fn persist(
@@ -40,6 +41,7 @@ pub fn create_persist_data_task(
     persistence: Arc<dyn EdgePersistence>,
     token_cache: Arc<DashMap<String, EdgeToken>>,
     features_cache: Arc<FeatureCache>,
+    delta_cache_manager: Option<Arc<DeltaCacheManager>>,
 ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
     Box::pin(async move {
         loop {
@@ -50,6 +52,11 @@ pub fn create_persist_data_task(
                         token_cache.clone(),
                         features_cache.clone()
                     ).await;
+
+                    if let Some(delta_cache_manager) = delta_cache_manager.as_ref()
+                        && let Err(e) = persistence.save_last_event_ids(delta_cache_manager.get_last_event_ids()).await {
+                            warn!("Could not persist last event ids: {e:?}");
+                        }
                 }
             }
         }
@@ -145,11 +152,11 @@ pub mod tests {
             panic!("Not expected to be called");
         }
 
-        async fn save_last_event_ids(&self, _: HashMap<String, u64>) -> EdgeResult<()> {
+        async fn save_last_event_ids(&self, _: HashMap<String, u32>) -> EdgeResult<()> {
             panic!("Not expected to be called");
         }
 
-        async fn load_last_event_ids(&self) -> EdgeResult<HashMap<String, u64>> {
+        async fn load_last_event_ids(&self) -> EdgeResult<HashMap<String, u32>> {
             panic!("Not expected to be called");
         }
     }

--- a/crates/oss/unleash-edge-persistence/src/lib.rs
+++ b/crates/oss/unleash-edge-persistence/src/lib.rs
@@ -23,6 +23,8 @@ pub trait EdgePersistence: Send + Sync {
     async fn save_features(&self, features: Vec<(String, ClientFeatures)>) -> EdgeResult<()>;
     async fn load_license_state(&self) -> EdgeResult<LicenseState>;
     async fn save_license_state(&self, license: &LicenseState) -> EdgeResult<()>;
+    async fn save_last_event_id(&self, event_id: u64) -> EdgeResult<()>;
+    async fn load_last_event_id(&self) -> EdgeResult<u64>;
 }
 
 async fn persist(
@@ -140,6 +142,14 @@ pub mod tests {
         }
 
         async fn save_license_state(&self, _: &LicenseState) -> EdgeResult<()> {
+            panic!("Not expected to be called");
+        }
+
+        async fn save_last_event_id(&self, _: u64) -> EdgeResult<()> {
+            panic!("Not expected to be called");
+        }
+
+        async fn load_last_event_id(&self) -> EdgeResult<u64> {
             panic!("Not expected to be called");
         }
     }

--- a/crates/oss/unleash-edge-persistence/src/lib.rs
+++ b/crates/oss/unleash-edge-persistence/src/lib.rs
@@ -32,16 +32,18 @@ async fn persist(
     persistence: Arc<dyn EdgePersistence>,
     token_cache: Arc<DashMap<String, EdgeToken>>,
     features_cache: Arc<FeatureCache>,
+    delta_cache_manager: Arc<DeltaCacheManager>,
 ) {
     save_known_tokens(&token_cache, &persistence).await;
     save_features(&features_cache, &persistence).await;
+    save_last_event_ids(&delta_cache_manager, &persistence).await;
 }
 
 pub fn create_persist_data_task(
     persistence: Arc<dyn EdgePersistence>,
     token_cache: Arc<DashMap<String, EdgeToken>>,
     features_cache: Arc<FeatureCache>,
-    delta_cache_manager: Option<Arc<DeltaCacheManager>>,
+    delta_cache_manager: Arc<DeltaCacheManager>,
 ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
     Box::pin(async move {
         loop {
@@ -50,13 +52,9 @@ pub fn create_persist_data_task(
                     persist(
                         persistence.clone(),
                         token_cache.clone(),
-                        features_cache.clone()
+                        features_cache.clone(),
+                        delta_cache_manager.clone(),
                     ).await;
-
-                    if let Some(delta_cache_manager) = delta_cache_manager.as_ref()
-                        && let Err(e) = persistence.save_last_event_ids(delta_cache_manager.get_last_event_ids()).await {
-                            warn!("Could not persist last event ids: {e:?}");
-                        }
                 }
             }
         }
@@ -67,11 +65,20 @@ pub fn create_once_off_persist(
     persistence: Arc<dyn EdgePersistence>,
     token_cache: Arc<DashMap<String, EdgeToken>>,
     features_cache: Arc<FeatureCache>,
+    delta_cache_manager: Arc<DeltaCacheManager>,
 ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
     let token_cache = token_cache.clone();
     let features_cache = features_cache.clone();
     let persistence = persistence.clone();
-    Box::pin(async move { persist(persistence, token_cache, features_cache).await })
+    Box::pin(async move {
+        persist(
+            persistence,
+            token_cache,
+            features_cache,
+            delta_cache_manager,
+        )
+        .await
+    })
 }
 
 async fn save_known_tokens(
@@ -113,6 +120,18 @@ async fn save_features(features_cache: &FeatureCache, persister: &Arc<dyn EdgePe
         }
     } else {
         debug!("No features found, skipping features persistence");
+    }
+}
+
+async fn save_last_event_ids(
+    delta_cache_manager: &Arc<DeltaCacheManager>,
+    persister: &Arc<dyn EdgePersistence>,
+) {
+    if let Err(save_error) = persister
+        .save_last_event_ids(delta_cache_manager.get_last_event_ids())
+        .await
+    {
+        warn!("Could not persist last event ids: {save_error:?}");
     }
 }
 

--- a/crates/oss/unleash-edge-persistence/src/redis.rs
+++ b/crates/oss/unleash-edge-persistence/src/redis.rs
@@ -18,6 +18,7 @@ use unleash_types::client_features::ClientFeatures;
 pub const FEATURES_KEY: &str = "unleash-features";
 pub const TOKENS_KEY: &str = "unleash-tokens";
 pub const LICENSE_STATE_KEY: &str = "unleash-license-state";
+pub const LAST_EVENT_ID_KEY: &str = "unleash-last-event-id";
 
 enum RedisClientOptions {
     Single(Client),
@@ -210,6 +211,44 @@ impl EdgePersistence for RedisPersister {
         };
         Ok(())
     }
+
+    async fn save_last_event_id(&self, event_id: u64) -> EdgeResult<()> {
+        debug!("Saving last event id to persistence: {event_id}");
+        let mut client = self.redis_client.write().await;
+        match &mut *client {
+            Single(c) => {
+                let mut conn = c
+                    .get_multiplexed_async_connection_with_config(&self.async_write_config())
+                    .await?;
+                let res: Result<(), RedisError> =
+                    conn.set(LAST_EVENT_ID_KEY, event_id).await;
+                res?;
+            }
+            Cluster(c) => {
+                let mut conn = c.get_connection()?;
+                conn.set(LAST_EVENT_ID_KEY, event_id)?
+            }
+        };
+        Ok(())
+    }
+
+    async fn load_last_event_id(&self) -> EdgeResult<u64> {
+        debug!("Loading last event id from persistence");
+        let mut client = self.redis_client.write().await;
+        let raw_event_id: u64 = match &mut *client {
+            Single(client) => {
+                let mut conn = client
+                    .get_multiplexed_async_connection_with_config(&self.async_read_config())
+                    .await?;
+                conn.get(LAST_EVENT_ID_KEY).await?
+            }
+            Cluster(client) => {
+                let mut conn = client.get_connection()?;
+                conn.get(LAST_EVENT_ID_KEY)?
+            }
+        };
+        Ok(raw_event_id)
+    }
 }
 
 #[cfg(test)]
@@ -309,5 +348,15 @@ mod tests {
         _node.stop().await.expect("Failed to stop redis");
         let loaded_state = redis_persister.load_license_state().await;
         assert!(loaded_state.is_err());
+    }
+
+    #[tokio::test]
+    async fn redis_saves_and_loads_last_event_id_correctly() {
+        let (_client, url, _node) = setup_redis().await;
+        let redis_persister = RedisPersister::new(&url, TEST_TIMEOUT, TEST_TIMEOUT).unwrap();
+        let event_id = 42;
+        redis_persister.save_last_event_id(event_id).await.unwrap();
+        let loaded_event_id = redis_persister.load_last_event_id().await.unwrap();
+        assert_eq!(loaded_event_id, event_id);
     }
 }

--- a/crates/oss/unleash-edge-persistence/src/redis.rs
+++ b/crates/oss/unleash-edge-persistence/src/redis.rs
@@ -18,7 +18,7 @@ use unleash_types::client_features::ClientFeatures;
 pub const FEATURES_KEY: &str = "unleash-features";
 pub const TOKENS_KEY: &str = "unleash-tokens";
 pub const LICENSE_STATE_KEY: &str = "unleash-license-state";
-pub const LAST_EVENT_ID_KEY: &str = "unleash-last-event-id";
+pub const LAST_EVENT_IDS_KEY: &str = "unleash-last-event-ids";
 
 enum RedisClientOptions {
     Single(Client),
@@ -212,38 +212,39 @@ impl EdgePersistence for RedisPersister {
         Ok(())
     }
 
-    async fn save_last_event_id(&self, event_id: u64) -> EdgeResult<()> {
-        debug!("Saving last event id to persistence: {event_id}");
+    async fn save_last_event_ids(&self, event_id: HashMap<String, u64>) -> EdgeResult<()> {
+        debug!("Saving last event id to persistence: {event_id:#?}");
         let mut client = self.redis_client.write().await;
+        let raw_event_ids = serde_json::to_string(&event_id)?;
         match &mut *client {
             Single(c) => {
                 let mut conn = c
                     .get_multiplexed_async_connection_with_config(&self.async_write_config())
                     .await?;
-                let res: Result<(), RedisError> = conn.set(LAST_EVENT_ID_KEY, event_id).await;
+                let res: Result<(), RedisError> = conn.set(LAST_EVENT_IDS_KEY, raw_event_ids).await;
                 res?;
             }
             Cluster(c) => {
                 let mut conn = c.get_connection()?;
-                conn.set(LAST_EVENT_ID_KEY, event_id)?
+                conn.set(LAST_EVENT_IDS_KEY, raw_event_ids)?
             }
         };
         Ok(())
     }
 
-    async fn load_last_event_id(&self) -> EdgeResult<u64> {
+    async fn load_last_event_ids(&self) -> EdgeResult<HashMap<String, u64>> {
         debug!("Loading last event id from persistence");
         let mut client = self.redis_client.write().await;
-        let raw_event_id: u64 = match &mut *client {
+        let raw_event_id: HashMap<String, u64> = match &mut *client {
             Single(client) => {
                 let mut conn = client
                     .get_multiplexed_async_connection_with_config(&self.async_read_config())
                     .await?;
-                conn.get(LAST_EVENT_ID_KEY).await?
+                conn.get(LAST_EVENT_IDS_KEY).await?
             }
             Cluster(client) => {
                 let mut conn = client.get_connection()?;
-                conn.get(LAST_EVENT_ID_KEY)?
+                conn.get(LAST_EVENT_IDS_KEY)?
             }
         };
         Ok(raw_event_id)
@@ -253,6 +254,7 @@ impl EdgePersistence for RedisPersister {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ahash::HashMapExt;
     use redis::Client;
     use std::{str::FromStr, time::Duration};
     use testcontainers_modules::redis::RedisStack;
@@ -353,9 +355,10 @@ mod tests {
     async fn redis_saves_and_loads_last_event_id_correctly() {
         let (_client, url, _node) = setup_redis().await;
         let redis_persister = RedisPersister::new(&url, TEST_TIMEOUT, TEST_TIMEOUT).unwrap();
-        let event_id = 42;
-        redis_persister.save_last_event_id(event_id).await.unwrap();
-        let loaded_event_id = redis_persister.load_last_event_id().await.unwrap();
-        assert_eq!(loaded_event_id, event_id);
+        let mut event_ids = HashMap::new();
+        event_ids.insert("development".to_string(), 42);
+        redis_persister.save_last_event_ids(event_ids.clone()).await.unwrap();
+        let loaded_event_ids = redis_persister.load_last_event_ids().await.unwrap();
+        assert_eq!(loaded_event_ids, event_ids);
     }
 }

--- a/crates/oss/unleash-edge-persistence/src/redis.rs
+++ b/crates/oss/unleash-edge-persistence/src/redis.rs
@@ -212,7 +212,7 @@ impl EdgePersistence for RedisPersister {
         Ok(())
     }
 
-    async fn save_last_event_ids(&self, event_ids: HashMap<String, u64>) -> EdgeResult<()> {
+    async fn save_last_event_ids(&self, event_ids: HashMap<String, u32>) -> EdgeResult<()> {
         debug!("Saving last event ids to persistence: {event_ids:#?}");
         let mut client = self.redis_client.write().await;
         let raw_event_ids = serde_json::to_string(&event_ids)?;
@@ -232,7 +232,7 @@ impl EdgePersistence for RedisPersister {
         Ok(())
     }
 
-    async fn load_last_event_ids(&self) -> EdgeResult<HashMap<String, u64>> {
+    async fn load_last_event_ids(&self) -> EdgeResult<HashMap<String, u32>> {
         debug!("Loading last event ids from persistence");
         let mut client = self.redis_client.write().await;
         let raw_event_ids: String = match &mut *client {
@@ -247,7 +247,7 @@ impl EdgePersistence for RedisPersister {
                 conn.get(LAST_EVENT_IDS_KEY)?
             }
         };
-        serde_json::from_str::<HashMap<String, u64>>(&raw_event_ids).map_err(EdgeError::from)
+        serde_json::from_str::<HashMap<String, u32>>(&raw_event_ids).map_err(EdgeError::from)
     }
 }
 

--- a/crates/oss/unleash-edge-persistence/src/redis.rs
+++ b/crates/oss/unleash-edge-persistence/src/redis.rs
@@ -220,8 +220,7 @@ impl EdgePersistence for RedisPersister {
                 let mut conn = c
                     .get_multiplexed_async_connection_with_config(&self.async_write_config())
                     .await?;
-                let res: Result<(), RedisError> =
-                    conn.set(LAST_EVENT_ID_KEY, event_id).await;
+                let res: Result<(), RedisError> = conn.set(LAST_EVENT_ID_KEY, event_id).await;
                 res?;
             }
             Cluster(c) => {

--- a/crates/oss/unleash-edge-persistence/src/redis.rs
+++ b/crates/oss/unleash-edge-persistence/src/redis.rs
@@ -212,10 +212,10 @@ impl EdgePersistence for RedisPersister {
         Ok(())
     }
 
-    async fn save_last_event_ids(&self, event_id: HashMap<String, u64>) -> EdgeResult<()> {
-        debug!("Saving last event id to persistence: {event_id:#?}");
+    async fn save_last_event_ids(&self, event_ids: HashMap<String, u64>) -> EdgeResult<()> {
+        debug!("Saving last event ids to persistence: {event_ids:#?}");
         let mut client = self.redis_client.write().await;
-        let raw_event_ids = serde_json::to_string(&event_id)?;
+        let raw_event_ids = serde_json::to_string(&event_ids)?;
         match &mut *client {
             Single(c) => {
                 let mut conn = c
@@ -233,9 +233,9 @@ impl EdgePersistence for RedisPersister {
     }
 
     async fn load_last_event_ids(&self) -> EdgeResult<HashMap<String, u64>> {
-        debug!("Loading last event id from persistence");
+        debug!("Loading last event ids from persistence");
         let mut client = self.redis_client.write().await;
-        let raw_event_id: HashMap<String, u64> = match &mut *client {
+        let raw_event_ids: String = match &mut *client {
             Single(client) => {
                 let mut conn = client
                     .get_multiplexed_async_connection_with_config(&self.async_read_config())
@@ -247,7 +247,7 @@ impl EdgePersistence for RedisPersister {
                 conn.get(LAST_EVENT_IDS_KEY)?
             }
         };
-        Ok(raw_event_id)
+        serde_json::from_str::<HashMap<String, u64>>(&raw_event_ids).map_err(EdgeError::from)
     }
 }
 
@@ -357,7 +357,10 @@ mod tests {
         let redis_persister = RedisPersister::new(&url, TEST_TIMEOUT, TEST_TIMEOUT).unwrap();
         let mut event_ids = HashMap::new();
         event_ids.insert("development".to_string(), 42);
-        redis_persister.save_last_event_ids(event_ids.clone()).await.unwrap();
+        redis_persister
+            .save_last_event_ids(event_ids.clone())
+            .await
+            .unwrap();
         let loaded_event_ids = redis_persister.load_last_event_ids().await.unwrap();
         assert_eq!(loaded_event_ids, event_ids);
     }

--- a/crates/oss/unleash-edge-persistence/src/s3.rs
+++ b/crates/oss/unleash-edge-persistence/src/s3.rs
@@ -201,7 +201,6 @@ pub mod s3_persister {
             }
         }
 
-
         async fn load_last_event_id(&self) -> EdgeResult<u64> {
             let response = self
                 .client

--- a/crates/oss/unleash-edge-persistence/src/s3.rs
+++ b/crates/oss/unleash-edge-persistence/src/s3.rs
@@ -18,7 +18,7 @@ pub mod s3_persister {
     pub const FEATURES_KEY: &str = "/unleash-features.json";
     pub const TOKENS_KEY: &str = "/unleash-tokens.json";
     pub const LICENSE_STATE_KEY: &str = "/unleash-license-state.json";
-    pub const LAST_EVENT_ID_KEY: &str = "/unleash-last-event-id.json";
+    pub const LAST_EVENT_IDS_KEY: &str = "/unleash-last-event-ids.json";
 
     pub struct S3Persister {
         client: s3::Client,
@@ -179,7 +179,7 @@ pub mod s3_persister {
             }
         }
 
-        async fn save_last_event_id(&self, event_id: u64) -> EdgeResult<()> {
+        async fn save_last_event_ids(&self, event_id: HashMap<String, u64>) -> EdgeResult<()> {
             let body_data = serde_json::to_vec(&event_id).map_err(|e| {
                 EdgeError::PersistenceError(format!("Failed to serialize last event id: {}", e))
             })?;
@@ -188,25 +188,25 @@ pub mod s3_persister {
                 .client
                 .put_object()
                 .bucket(self.bucket.clone())
-                .key(LAST_EVENT_ID_KEY)
+                .key(LAST_EVENT_IDS_KEY)
                 .body(byte_stream)
                 .send()
                 .await
             {
                 Ok(_) => Ok(()),
                 Err(s3_err) => Err(EdgeError::PersistenceError(format!(
-                    "Failed to save last event id: {}",
+                    "Failed to save last event ids: {}",
                     s3_err.into_service_error()
                 ))),
             }
         }
 
-        async fn load_last_event_id(&self) -> EdgeResult<u64> {
+        async fn load_last_event_ids(&self) -> EdgeResult<HashMap<String, u64>> {
             let response = self
                 .client
                 .get_object()
                 .bucket(self.bucket.clone())
-                .key(LAST_EVENT_ID_KEY)
+                .key(LAST_EVENT_IDS_KEY)
                 .response_content_type("application/json")
                 .send()
                 .await
@@ -230,6 +230,7 @@ mod tests {
         use crate::s3::s3_persister::S3Persister;
 
         use ahash::HashMap;
+        use ahash::HashMapExt;
         use aws_config::Region;
         use aws_sdk_s3 as s3;
         use aws_sdk_s3::config::Credentials;
@@ -358,10 +359,11 @@ mod tests {
         #[tokio::test]
         async fn test_s3_persister_saves_and_loads_last_event_id_correctly() {
             let (_localstack, persister) = setup_s3_persister().await;
-            let event_id = 42;
-            persister.save_last_event_id(event_id).await.unwrap();
-            let loaded_event_id = persister.load_last_event_id().await.unwrap();
-            assert_eq!(loaded_event_id, event_id);
+            let mut event_ids = HashMap::new();
+            event_ids.insert("development".to_string(), 42);
+            persister.save_last_event_ids(event_ids.clone()).await.unwrap();
+            let loaded_event_ids = persister.load_last_event_ids().await.unwrap();
+            assert_eq!(loaded_event_ids, event_ids);
         }
     }
 }

--- a/crates/oss/unleash-edge-persistence/src/s3.rs
+++ b/crates/oss/unleash-edge-persistence/src/s3.rs
@@ -179,9 +179,9 @@ pub mod s3_persister {
             }
         }
 
-        async fn save_last_event_ids(&self, event_id: HashMap<String, u64>) -> EdgeResult<()> {
-            let body_data = serde_json::to_vec(&event_id).map_err(|e| {
-                EdgeError::PersistenceError(format!("Failed to serialize last event id: {}", e))
+        async fn save_last_event_ids(&self, event_ids: HashMap<String, u64>) -> EdgeResult<()> {
+            let body_data = serde_json::to_vec(&event_ids).map_err(|e| {
+                EdgeError::PersistenceError(format!("Failed to serialize last event ids: {}", e))
             })?;
             let byte_stream = ByteStream::new(SdkBody::from(body_data));
             match self
@@ -361,7 +361,10 @@ mod tests {
             let (_localstack, persister) = setup_s3_persister().await;
             let mut event_ids = HashMap::new();
             event_ids.insert("development".to_string(), 42);
-            persister.save_last_event_ids(event_ids.clone()).await.unwrap();
+            persister
+                .save_last_event_ids(event_ids.clone())
+                .await
+                .unwrap();
             let loaded_event_ids = persister.load_last_event_ids().await.unwrap();
             assert_eq!(loaded_event_ids, event_ids);
         }

--- a/crates/oss/unleash-edge-persistence/src/s3.rs
+++ b/crates/oss/unleash-edge-persistence/src/s3.rs
@@ -18,6 +18,7 @@ pub mod s3_persister {
     pub const FEATURES_KEY: &str = "/unleash-features.json";
     pub const TOKENS_KEY: &str = "/unleash-tokens.json";
     pub const LICENSE_STATE_KEY: &str = "/unleash-license-state.json";
+    pub const LAST_EVENT_ID_KEY: &str = "/unleash-last-event-id.json";
 
     pub struct S3Persister {
         client: s3::Client,
@@ -177,6 +178,47 @@ pub mod s3_persister {
                 ))),
             }
         }
+
+        async fn save_last_event_id(&self, event_id: u64) -> EdgeResult<()> {
+            let body_data = serde_json::to_vec(&event_id).map_err(|e| {
+                EdgeError::PersistenceError(format!("Failed to serialize last event id: {}", e))
+            })?;
+            let byte_stream = ByteStream::new(SdkBody::from(body_data));
+            match self
+                .client
+                .put_object()
+                .bucket(self.bucket.clone())
+                .key(LAST_EVENT_ID_KEY)
+                .body(byte_stream)
+                .send()
+                .await
+            {
+                Ok(_) => Ok(()),
+                Err(s3_err) => Err(EdgeError::PersistenceError(format!(
+                    "Failed to save last event id: {}",
+                    s3_err.into_service_error()
+                ))),
+            }
+        }
+
+
+        async fn load_last_event_id(&self) -> EdgeResult<u64> {
+            let response = self
+                .client
+                .get_object()
+                .bucket(self.bucket.clone())
+                .key(LAST_EVENT_ID_KEY)
+                .response_content_type("application/json")
+                .send()
+                .await
+                .map_err(|_| {
+                    EdgeError::PersistenceError("Failed to load last event id".to_string())
+                })?;
+            let data = response.body.collect().await.map_err(|_| {
+                EdgeError::PersistenceError("Failed to read last event id data".to_string())
+            })?;
+            serde_json::from_slice(&data.to_vec()).map_err(EdgeError::from)
+        }
     }
 }
 
@@ -312,6 +354,15 @@ mod tests {
                 loaded_license_state,
                 Err(EdgeError::PersistenceError(_))
             ));
+        }
+
+        #[tokio::test]
+        async fn test_s3_persister_saves_and_loads_last_event_id_correctly() {
+            let (_localstack, persister) = setup_s3_persister().await;
+            let event_id = 42;
+            persister.save_last_event_id(event_id).await.unwrap();
+            let loaded_event_id = persister.load_last_event_id().await.unwrap();
+            assert_eq!(loaded_event_id, event_id);
         }
     }
 }

--- a/crates/oss/unleash-edge-persistence/src/s3.rs
+++ b/crates/oss/unleash-edge-persistence/src/s3.rs
@@ -179,7 +179,7 @@ pub mod s3_persister {
             }
         }
 
-        async fn save_last_event_ids(&self, event_ids: HashMap<String, u64>) -> EdgeResult<()> {
+        async fn save_last_event_ids(&self, event_ids: HashMap<String, u32>) -> EdgeResult<()> {
             let body_data = serde_json::to_vec(&event_ids).map_err(|e| {
                 EdgeError::PersistenceError(format!("Failed to serialize last event ids: {}", e))
             })?;
@@ -201,7 +201,7 @@ pub mod s3_persister {
             }
         }
 
-        async fn load_last_event_ids(&self) -> EdgeResult<HashMap<String, u64>> {
+        async fn load_last_event_ids(&self) -> EdgeResult<HashMap<String, u32>> {
             let response = self
                 .client
                 .get_object()
@@ -211,10 +211,10 @@ pub mod s3_persister {
                 .send()
                 .await
                 .map_err(|_| {
-                    EdgeError::PersistenceError("Failed to load last event id".to_string())
+                    EdgeError::PersistenceError("Failed to load last event ids".to_string())
                 })?;
             let data = response.body.collect().await.map_err(|_| {
-                EdgeError::PersistenceError("Failed to read last event id data".to_string())
+                EdgeError::PersistenceError("Failed to read last event ids data".to_string())
             })?;
             serde_json::from_slice(&data.to_vec()).map_err(EdgeError::from)
         }

--- a/crates/oss/unleash-edge/Cargo.toml
+++ b/crates/oss/unleash-edge/Cargo.toml
@@ -77,6 +77,7 @@ unleash-yggdrasil = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+ahash = { workspace = true }
 axum-test = { workspace = true }
 tracing-test = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/oss/unleash-edge/src/edge_builder.rs
+++ b/crates/oss/unleash-edge/src/edge_builder.rs
@@ -22,10 +22,11 @@ use unleash_edge_auth::token_validator::{
 use unleash_edge_cli::{
     AuthHeaders, EdgeArgs, LogFormat, OtelExporterProtocol, RedisArgs, RedisMode, S3Args,
 };
+use unleash_edge_delta::cache::{DeltaCache, DeltaHydrationEvent};
 use unleash_edge_delta::cache_manager::{DeltaCacheManager, create_terminate_sse_connections_task};
 use unleash_edge_feature_cache::FeatureCache;
 use unleash_edge_feature_refresh::delta_refresh::{
-    DeltaRefresher, start_streaming_delta_background_task,
+    DELTA_CACHE_LIMIT, DeltaRefresher, start_streaming_delta_background_task,
 };
 use unleash_edge_feature_refresh::{
     FeatureRefreshConfig, FeatureRefresher, HydratorType, start_refresh_features_background_task,
@@ -140,8 +141,7 @@ async fn get_data_source(args: &PersistenceArgs) -> Option<Arc<dyn EdgePersisten
 }
 
 async fn hydrate_from_persistent_storage(cache: CacheContainer, storage: Arc<dyn EdgePersistence>) {
-    let (token_cache, features_cache, _delta_cache, engine_cache) = cache;
-    // TODO: do we need to hydrate from persistent storage for delta?
+    let (token_cache, features_cache, delta_cache, engine_cache) = cache;
     let tokens = storage.load_tokens().await.unwrap_or_else(|error| {
         warn!("Failed to load tokens from cache {error:?}");
         vec![]
@@ -160,11 +160,23 @@ async fn hydrate_from_persistent_storage(cache: CacheContainer, storage: Arc<dyn
         features_cache.insert(key.clone(), features.clone());
         let mut engine_state = EngineState::default();
 
-        let warnings = engine_state.take_state(UpdateMessage::FullResponse(features));
+        let warnings = engine_state.take_state(UpdateMessage::FullResponse(features.clone()));
         if let Some(warnings) = warnings {
             warn!("Failed to hydrate features for {key:?}: {warnings:?}");
         }
         engine_cache.insert(key.clone(), engine_state);
+
+        delta_cache.insert_cache(
+            key.as_str(),
+            DeltaCache::new(
+                DeltaHydrationEvent {
+                    event_id: 0,
+                    features: features.features.clone(),
+                    segments: features.segments.unwrap_or_else(|| vec![]).clone(),
+                },
+                DELTA_CACHE_LIMIT,
+            ),
+        );
     }
 }
 
@@ -934,17 +946,84 @@ pub async fn resolve_license(
 
 #[cfg(test)]
 mod tests {
-    use crate::edge_builder::{EdgeBuilderArgs, PersistenceArgs, build_edge};
-    use chrono::Duration;
+    use crate::edge_builder::build_caches;
+    use std::env::temp_dir;
+    #[cfg(feature = "enterprise")]
     use std::path::Path;
+    #[cfg(feature = "enterprise")]
     use std::str::FromStr;
     use std::sync::Arc;
     use ulid::Ulid;
+    use unleash_edge_persistence::EdgePersistence;
+    use unleash_edge_persistence::file::FilePersister;
+    use unleash_types::client_features::{ClientFeature, ClientFeatures, Segment};
+
+    #[cfg(feature = "enterprise")]
+    use crate::edge_builder::{EdgeBuilderArgs, PersistenceArgs, build_edge};
+    #[cfg(feature = "enterprise")]
+    use chrono::Duration;
+    #[cfg(feature = "enterprise")]
     use unleash_edge_cli::{AuthHeaders, EdgeArgs, HmacConfig};
+    #[cfg(feature = "enterprise")]
     use unleash_edge_http_client::ClientMetaInformation;
+    #[cfg(feature = "enterprise")]
     use unleash_edge_types::metrics::instance_data::{ApiKeyIdentity, EdgeInstanceData, Hosting};
+    #[cfg(feature = "enterprise")]
     use unleash_edge_types::tokens::EdgeToken;
+    #[cfg(feature = "enterprise")]
     use url::Url;
+
+    #[tokio::test]
+    async fn hydrates_delta_cache_from_persistent_feature_backup() {
+        let key = "development".to_string();
+        let feature = ClientFeature {
+            name: "test-flag".to_string(),
+            enabled: true,
+            ..Default::default()
+        };
+        let segment = Segment {
+            id: 7,
+            constraints: vec![],
+        };
+        let features = ClientFeatures {
+            features: vec![feature.clone()],
+            version: 2,
+            segments: Some(vec![segment.clone()]),
+            query: None,
+            meta: None,
+        };
+
+        let backup_folder = temp_dir().join(Ulid::new().to_string());
+        let persister = FilePersister::new(&backup_folder);
+        persister
+            .save_features(vec![(key.clone(), features.clone())])
+            .await
+            .unwrap();
+
+        let (token_cache, features_cache, delta_cache, engine_cache) = build_caches();
+        super::hydrate_from_persistent_storage(
+            (
+                token_cache,
+                features_cache.clone(),
+                delta_cache.clone(),
+                engine_cache.clone(),
+            ),
+            Arc::new(persister),
+        )
+        .await;
+
+        assert!(features_cache.get(&key).is_some());
+        assert!(engine_cache.get(&key).is_some());
+
+        let delta_cache = delta_cache
+            .get(&key)
+            .expect("delta cache should be hydrated from persisted features");
+        let hydration_event = delta_cache.get_hydration_event();
+        assert_eq!(hydration_event.event_id, 0);
+        assert_eq!(hydration_event.features, vec![feature]);
+        assert_eq!(hydration_event.segments, vec![segment]);
+        assert!(delta_cache.has_revision(0));
+    }
 
     #[tokio::test]
     #[cfg(feature = "enterprise")]

--- a/crates/oss/unleash-edge/src/edge_builder.rs
+++ b/crates/oss/unleash-edge/src/edge_builder.rs
@@ -179,7 +179,9 @@ async fn hydrate_from_persistent_storage(cache: CacheContainer, storage: Arc<dyn
                 ),
             );
         } else {
-            debug!("Skipping delta cache hydration for {key:?} because persisted feature set is empty");
+            debug!(
+                "Skipping delta cache hydration for {key:?} because persisted feature set is empty"
+            );
         }
     }
 }

--- a/crates/oss/unleash-edge/src/edge_builder.rs
+++ b/crates/oss/unleash-edge/src/edge_builder.rs
@@ -961,7 +961,7 @@ pub async fn resolve_license(
 #[cfg(test)]
 mod tests {
     use crate::edge_builder::build_caches;
-    use ahash::HashMap;
+    use ahash::{HashMap, HashMapExt};
     use std::env::temp_dir;
     use std::sync::Arc;
     use ulid::Ulid;

--- a/crates/oss/unleash-edge/src/edge_builder.rs
+++ b/crates/oss/unleash-edge/src/edge_builder.rs
@@ -155,6 +155,11 @@ async fn hydrate_from_persistent_storage(cache: CacheContainer, storage: Arc<dyn
         token_cache.insert(token.token.clone(), token);
     }
 
+    let last_event_ids = storage.load_last_event_ids().await.unwrap_or_else(|error| {
+        warn!("Failed to load last event ids from cache {error:?}");
+        Default::default()
+    });
+
     for (key, features) in features {
         debug!("Hydrating features for {key:?}");
         features_cache.insert(key.clone(), features.clone());
@@ -166,12 +171,14 @@ async fn hydrate_from_persistent_storage(cache: CacheContainer, storage: Arc<dyn
         }
         engine_cache.insert(key.clone(), engine_state);
 
-        if !features.features.is_empty() {
+        if !features.features.is_empty()
+            && let Some(last_event_id) = last_event_ids.get(&key)
+        {
             delta_cache.insert_cache(
                 key.as_str(),
                 DeltaCache::new(
                     DeltaHydrationEvent {
-                        event_id: 0,
+                        event_id: *last_event_id,
                         features: features.features.clone(),
                         segments: features.segments.unwrap_or_default(),
                     },
@@ -180,7 +187,7 @@ async fn hydrate_from_persistent_storage(cache: CacheContainer, storage: Arc<dyn
             );
         } else {
             debug!(
-                "Skipping delta cache hydration for {key:?} because persisted feature set is empty"
+                "Skipping delta cache hydration for {key:?} because persisted feature set is empty or missing a last event id"
             );
         }
     }
@@ -265,7 +272,6 @@ pub async fn build_edge(
         feature_cache: feature_cache.clone(),
         delta_cache_manager: delta_cache.clone(),
         engine_cache: engine_cache.clone(),
-        persistence: persistence.clone(),
         feature_config: &feature_config,
         client_meta_information: &client_meta_information,
         edge_instance_data: edge_instance_data.clone(),
@@ -752,10 +758,18 @@ fn create_edge_mode_background_tasks(
     tasks.push(hydration_task);
 
     if let Some(persistence) = persistence.clone() {
+        let delta_cache_manager = match &refresher {
+            HydratorType::Streaming(delta_refresher) => {
+                Some(delta_refresher.delta_cache_manager.clone())
+            }
+            HydratorType::Polling(_) => None,
+        };
+
         tasks.push(create_persist_data_task(
             persistence.clone(),
             token_cache.clone(),
             feature_cache.clone(),
+            delta_cache_manager,
         ));
     } else {
         info!("No persistence configured, skipping persistence");
@@ -819,7 +833,6 @@ struct LoadHydratorArgs<'a> {
     feature_cache: Arc<FeatureCache>,
     delta_cache_manager: Arc<DeltaCacheManager>,
     engine_cache: Arc<EngineCache>,
-    persistence: Option<Arc<dyn EdgePersistence>>,
     feature_config: &'a FeatureRefreshConfig,
     client_meta_information: &'a ClientMetaInformation,
     edge_instance_data: Arc<EdgeInstanceData>,
@@ -834,7 +847,6 @@ fn load_hydrator(
         feature_cache,
         delta_cache_manager,
         engine_cache,
-        persistence,
         feature_config,
         client_meta_information,
         edge_instance_data,
@@ -849,7 +861,6 @@ fn load_hydrator(
             features_cache: feature_cache.clone(),
             engine_cache: engine_cache.clone(),
             refresh_interval: features_refresh_interval,
-            persistence: persistence.clone(),
             streaming: true,
             client_meta_information: client_meta_information.clone(),
             edge_instance_data: edge_instance_data.clone(),
@@ -862,7 +873,6 @@ fn load_hydrator(
             feature_cache.clone(),
             delta_cache_manager.clone(),
             engine_cache.clone(),
-            persistence.clone(),
             feature_config.clone(),
             edge_instance_data.clone(),
         ));
@@ -878,7 +888,6 @@ fn load_hydrator(
         feature_cache,
         delta_cache_manager,
         engine_cache,
-        persistence,
         feature_config,
         client_meta_information,
         edge_instance_data,
@@ -891,7 +900,6 @@ fn load_hydrator(
         feature_cache.clone(),
         delta_cache_manager.clone(),
         engine_cache.clone(),
-        persistence.clone(),
         feature_config.clone(),
         edge_instance_data.clone(),
     ));
@@ -953,6 +961,7 @@ pub async fn resolve_license(
 #[cfg(test)]
 mod tests {
     use crate::edge_builder::build_caches;
+    use ahash::HashMap;
     use std::env::temp_dir;
     use std::sync::Arc;
     use ulid::Ulid;
@@ -986,6 +995,9 @@ mod tests {
             .save_features(vec![(key.clone(), features.clone())])
             .await
             .unwrap();
+        let mut last_event_ids = HashMap::new();
+        last_event_ids.insert(key.clone(), 42);
+        persister.save_last_event_ids(last_event_ids).await.unwrap();
 
         let (token_cache, features_cache, delta_cache, engine_cache) = build_caches();
         super::hydrate_from_persistent_storage(
@@ -1006,6 +1018,7 @@ mod tests {
             .get(&key)
             .expect("delta cache should be hydrated from persisted features");
         let hydration_event = delta_cache.get_hydration_event();
+        assert_eq!(hydration_event.event_id, 42);
         assert_eq!(hydration_event.features, vec![feature]);
         assert_eq!(hydration_event.segments, vec![segment]);
     }

--- a/crates/oss/unleash-edge/src/edge_builder.rs
+++ b/crates/oss/unleash-edge/src/edge_builder.rs
@@ -948,30 +948,11 @@ pub async fn resolve_license(
 mod tests {
     use crate::edge_builder::build_caches;
     use std::env::temp_dir;
-    #[cfg(feature = "enterprise")]
-    use std::path::Path;
-    #[cfg(feature = "enterprise")]
-    use std::str::FromStr;
     use std::sync::Arc;
     use ulid::Ulid;
     use unleash_edge_persistence::EdgePersistence;
     use unleash_edge_persistence::file::FilePersister;
     use unleash_types::client_features::{ClientFeature, ClientFeatures, Segment};
-
-    #[cfg(feature = "enterprise")]
-    use crate::edge_builder::{EdgeBuilderArgs, PersistenceArgs, build_edge};
-    #[cfg(feature = "enterprise")]
-    use chrono::Duration;
-    #[cfg(feature = "enterprise")]
-    use unleash_edge_cli::{AuthHeaders, EdgeArgs, HmacConfig};
-    #[cfg(feature = "enterprise")]
-    use unleash_edge_http_client::ClientMetaInformation;
-    #[cfg(feature = "enterprise")]
-    use unleash_edge_types::metrics::instance_data::{ApiKeyIdentity, EdgeInstanceData, Hosting};
-    #[cfg(feature = "enterprise")]
-    use unleash_edge_types::tokens::EdgeToken;
-    #[cfg(feature = "enterprise")]
-    use url::Url;
 
     #[tokio::test]
     async fn hydrates_delta_cache_from_persistent_feature_backup() {
@@ -1019,14 +1000,26 @@ mod tests {
             .get(&key)
             .expect("delta cache should be hydrated from persisted features");
         let hydration_event = delta_cache.get_hydration_event();
-        assert_eq!(hydration_event.event_id, 0);
         assert_eq!(hydration_event.features, vec![feature]);
         assert_eq!(hydration_event.segments, vec![segment]);
-        assert!(delta_cache.has_revision(0));
     }
+}
+
+#[cfg(all(test, feature = "enterprise"))]
+mod enterprise_tests {
+    use crate::edge_builder::{EdgeBuilderArgs, PersistenceArgs, build_edge};
+    use chrono::Duration;
+    use std::path::Path;
+    use std::str::FromStr;
+    use std::sync::Arc;
+    use ulid::Ulid;
+    use unleash_edge_cli::{AuthHeaders, EdgeArgs, HmacConfig};
+    use unleash_edge_http_client::ClientMetaInformation;
+    use unleash_edge_types::metrics::instance_data::{ApiKeyIdentity, EdgeInstanceData, Hosting};
+    use unleash_edge_types::tokens::EdgeToken;
+    use url::Url;
 
     #[tokio::test]
-    #[cfg(feature = "enterprise")]
     async fn restores_revision_id_from_backup_if_present() {
         let backup_folder = Path::new("../../../examples/backup/sandbox");
         let edge_args = EdgeArgs {
@@ -1111,7 +1104,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "enterprise")]
     fn rejects_multiple_tokens_same_env_in_delta() {
         let mut args = EdgeArgs {
             upstream_url: "http://localhost:4242".to_string(),
@@ -1129,7 +1121,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "enterprise")]
     fn allows_multiple_envs_in_delta() {
         let mut args = EdgeArgs {
             upstream_url: "http://localhost:4242".to_string(),
@@ -1147,7 +1138,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "enterprise")]
     fn allows_multiple_tokens_same_env_in_polling() {
         let args = EdgeArgs {
             upstream_url: "http://localhost:4242".to_string(),

--- a/crates/oss/unleash-edge/src/edge_builder.rs
+++ b/crates/oss/unleash-edge/src/edge_builder.rs
@@ -166,17 +166,21 @@ async fn hydrate_from_persistent_storage(cache: CacheContainer, storage: Arc<dyn
         }
         engine_cache.insert(key.clone(), engine_state);
 
-        delta_cache.insert_cache(
-            key.as_str(),
-            DeltaCache::new(
-                DeltaHydrationEvent {
-                    event_id: 0,
-                    features: features.features.clone(),
-                    segments: features.segments.unwrap_or_default(),
-                },
-                DELTA_CACHE_LIMIT,
-            ),
-        );
+        if !features.features.is_empty() {
+            delta_cache.insert_cache(
+                key.as_str(),
+                DeltaCache::new(
+                    DeltaHydrationEvent {
+                        event_id: 0,
+                        features: features.features.clone(),
+                        segments: features.segments.unwrap_or_default(),
+                    },
+                    DELTA_CACHE_LIMIT,
+                ),
+            );
+        } else {
+            debug!("Skipping delta cache hydration for {key:?} because persisted feature set is empty");
+        }
     }
 }
 

--- a/crates/oss/unleash-edge/src/edge_builder.rs
+++ b/crates/oss/unleash-edge/src/edge_builder.rs
@@ -172,7 +172,7 @@ async fn hydrate_from_persistent_storage(cache: CacheContainer, storage: Arc<dyn
                 DeltaHydrationEvent {
                     event_id: 0,
                     features: features.features.clone(),
-                    segments: features.segments.unwrap_or_else(|| vec![]).clone(),
+                    segments: features.segments.unwrap_or_else(std::vec::Vec::new).clone(),
                 },
                 DELTA_CACHE_LIMIT,
             ),

--- a/crates/oss/unleash-edge/src/edge_builder.rs
+++ b/crates/oss/unleash-edge/src/edge_builder.rs
@@ -172,7 +172,7 @@ async fn hydrate_from_persistent_storage(cache: CacheContainer, storage: Arc<dyn
                 DeltaHydrationEvent {
                     event_id: 0,
                     features: features.features.clone(),
-                    segments: features.segments.unwrap_or_else(std::vec::Vec::new).clone(),
+                    segments: features.segments.unwrap_or_default(),
                 },
                 DELTA_CACHE_LIMIT,
             ),

--- a/crates/oss/unleash-edge/src/edge_builder.rs
+++ b/crates/oss/unleash-edge/src/edge_builder.rs
@@ -526,6 +526,7 @@ pub async fn build_edge_state(
         deferred_validation_rx,
         edge_instance_data: edge_instance_data.clone(),
         feature_cache: features_cache.clone(),
+        delta_cache_manager: delta_cache_manager.clone(),
         instance_data_sender: instance_data_sender.clone(),
         instances_observed_for_app_context: args.instances_observed_for_app_context.clone(),
         metrics_cache_clone: metrics_cache.clone(),
@@ -618,6 +619,7 @@ fn create_shutdown_tasks(
             persistence,
             token_cache.clone(),
             feature_cache,
+            delta_cache_manager.clone(),
         ));
     }
 
@@ -650,6 +652,7 @@ pub(crate) struct BackgroundTaskArgs {
     deferred_validation_rx: Option<tokio::sync::mpsc::UnboundedReceiver<String>>,
     edge_instance_data: Arc<EdgeInstanceData>,
     feature_cache: Arc<FeatureCache>,
+    delta_cache_manager: Arc<DeltaCacheManager>,
     instance_data_sender: Arc<InstanceDataSending>,
     instances_observed_for_app_context: Arc<RwLock<Vec<EdgeInstanceData>>>,
     metrics_cache_clone: Arc<MetricsCache>,
@@ -679,6 +682,7 @@ fn create_edge_mode_background_tasks(
         deferred_validation_rx,
         edge_instance_data,
         feature_cache,
+        delta_cache_manager,
         instance_data_sender,
         instances_observed_for_app_context,
         metrics_cache_clone,
@@ -758,13 +762,6 @@ fn create_edge_mode_background_tasks(
     tasks.push(hydration_task);
 
     if let Some(persistence) = persistence.clone() {
-        let delta_cache_manager = match &refresher {
-            HydratorType::Streaming(delta_refresher) => {
-                Some(delta_refresher.delta_cache_manager.clone())
-            }
-            HydratorType::Polling(_) => None,
-        };
-
         tasks.push(create_persist_data_task(
             persistence.clone(),
             token_cache.clone(),

--- a/crates/oss/unleash-edge/src/edge_builder.rs
+++ b/crates/oss/unleash-edge/src/edge_builder.rs
@@ -171,14 +171,12 @@ async fn hydrate_from_persistent_storage(cache: CacheContainer, storage: Arc<dyn
         }
         engine_cache.insert(key.clone(), engine_state);
 
-        if !features.features.is_empty()
-            && let Some(last_event_id) = last_event_ids.get(&key)
-        {
+        if !features.features.is_empty() {
             delta_cache.insert_cache(
                 key.as_str(),
                 DeltaCache::new(
                     DeltaHydrationEvent {
-                        event_id: *last_event_id,
+                        event_id: *last_event_ids.get(&key).unwrap_or(&0),
                         features: features.features.clone(),
                         segments: features.segments.unwrap_or_default(),
                     },


### PR DESCRIPTION
This allows Edge to restart without line of sight to Unleash and still serve api/client/features when in streaming mode. Should also allow streaming clients to get their initial hydration event and continue when Unleash comes online