### PR TITLE
docs: add some details into the enterprise-edge dockerhub landing page

### DIFF
--- a/.github/workflows/build-docker-enterprise.yaml
+++ b/.github/workflows/build-docker-enterprise.yaml
@@ -214,3 +214,20 @@ jobs:
           docker buildx imagetools inspect ${{ env.DOCKERHUB_SLUG }}:${tag}
           docker buildx imagetools inspect ${{ env.GHCR_SLUG }}:${tag}
           docker buildx imagetools inspect ${{ steps.login-ecr-public.outputs.registry }}/unleashorg/unleash-edge-enterprise:${tag}
+
+  update-dockerhub-description:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    needs:
+      - merge
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.DOCKERHUB_SLUG }}
+          short-description: Enterprise Edge, a high-performance proxy for scaling Unleash SDK connections
+          readme-filepath: ./docs/dockerhub-enterprise.md

--- a/.github/workflows/build-docker-enterprise.yaml
+++ b/.github/workflows/build-docker-enterprise.yaml
@@ -13,6 +13,7 @@ on:
       - "**/*.toml"
       - "**/*.lock"
       - ".github/workflows/build-docker-enterprise.yaml"
+      - "docs/dockerhub-enterprise.md"
       - "Dockerfile"
     tags:
       - "unleash-edge-v[0-9]+.[0-9]+.[0-9]+*"
@@ -22,6 +23,7 @@ on:
       - "**/*.toml"
       - "**/*.lock"
       - ".github/workflows/build-docker-enterprise.yaml"
+      - "docs/dockerhub-enterprise.md"
       - "Dockerfile"
   workflow_dispatch:
 

--- a/docs/dockerhub-enterprise.md
+++ b/docs/dockerhub-enterprise.md
@@ -1,0 +1,49 @@
+# Unleash Enterprise Edge
+
+Unleash Enterprise Edge is a high-performance proxy layer between Unleash and your SDKs. It runs close to your
+applications, keeps feature flag data cached, and helps large installations scale client and server SDK traffic without
+increasing load on the Unleash server.
+
+This image contains the enterprise build of Unleash Edge. It requires a valid Enterprise Edge license and is intended for
+customers using the enterprise-only Edge capabilities documented at
+[docs.getunleash.io/unleash-edge](https://docs.getunleash.io/unleash-edge).
+
+## Quickstart
+
+Run Enterprise Edge in edge mode with an upstream Unleash URL and one or more client API tokens:
+
+```shell
+docker run -p 3063:3063 \
+  -e UPSTREAM_URL=<your_unleash_instance> \
+  -e TOKENS=<your_client_token> \
+  unleashorg/unleash-edge-enterprise:<version> edge
+```
+
+Once Edge is running, point SDKs at:
+
+```text
+http://localhost:3063/api
+```
+
+Replace `localhost:3063` with the host and port where your Edge instance is reachable.
+
+## Image tags
+
+Use a pinned version tag for production deployments:
+
+```shell
+docker pull unleashorg/unleash-edge-enterprise:<version>
+```
+
+The same image is also published to:
+
+- GitHub Container Registry: `ghcr.io/unleash/unleash-edge-enterprise:<version>`
+- Amazon ECR Public: `public.ecr.aws/unleashorg/unleash-edge-enterprise:<version>`
+
+## Documentation
+
+- [Enterprise Edge documentation](https://docs.getunleash.io/unleash-edge)
+- [Deploying Edge](https://docs.getunleash.io/unleash-edge/deploy)
+- [How tokens work](https://docs.getunleash.io/unleash-edge/deploy#tokens)
+- [Troubleshooting](https://docs.getunleash.io/unleash-edge/deploy#troubleshooting)
+- [Unleash Edge repository](https://github.com/Unleash/unleash-edge)

--- a/docs/dockerhub-enterprise.md
+++ b/docs/dockerhub-enterprise.md
@@ -4,8 +4,7 @@ Unleash Enterprise Edge is a high-performance proxy layer between Unleash and yo
 applications, keeps feature flag data cached, and helps large installations scale client and server SDK traffic without
 increasing load on the Unleash server.
 
-This image is the enterprise build of Unleash Edge and requires a valid license. Learn more about [Unleash Enterprise Edge](docs.getunleash.io/unleash-edge).
-customers using the enterprise-only Edge capabilities documented at
+This image is the enterprise build of Unleash Edge and requires a valid license. Learn more about [Unleash Enterprise Edge](https://docs.getunleash.io/unleash-edge).
 
 ## Quickstart
 

--- a/docs/dockerhub-enterprise.md
+++ b/docs/dockerhub-enterprise.md
@@ -4,9 +4,8 @@ Unleash Enterprise Edge is a high-performance proxy layer between Unleash and yo
 applications, keeps feature flag data cached, and helps large installations scale client and server SDK traffic without
 increasing load on the Unleash server.
 
-This image contains the enterprise build of Unleash Edge. It requires a valid Enterprise Edge license and is intended for
+This image is the enterprise build of Unleash Edge and requires a valid license. Learn more about [Unleash Enterprise Edge](docs.getunleash.io/unleash-edge).
 customers using the enterprise-only Edge capabilities documented at
-[docs.getunleash.io/unleash-edge](https://docs.getunleash.io/unleash-edge).
 
 ## Quickstart
 


### PR DESCRIPTION
This landing page is really sad: https://hub.docker.com/r/unleashorg/unleash-edge-enterprise

Compared to our other landing pages such as https://hub.docker.com/r/unleashorg/unleash-server or https://hub.docker.com/r/unleashorg/unleash-enterprise

Those two were likely done manually, but we can potentially do this in a version controlled manner as well...