### PR TITLE
feat: add single client feature endpoint

### DIFF
--- a/crates/oss/unleash-edge-client-api/src/features.rs
+++ b/crates/oss/unleash-edge-client-api/src/features.rs
@@ -84,20 +84,16 @@ pub async fn get_feature(
     AuthToken(edge_token): AuthToken,
     Path(feature_name): Path<String>,
 ) -> EdgeJsonResult<ClientFeature> {
+    let filters = FeatureFilters { name_prefix: None };
 
-    let cache_entry = app_state
-        .features_cache
-        .get(&cache_key(&edge_token))
-        .ok_or(EdgeError::ClientCacheError)?;
-
-    let feature = cache_entry
+    let Json(features) = resolve_features(&app_state, edge_token, filters).await?;
+    let feature = features
         .features
-        .iter()
-        .find(|f| f.name == feature_name)
-        .cloned()
+        .into_iter()
+        .find(|feature| feature.name == feature_name)
         .ok_or(EdgeError::FeatureNotFound(feature_name))?;
 
-    Ok(Json(feature.clone()))
+    Ok(Json(feature))
 }
 
 #[instrument(skip(app_state, edge_token, filter_query))]

--- a/crates/oss/unleash-edge-client-api/src/features.rs
+++ b/crates/oss/unleash-edge-client-api/src/features.rs
@@ -1,4 +1,4 @@
-use axum::extract::{FromRef, Query, State};
+use axum::extract::{FromRef, Path, Query, State};
 use axum::routing::get;
 use axum::{Json, Router};
 use dashmap::DashMap;
@@ -14,7 +14,7 @@ use unleash_edge_feature_refresh::{HydratorType, features_for_filter};
 use unleash_edge_types::errors::EdgeError;
 use unleash_edge_types::tokens::{EdgeToken, cache_key};
 use unleash_edge_types::{EdgeJsonResult, EdgeResult, FeatureFilters, TokenCache, TokenRefresh};
-use unleash_types::client_features::ClientFeatures;
+use unleash_types::client_features::{ClientFeature, ClientFeatures};
 
 #[utoipa::path(
     get,
@@ -60,6 +60,44 @@ pub async fn post_features(
     Query(filter_query): Query<FeatureFilters>,
 ) -> EdgeJsonResult<ClientFeatures> {
     resolve_features(&app_state, edge_token, filter_query).await
+}
+
+#[utoipa::path(
+    get,
+    path = "/features/{feature_name}",
+    context_path = "/api/client",
+    params(
+        ("feature_name" = String, Path, description = "The name of the feature")
+    ),
+    responses(
+        (status = 200, description = "Return a single feature toggle for this token", body = ClientFeature),
+        (status = 403, description = "Was not allowed to access features"),
+        (status = 404, description = "The feature was not found")
+    ),
+    security(
+        ("Authorization" = [])
+    )
+)]
+#[instrument(skip(app_state, edge_token))]
+pub async fn get_feature(
+    State(app_state): State<FeatureState>,
+    AuthToken(edge_token): AuthToken,
+    Path(feature_name): Path<String>,
+) -> EdgeJsonResult<ClientFeature> {
+
+    let cache_entry = app_state
+        .features_cache
+        .get(&cache_key(&edge_token))
+        .ok_or(EdgeError::ClientCacheError)?;
+
+    let feature = cache_entry
+        .features
+        .iter()
+        .find(|f| f.name == feature_name)
+        .cloned()
+        .ok_or(EdgeError::FeatureNotFound(feature_name))?;
+
+    Ok(Json(feature.clone()))
 }
 
 #[instrument(skip(app_state, edge_token, filter_query))]
