### PR TITLE
fix: allow metrics buckets to be missing to support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1351,9 +1351,9 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -2300,6 +2300,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -6139,9 +6144,9 @@ dependencies = [
 
 [[package]]
 name = "unleash-types"
-version = "0.15.23"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f353106eed861507cc196874f307f466cdd5339c18d1d5542ca96ac9b1625696"
+checksum = "75aa5b25bab4826d8d9ec316332f0fa07326cf969d56589a2992ba04aa39793d"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -6154,15 +6159,15 @@ dependencies = [
 
 [[package]]
 name = "unleash-yggdrasil"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec37de350a43b5c6fdc836fe204eadb5da55b312e4cda5d543f21e24b6201117"
+checksum = "dc388a0e337e1e6aeab4508d3a49751ea7367938b5572ce19da55541d67e820e"
 dependencies = [
  "ahash",
  "chrono",
  "convert_case",
  "dashmap",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "ipnet",
  "ipnetwork",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,8 +152,8 @@ unleash-edge-request-logger = { path = "./crates/oss/unleash-edge-request-logger
 unleash-edge-streaming = { path = "./crates/enterprise/unleash-edge-streaming" }
 unleash-edge-tracing = { path = "./crates/enterprise/unleash-edge-tracing" }
 unleash-edge-types = { path = "./crates/oss/unleash-edge-types" }
-unleash-types = { version = "0.15.23", features = ["hashes", "openapi"] }
-unleash-yggdrasil = { version = "0.21.1" }
+unleash-types = { version = "0.16.1", features = ["hashes", "openapi"] }
+unleash-yggdrasil = { version = "0.21.2" }
 url = { version = "2.5.8" }
 utoipa = { version = "5.5.0", features = ["chrono", "axum_extras"] }
 utoipauto = { version = "0.3.0-alpha.2" }

--- a/crates/oss/unleash-edge-client-api/src/metrics.rs
+++ b/crates/oss/unleash-edge-client-api/src/metrics.rs
@@ -256,6 +256,18 @@ mod tests {
     }
 
     #[tokio::test]
+    pub async fn metrics_endpoint_accepts_payload_without_bucket() {
+        let metrics_cache = Arc::new(MetricsCache::default());
+        let token =
+            EdgeToken::from_str("*:development.abc123def").expect("Failed to build edge token");
+
+        let server = build_metrics_server(metrics_cache.clone()).await;
+        make_metrics_post_request_without_bucket(server, &token.token).await;
+
+        assert!(metrics_cache.metrics.is_empty());
+    }
+
+    #[tokio::test]
     pub async fn bulk_metrics_endpoint_correctly_refuses_metrics_without_auth_header() {
         let metrics_cache = Arc::new(MetricsCache::default());
         let server = build_metrics_server(metrics_cache.clone()).await;
@@ -278,7 +290,7 @@ mod tests {
             app_name: "some-app".into(),
             instance_id: Some("some-instance".into()),
             connection_id: Some("some-connection".into()),
-            bucket: MetricBucket {
+            bucket: Some(MetricBucket {
                 start: Utc.with_ymd_and_hms(1867, 11, 7, 12, 0, 0).unwrap(),
                 stop: Utc.with_ymd_and_hms(1934, 11, 7, 12, 0, 0).unwrap(),
                 toggles: hashmap! {
@@ -288,7 +300,7 @@ mod tests {
                         variants: hashmap! {}
                     }
                 },
-            },
+            }),
             environment: Some("development".into()),
             impact_metrics: Some(vec![ImpactMetric::Counter {
                 name: "test_counter".into(),
@@ -316,6 +328,29 @@ mod tests {
             .await;
         assert_eq!(r.status_code(), StatusCode::ACCEPTED);
     }
+
+    async fn make_metrics_post_request_without_bucket(server: TestServer, authorization: &str) {
+        let payload = serde_json::json!({
+            "appName": "some-app",
+            "instanceId": "some-instance",
+            "connectionId": "some-connection",
+            "environment": "development",
+            "metadata": {
+                "platformName": "test",
+                "platformVersion": "1.0",
+                "sdkVersion": "1.0",
+                "sdkType": "backend"
+            }
+        });
+
+        let r = server
+            .post("/metrics")
+            .add_header("Authorization", authorization)
+            .json(&payload)
+            .await;
+        assert_eq!(r.status_code(), StatusCode::ACCEPTED);
+    }
+
     async fn make_bulk_metrics_post_request(server: TestServer, authorization: &str) {
         let r = server
             .post("/metrics/bulk")

--- a/crates/oss/unleash-edge-metrics/src/client_impact_metrics.rs
+++ b/crates/oss/unleash-edge-metrics/src/client_impact_metrics.rs
@@ -290,7 +290,7 @@ mod test {
 
         sink_impact_metrics(
             &cache,
-            convert_to_impact_metrics_env(counter, app.into(), env.into()),
+            convert_to_impact_metrics_env(counter, app, env),
         );
 
         let key = ImpactMetricsKey {
@@ -321,7 +321,7 @@ mod test {
 
         sink_impact_metrics(
             &cache,
-            convert_to_impact_metrics_env(gauge, app.into(), env.into()),
+            convert_to_impact_metrics_env(gauge, app, env),
         );
 
         let key = ImpactMetricsKey {
@@ -351,7 +351,7 @@ mod test {
 
         sink_impact_metrics(
             &cache,
-            convert_to_impact_metrics_env(histogram, app.into(), env.into()),
+            convert_to_impact_metrics_env(histogram, app, env),
         );
 
         let key = ImpactMetricsKey {
@@ -393,14 +393,14 @@ mod test {
                 app_name: "app1".into(),
                 environment: "test".into(),
             },
-            convert_to_impact_metrics_env(app1_metrics, "app1".into(), "test".into()),
+            convert_to_impact_metrics_env(app1_metrics, "app1", "test"),
         );
         cache.impact_metrics.insert(
             ImpactMetricsKey {
                 app_name: "app2".into(),
                 environment: "test".into(),
             },
-            convert_to_impact_metrics_env(app2_metrics, "app2".into(), "test".into()),
+            convert_to_impact_metrics_env(app2_metrics, "app2", "test"),
         );
 
         let all_metrics: Vec<_> = cache
@@ -474,7 +474,7 @@ mod test {
 
         sink_impact_metrics(
             &cache,
-            convert_to_impact_metrics_env(metrics, app.into(), env.into()),
+            convert_to_impact_metrics_env(metrics, app, env),
         );
 
         let key = ImpactMetricsKey {

--- a/crates/oss/unleash-edge-metrics/src/client_impact_metrics.rs
+++ b/crates/oss/unleash-edge-metrics/src/client_impact_metrics.rs
@@ -6,12 +6,12 @@ use unleash_types::client_metrics::{ImpactMetric, ImpactMetricEnv};
 
 pub fn convert_to_impact_metrics_env(
     metrics: Vec<ImpactMetric>,
-    app_name: String,
-    environment: String,
+    app_name: &str,
+    environment: &str,
 ) -> Vec<ImpactMetricEnv> {
     metrics
         .into_iter()
-        .map(|metric| ImpactMetricEnv::new(metric, app_name.clone(), environment.clone()))
+        .map(|metric| ImpactMetricEnv::new(metric, app_name.to_string(), environment.to_string()))
         .collect()
 }
 
@@ -365,7 +365,7 @@ mod test {
                 assert_eq!(samples[0].count, 10);
                 assert_eq!(samples[0].sum, 20.0);
                 assert_eq!(samples[0].buckets[0].count, 1 + 2); // 3/3 + 7/3
-                assert_eq!(samples[0].buckets[1].count, 2 + 4); // 3*2/3 + 7*2/3  
+                assert_eq!(samples[0].buckets[1].count, 2 + 4); // 3*2/3 + 7*2/3
                 assert_eq!(samples[0].buckets[2].count, 3 + 7); // total counts
             }
             _ => panic!("Expected histogram metric"),

--- a/crates/oss/unleash-edge-metrics/src/client_impact_metrics.rs
+++ b/crates/oss/unleash-edge-metrics/src/client_impact_metrics.rs
@@ -288,10 +288,7 @@ mod test {
             ],
         )];
 
-        sink_impact_metrics(
-            &cache,
-            convert_to_impact_metrics_env(counter, app, env),
-        );
+        sink_impact_metrics(&cache, convert_to_impact_metrics_env(counter, app, env));
 
         let key = ImpactMetricsKey {
             app_name: app.into(),
@@ -319,10 +316,7 @@ mod test {
             ],
         )];
 
-        sink_impact_metrics(
-            &cache,
-            convert_to_impact_metrics_env(gauge, app, env),
-        );
+        sink_impact_metrics(&cache, convert_to_impact_metrics_env(gauge, app, env));
 
         let key = ImpactMetricsKey {
             app_name: app.into(),
@@ -349,10 +343,7 @@ mod test {
             ],
         )];
 
-        sink_impact_metrics(
-            &cache,
-            convert_to_impact_metrics_env(histogram, app, env),
-        );
+        sink_impact_metrics(&cache, convert_to_impact_metrics_env(histogram, app, env));
 
         let key = ImpactMetricsKey {
             app_name: app.into(),
@@ -472,10 +463,7 @@ mod test {
             vec![create_sample(1.0, labels)],
         )];
 
-        sink_impact_metrics(
-            &cache,
-            convert_to_impact_metrics_env(metrics, app, env),
-        );
+        sink_impact_metrics(&cache, convert_to_impact_metrics_env(metrics, app, env));
 
         let key = ImpactMetricsKey {
             app_name: app.into(),

--- a/crates/oss/unleash-edge-metrics/src/client_metrics.rs
+++ b/crates/oss/unleash-edge-metrics/src/client_metrics.rs
@@ -295,20 +295,22 @@ pub fn register_client_metrics(
         .clone()
         .unwrap_or_else(|| "development".into());
 
-    let client_metrics_env = unleash_types::client_metrics::from_bucket_app_name_and_env(
-        metrics.bucket,
-        metrics.app_name.clone(),
-        environment.clone(),
-        metrics.metadata.clone(),
-    );
-
     if let Some(impact_metrics) = metrics.impact_metrics {
         let impact_metrics_env =
-            convert_to_impact_metrics_env(impact_metrics, metrics.app_name.clone(), environment);
+            convert_to_impact_metrics_env(impact_metrics, &metrics.app_name, &environment);
         sink_impact_metrics(&metrics_cache, impact_metrics_env);
     }
 
-    sink_metrics(&metrics_cache, &client_metrics_env);
+    if let Some(bucket) = metrics.bucket {
+        let client_metrics_env = unleash_types::client_metrics::from_bucket_app_name_and_env(
+            bucket,
+            metrics.app_name.clone(),
+            environment.clone(),
+            metrics.metadata.clone(),
+        );
+
+        sink_metrics(&metrics_cache, &client_metrics_env);
+    }
 }
 
 pub fn register_bulk_metrics(


### PR DESCRIPTION
Allows metric bucket to be missing, to allow impact metrics to work without feature evaluations