@@ -156,9 +194,127 @@ where
     FeatureState: FromRef<S>,
     AuthState: FromRef<S>,
 {
-    Router::new().route("/features", get(get_features).post(post_features))
+    Router::new()
+        .route("/features", get(get_features).post(post_features))
+        .route("/features/{feature_name}", get(get_feature))
 }
 
 pub fn router() -> Router<AppState> {
     features_router_for::<AppState>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::extract::FromRef;
+    use axum::http::StatusCode;
+    use axum_test::TestServer;
+    use std::str::FromStr;
+    use std::sync::Arc;
+    use unleash_edge_cli::AuthHeaders;
+    use unleash_edge_types::tokens::cache_key;
+
+    #[derive(Clone)]
+    struct TestState {
+        auth: AuthState,
+        features: FeatureState,
+    }
+
+    impl FromRef<TestState> for AuthState {
+        fn from_ref(state: &TestState) -> Self {
+            state.auth.clone()
+        }
+    }
+
+    impl FromRef<TestState> for FeatureState {
+        fn from_ref(state: &TestState) -> Self {
+            state.features.clone()
+        }
+    }
+
+    fn build_server(features_cache: Arc<FeatureCache>, token_cache: Arc<TokenCache>) -> TestServer {
+        let app_state = TestState {
+            auth: AuthState {
+                auth_headers: AuthHeaders::default(),
+                token_cache: token_cache.clone(),
+            },
+            features: FeatureState {
+                tokens_to_refresh: None,
+                features_cache,
+                token_cache,
+            },
+        };
+
+        let router = features_router_for::<TestState>().with_state(app_state);
+        TestServer::builder().http_transport().build(router)
+    }
+
+    #[tokio::test]
+    async fn single_feature_endpoint_returns_feature() {
+        let token_cache = Arc::new(TokenCache::default());
+        let features_cache = Arc::new(FeatureCache::default());
+        let edge_token =
+            EdgeToken::from_str("*:development.somesecret").expect("Could not parse edge token");
+
+        token_cache.insert(edge_token.token.clone(), edge_token.clone());
+        features_cache.insert(
+            cache_key(&edge_token),
+            ClientFeatures {
+                version: 2,
+                features: vec![ClientFeature {
+                    name: "my-feature".to_string(),
+                    project: Some("default".to_string()),
+                    enabled: true,
+                    ..ClientFeature::default()
+                }],
+                query: None,
+                segments: None,
+                meta: None,
+            },
+        );
+
+        let server = build_server(features_cache, token_cache);
+
+        let response = server
+            .get("/features/my-feature")
+            .add_header("Authorization", edge_token.token)
+            .await;
+
+        response.assert_status(StatusCode::OK);
+        assert_eq!(response.json::<ClientFeature>().name, "my-feature");
+    }
+
+    #[tokio::test]
+    async fn single_feature_endpoint_returns_not_found_for_missing_feature() {
+        let token_cache = Arc::new(TokenCache::default());
+        let features_cache = Arc::new(FeatureCache::default());
+        let edge_token =
+            EdgeToken::from_str("*:development.somesecret").expect("Could not parse edge token");
+
+        token_cache.insert(edge_token.token.clone(), edge_token.clone());
+        features_cache.insert(
+            cache_key(&edge_token),
+            ClientFeatures {
+                version: 2,
+                features: vec![ClientFeature {
+                    name: "my-feature".to_string(),
+                    project: Some("default".to_string()),
+                    enabled: true,
+                    ..ClientFeature::default()
+                }],
+                query: None,
+                segments: None,
+                meta: None,
+            },
+        );
+
+        let server = build_server(features_cache, token_cache);
+
+        let response = server
+            .get("/features/unknown-feature")
+            .add_header("Authorization", edge_token.token)
+            .await;
+
+        response.assert_status(StatusCode::NOT_FOUND);
+    }
 }


### PR DESCRIPTION
Adds an endpoint that resolves a single client feature - this is so that we can match the Unleash API.

This does a few things differently because there's no real path to make them match identically:

- Edge does not include the description of the flag, think that's okay. That's already happening on the features endpoint anyway
- Edge does not respect tag filtering, because Edge does not have tags present, same on features endpoint
- Environment and project filtering are ignored, we're moving towards deprecating that on Unleash, no point in adding them in here. Environment + project are respected via the token anyway
- Name prefix filtering is ignored, in Unleash the prefix filter is set to the flag name so behavior matches