### PR TITLE
docs: openapi docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6241,8 +6241,15 @@ dependencies = [
  "serde_json",
  "url",
  "utoipa",
+ "utoipa-swagger-ui-vendored",
  "zip",
 ]
+
+[[package]]
+name = "utoipa-swagger-ui-vendored"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5539,6 +5539,7 @@ dependencies = [
  "unleash-types",
  "unleash-yggdrasil",
  "url",
+ "utoipa",
  "utoipa-swagger-ui",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1626,6 +1635,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,6 +2004,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -4137,6 +4158,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2 0.10.9",
+ "walkdir",
+]
+
+[[package]]
 name = "rust-multipart-rfc7578_2"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5484,6 +5539,7 @@ dependencies = [
  "unleash-types",
  "unleash-yggdrasil",
  "url",
+ "utoipa-swagger-ui",
 ]
 
 [[package]]
@@ -6167,6 +6223,24 @@ dependencies = [
  "quote",
  "regex",
  "syn",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "9.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
+dependencies = [
+ "axum",
+ "base64",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "url",
+ "utoipa",
+ "zip",
 ]
 
 [[package]]
@@ -6922,10 +6996,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,7 @@ unleash-yggdrasil = { version = "0.21.2" }
 url = { version = "2.5.8" }
 utoipa = { version = "5.5.0", features = ["chrono", "axum_extras"] }
 utoipauto = { version = "0.3.0-alpha.2" }
-utoipa-swagger-ui = { version = "9.0.2", features = ["axum"] }
+utoipa-swagger-ui = { version = "9.0.2", features = ["axum", "vendored"] }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/crates/oss/unleash-edge-client-api/src/lib.rs
+++ b/crates/oss/unleash-edge-client-api/src/lib.rs
@@ -45,8 +45,8 @@ impl Modify for SecurityAddon {
             SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::new("Authorization"))),
         );
 
-	// muck with the pathing a little, this gives us a nice user friendly display name,
-	// and allows us to stop the library tagging on the crate name which is just annoying noise
+        // muck with the pathing a little, this gives us a nice user friendly display name,
+        // and allows us to stop the library tagging on the crate name which is just annoying noise
         for path_item in openapi.paths.paths.values_mut() {
             if let Some(operation) = path_item.get.as_mut() {
                 operation.tags = Some(vec!["Client API".to_string()]);

--- a/crates/oss/unleash-edge-client-api/src/lib.rs
+++ b/crates/oss/unleash-edge-client-api/src/lib.rs
@@ -1,6 +1,8 @@
 use axum::{Router, extract::FromRef};
 use unleash_edge_appstate::AppState;
 use unleash_edge_appstate::edge_token_extractor::AuthState;
+use utoipa::openapi::security::{ApiKey, ApiKeyValue, SecurityScheme};
+use utoipa::{Modify, OpenApi};
 
 use crate::{
     delta::DeltaState, features::FeatureState, metrics::MetricsState, register::RegisterState,
@@ -12,6 +14,71 @@ pub mod features;
 pub mod metrics;
 pub mod register;
 pub mod streaming;
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        crate::features::get_features,
+        crate::features::post_features,
+        crate::features::get_feature,
+        crate::metrics::post_metrics,
+        crate::metrics::post_bulk_metrics,
+        crate::register::register
+    ),
+    tags(
+        (name = "Client API", description = "Unleash Edge client endpoints")
+    ),
+    modifiers(&SecurityAddon)
+)]
+pub struct ClientApiDoc;
+
+struct SecurityAddon;
+
+impl Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        let components = openapi
+            .components
+            .get_or_insert_with(utoipa::openapi::Components::new);
+
+        components.add_security_scheme(
+            "Authorization",
+            SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::new("Authorization"))),
+        );
+
+	// muck with the pathing a little, this gives us a nice user friendly display name,
+	// and allows us to stop the library tagging on the crate name which is just annoying noise
+        for path_item in openapi.paths.paths.values_mut() {
+            if let Some(operation) = path_item.get.as_mut() {
+                operation.tags = Some(vec!["Client API".to_string()]);
+            }
+            if let Some(operation) = path_item.post.as_mut() {
+                operation.tags = Some(vec!["Client API".to_string()]);
+            }
+            if let Some(operation) = path_item.put.as_mut() {
+                operation.tags = Some(vec!["Client API".to_string()]);
+            }
+            if let Some(operation) = path_item.delete.as_mut() {
+                operation.tags = Some(vec!["Client API".to_string()]);
+            }
+            if let Some(operation) = path_item.patch.as_mut() {
+                operation.tags = Some(vec!["Client API".to_string()]);
+            }
+            if let Some(operation) = path_item.options.as_mut() {
+                operation.tags = Some(vec!["Client API".to_string()]);
+            }
+            if let Some(operation) = path_item.head.as_mut() {
+                operation.tags = Some(vec!["Client API".to_string()]);
+            }
+            if let Some(operation) = path_item.trace.as_mut() {
+                operation.tags = Some(vec!["Client API".to_string()]);
+            }
+        }
+    }
+}
+
+pub fn openapi() -> utoipa::openapi::OpenApi {
+    ClientApiDoc::openapi()
+}
 
 pub fn router_for<S>() -> Router<S>
 where

--- a/crates/oss/unleash-edge-frontend-api/src/frontend.rs
+++ b/crates/oss/unleash-edge-frontend-api/src/frontend.rs
@@ -24,8 +24,8 @@ use unleash_types::frontend::{EvaluatedToggle, EvaluatedVariant, FrontendResult}
 
 #[utoipa::path(
     get,
-    path = "/all",
-    context_path = "/api/frontend",
+    path = "/frontend/all",
+    context_path = "/api",
     responses(
 (status = 200, description = "Return all known feature toggles for this token in evaluated (true|false) state", body = FrontendResult),
 (status = 403, description = "Was not allowed to access features")
@@ -45,6 +45,19 @@ pub async fn frontend_get_all_features(
     all_features(app_state, edge_token, &context, client_ip)
 }
 
+#[utoipa::path(
+    post,
+    path = "/frontend/all",
+    context_path = "/api",
+    responses(
+        (status = 200, description = "Return all known feature toggles for this token in evaluated (true|false) state", body = FrontendResult),
+        (status = 403, description = "Was not allowed to access features")
+    ),
+    request_body = Context,
+    security(
+        ("Authorization" = [])
+    )
+)]
 #[instrument(skip(app_state, edge_token, client_ip, context))]
 pub async fn frontend_post_all_features(
     State(app_state): State<FrontendState>,
@@ -55,6 +68,19 @@ pub async fn frontend_post_all_features(
     all_features(app_state, edge_token, &context, client_ip)
 }
 
+#[utoipa::path(
+    get,
+    path = "/frontend",
+    context_path = "/api",
+    responses(
+        (status = 200, description = "Return enabled feature toggles for this token in evaluated state", body = FrontendResult),
+        (status = 403, description = "Was not allowed to access features")
+    ),
+    params(Context),
+    security(
+        ("Authorization" = [])
+    )
+)]
 #[instrument(skip(app_state, edge_token, client_ip, context))]
 pub async fn frontend_get_enabled_features(
     State(app_state): State<FrontendState>,
@@ -65,6 +91,19 @@ pub async fn frontend_get_enabled_features(
     enabled_features(app_state, edge_token, &context, client_ip)
 }
 
+#[utoipa::path(
+    post,
+    path = "/frontend",
+    context_path = "/api",
+    responses(
+        (status = 200, description = "Return enabled feature toggles for this token in evaluated state", body = FrontendResult),
+        (status = 403, description = "Was not allowed to access features")
+    ),
+    request_body = Context,
+    security(
+        ("Authorization" = [])
+    )
+)]
 #[instrument(skip(app_state, edge_token, client_ip, context))]
 pub async fn frontend_post_enabled_features(
     State(app_state): State<FrontendState>,
@@ -75,6 +114,19 @@ pub async fn frontend_post_enabled_features(
     enabled_features(app_state, edge_token, &context, client_ip)
 }
 
+#[utoipa::path(
+    post,
+    path = "/frontend/client/metrics",
+    context_path = "/api",
+    responses(
+        (status = 202, description = "Accepted frontend client metrics"),
+        (status = 403, description = "Was not allowed to post metrics")
+    ),
+    request_body = ClientMetrics,
+    security(
+        ("Authorization" = [])
+    )
+)]
 #[instrument(skip(app_state, edge_token, metrics))]
 pub async fn frontend_post_metrics(
     app_state: State<FrontendState>,
@@ -92,6 +144,19 @@ pub async fn frontend_post_metrics(
         .unwrap()
 }
 
+#[utoipa::path(
+    post,
+    path = "/frontend/client/register",
+    context_path = "/api",
+    responses(
+        (status = 202, description = "Accepted frontend client application registration"),
+        (status = 403, description = "Was not allowed to register client application")
+    ),
+    request_body = ClientApplication,
+    security(
+        ("Authorization" = [])
+    )
+)]
 #[instrument(skip(app_state, edge_token, client_application))]
 pub async fn frontend_register_client(
     State(app_state): State<FrontendState>,
@@ -110,6 +175,23 @@ pub async fn frontend_register_client(
         .unwrap()
 }
 
+#[utoipa::path(
+    get,
+    path = "/frontend/features/{feature_name}",
+    context_path = "/api",
+    params(
+        ("feature_name" = String, Path, description = "The name of the feature"),
+        Context
+    ),
+    responses(
+        (status = 200, description = "Return evaluated state for a single feature", body = EvaluatedToggle),
+        (status = 403, description = "Was not allowed to access features"),
+        (status = 404, description = "The feature was not found")
+    ),
+    security(
+        ("Authorization" = [])
+    )
+)]
 #[instrument(skip(app_state, edge_token, feature_name, context, client_ip))]
 pub async fn frontend_get_feature(
     State(app_state): State<FrontendState>,
@@ -129,6 +211,23 @@ pub async fn frontend_get_feature(
     .map(Json)
 }
 
+#[utoipa::path(
+    post,
+    path = "/frontend/features/{feature_name}",
+    context_path = "/api",
+    params(
+        ("feature_name" = String, Path, description = "The name of the feature")
+    ),
+    responses(
+        (status = 200, description = "Return evaluated state for a single feature", body = EvaluatedToggle),
+        (status = 403, description = "Was not allowed to access features"),
+        (status = 404, description = "The feature was not found")
+    ),
+    request_body = Context,
+    security(
+        ("Authorization" = [])
+    )
+)]
 #[instrument(skip(app_state, edge_token, feature_name, context, client_ip))]
 pub async fn frontend_post_feature(
     State(app_state): State<FrontendState>,

--- a/crates/oss/unleash-edge-frontend-api/src/lib.rs
+++ b/crates/oss/unleash-edge-frontend-api/src/lib.rs
@@ -69,8 +69,8 @@ impl Modify for FrontendSecurityAddon {
             SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::new("Authorization"))),
         );
 
-	// muck with the pathing a little, this gives us a nice user friendly display name,
-	// and allows us to stop the library tagging on the crate name which is just annoying noise
+        // muck with the pathing a little, this gives us a nice user friendly display name,
+        // and allows us to stop the library tagging on the crate name which is just annoying noise
         for path_item in openapi.paths.paths.values_mut() {
             if let Some(operation) = path_item.get.as_mut() {
                 operation.tags = Some(vec!["Frontend API".to_string()]);

--- a/crates/oss/unleash-edge-frontend-api/src/lib.rs
+++ b/crates/oss/unleash-edge-frontend-api/src/lib.rs
@@ -12,6 +12,8 @@ use unleash_edge_types::tokens::{EdgeToken, cache_key};
 use unleash_types::client_features::Context;
 use unleash_types::frontend::{EvaluatedToggle, EvaluatedVariant, FrontendResult};
 use unleash_yggdrasil::ResolvedToggle;
+use utoipa::openapi::security::{ApiKey, ApiKeyValue, SecurityScheme};
+use utoipa::{Modify, OpenApi};
 
 use crate::frontend::FrontendState;
 
@@ -34,6 +36,73 @@ where
 pub(crate) mod client_ip;
 pub mod frontend;
 pub mod querystring_extractor;
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        crate::frontend::frontend_get_enabled_features,
+        crate::frontend::frontend_post_enabled_features,
+        crate::frontend::frontend_get_all_features,
+        crate::frontend::frontend_post_all_features,
+        crate::frontend::frontend_get_feature,
+        crate::frontend::frontend_post_feature,
+        crate::frontend::frontend_post_metrics,
+        crate::frontend::frontend_register_client
+    ),
+    tags(
+        (name = "Frontend API", description = "Unleash Edge frontend endpoints")
+    ),
+    modifiers(&FrontendSecurityAddon)
+)]
+pub struct FrontendApiDoc;
+
+struct FrontendSecurityAddon;
+
+impl Modify for FrontendSecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        let components = openapi
+            .components
+            .get_or_insert_with(utoipa::openapi::Components::new);
+
+        components.add_security_scheme(
+            "Authorization",
+            SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::new("Authorization"))),
+        );
+
+	// muck with the pathing a little, this gives us a nice user friendly display name,
+	// and allows us to stop the library tagging on the crate name which is just annoying noise
+        for path_item in openapi.paths.paths.values_mut() {
+            if let Some(operation) = path_item.get.as_mut() {
+                operation.tags = Some(vec!["Frontend API".to_string()]);
+            }
+            if let Some(operation) = path_item.post.as_mut() {
+                operation.tags = Some(vec!["Frontend API".to_string()]);
+            }
+            if let Some(operation) = path_item.put.as_mut() {
+                operation.tags = Some(vec!["Frontend API".to_string()]);
+            }
+            if let Some(operation) = path_item.delete.as_mut() {
+                operation.tags = Some(vec!["Frontend API".to_string()]);
+            }
+            if let Some(operation) = path_item.patch.as_mut() {
+                operation.tags = Some(vec!["Frontend API".to_string()]);
+            }
+            if let Some(operation) = path_item.options.as_mut() {
+                operation.tags = Some(vec!["Frontend API".to_string()]);
+            }
+            if let Some(operation) = path_item.head.as_mut() {
+                operation.tags = Some(vec!["Frontend API".to_string()]);
+            }
+            if let Some(operation) = path_item.trace.as_mut() {
+                operation.tags = Some(vec!["Frontend API".to_string()]);
+            }
+        }
+    }
+}
+
+pub fn openapi() -> utoipa::openapi::OpenApi {
+    FrontendApiDoc::openapi()
+}
 
 pub fn router(disable_all_endpoints: bool) -> Router<AppState> {
     Router::new().merge(frontend::frontend_router_for(disable_all_endpoints))

--- a/crates/oss/unleash-edge/Cargo.toml
+++ b/crates/oss/unleash-edge/Cargo.toml
@@ -53,6 +53,7 @@ tower-http = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 ulid = { workspace = true }
+utoipa-swagger-ui = { workspace = true }
 unleash-edge-appstate = { workspace = true }
 unleash-edge-auth = { workspace = true }
 unleash-edge-backstage = { workspace = true }

--- a/crates/oss/unleash-edge/Cargo.toml
+++ b/crates/oss/unleash-edge/Cargo.toml
@@ -53,6 +53,7 @@ tower-http = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 ulid = { workspace = true }
+utoipa = { workspace = true }
 utoipa-swagger-ui = { workspace = true }
 unleash-edge-appstate = { workspace = true }
 unleash-edge-auth = { workspace = true }

--- a/crates/oss/unleash-edge/src/lib.rs
+++ b/crates/oss/unleash-edge/src/lib.rs
@@ -18,7 +18,6 @@ use tower::ServiceBuilder;
 use tower_http::compression::CompressionLayer;
 use tracing::warn;
 use ulid::Ulid;
-use utoipa_swagger_ui::{Config, SwaggerUi};
 use unleash_edge_auth::token_validator::TokenValidator;
 use unleash_edge_cli::{AuthHeaders, CliArgs, EdgeMode, HmacConfig, NetworkAddr};
 use unleash_edge_delta::cache_manager::DeltaCacheManager;
@@ -37,6 +36,7 @@ use unleash_edge_types::tokens::EdgeToken;
 use unleash_edge_types::urls::UnleashUrls;
 use unleash_edge_types::{BackgroundTask, EdgeResult, EngineCache, TokenCache};
 use url::Url;
+use utoipa_swagger_ui::{Config, SwaggerUi};
 
 pub mod edge_builder;
 pub mod health_checker;
@@ -240,18 +240,18 @@ pub async fn configure_server(args: CliArgs) -> EdgeResult<(Router, Vec<Backgrou
     };
 
     let top_router: Router = Router::new()
-        .merge(SwaggerUi::new("/docs/openapi").url(
-            "/docs/openapi.json",
-            {
-                let mut openapi = unleash_edge_client_api::openapi();
-                openapi.merge(unleash_edge_frontend_api::openapi());
-                openapi.info.title = "Unleash Edge".to_string();
-                openapi.info.contact = None;
-                openapi.info.license = None;
-                openapi
-            },
+        .merge(
+            SwaggerUi::new("/docs/openapi")
+                .url("/docs/openapi.json", {
+                    let mut openapi = unleash_edge_client_api::openapi();
+                    openapi.merge(unleash_edge_frontend_api::openapi());
+                    openapi.info.title = "Unleash Edge".to_string();
+                    openapi.info.contact = None;
+                    openapi.info.license = None;
+                    openapi
+                })
+                .config(Config::default().use_base_layout()),
         )
-        .config(Config::default().use_base_layout()))
         .nest("/api", api_router)
         .nest("/edge", unleash_edge_edge_api::router())
         .nest("/internal-backstage", backstage_router)

--- a/crates/oss/unleash-edge/src/lib.rs
+++ b/crates/oss/unleash-edge/src/lib.rs
@@ -244,20 +244,15 @@ pub async fn configure_server(args: CliArgs) -> EdgeResult<(Router, Vec<Backgrou
         let base_path = args.http.base_path.trim().trim_matches('/');
         if base_path.is_empty() {
             String::new()
-            String::new()
+        } else {
             format!("/{base_path}")
-            format!("/{}", base_path.trim_matches('/'))
-
-    let openapi_json_url = if normalized_base_path.is_empty() {
-        "/docs/openapi.json".to_string()
-    } else {
-        format!("{}/docs/openapi.json", normalized_base_path)
+        }
     };
 
     let top_router: Router = Router::new()
         .merge(
             SwaggerUi::new("/docs/openapi")
-                .url(openapi_json_url, {
+                .url("/docs/openapi.json", {
                     let mut openapi = unleash_edge_client_api::openapi();
                     openapi.merge(unleash_edge_frontend_api::openapi());
                     openapi.info.title = "Unleash Edge".to_string();

--- a/crates/oss/unleash-edge/src/lib.rs
+++ b/crates/oss/unleash-edge/src/lib.rs
@@ -240,14 +240,13 @@ pub async fn configure_server(args: CliArgs) -> EdgeResult<(Router, Vec<Backgrou
         unleash_edge_backstage::router(args.internal_backstage.clone())
     };
 
-    let normalized_base_path = if args.http.base_path.len() > 1 {
-        if !args.http.base_path.starts_with('/') {
-            format!("/{}", args.http.base_path)
+    let normalized_base_path = {
+        let base_path = args.http.base_path.trim();
+        if base_path.is_empty() || base_path == "/" {
+            String::new()
         } else {
-            args.http.base_path.clone()
+            format!("/{}", base_path.trim_matches('/'))
         }
-    } else {
-        String::new()
     };
 
     let openapi_json_url = if normalized_base_path.is_empty() {

--- a/crates/oss/unleash-edge/src/lib.rs
+++ b/crates/oss/unleash-edge/src/lib.rs
@@ -18,6 +18,7 @@ use tower::ServiceBuilder;
 use tower_http::compression::CompressionLayer;
 use tracing::warn;
 use ulid::Ulid;
+use utoipa::openapi::server::Server;
 use unleash_edge_auth::token_validator::TokenValidator;
 use unleash_edge_cli::{AuthHeaders, CliArgs, EdgeMode, HmacConfig, NetworkAddr};
 use unleash_edge_delta::cache_manager::DeltaCacheManager;
@@ -239,15 +240,34 @@ pub async fn configure_server(args: CliArgs) -> EdgeResult<(Router, Vec<Backgrou
         unleash_edge_backstage::router(args.internal_backstage.clone())
     };
 
+    let normalized_base_path = if args.http.base_path.len() > 1 {
+        if !args.http.base_path.starts_with('/') {
+            format!("/{}", args.http.base_path)
+        } else {
+            args.http.base_path.clone()
+        }
+    } else {
+        String::new()
+    };
+
+    let openapi_json_url = if normalized_base_path.is_empty() {
+        "/docs/openapi.json".to_string()
+    } else {
+        format!("{}/docs/openapi.json", normalized_base_path)
+    };
+
     let top_router: Router = Router::new()
         .merge(
             SwaggerUi::new("/docs/openapi")
-                .url("/docs/openapi.json", {
+                .url(openapi_json_url, {
                     let mut openapi = unleash_edge_client_api::openapi();
                     openapi.merge(unleash_edge_frontend_api::openapi());
                     openapi.info.title = "Unleash Edge".to_string();
                     openapi.info.contact = None;
                     openapi.info.license = None;
+                    if !normalized_base_path.is_empty() {
+                        openapi.servers = Some(vec![Server::new(normalized_base_path.clone())]);
+                    }
                     openapi
                 })
                 .config(Config::default().use_base_layout()),
@@ -276,14 +296,9 @@ pub async fn configure_server(args: CliArgs) -> EdgeResult<(Router, Vec<Backgrou
         )
         .with_state(app_state);
 
-    let router_to_host = if args.http.base_path.len() > 1 {
+    let router_to_host = if !normalized_base_path.is_empty() {
         info!("Had a path different from root. Setting up a nested router");
-        let path = if !args.http.base_path.starts_with("/") {
-            format!("/{}", args.http.base_path)
-        } else {
-            args.http.base_path.clone()
-        };
-        Router::new().nest(&path, top_router)
+        Router::new().nest(&normalized_base_path, top_router)
     } else {
         top_router
     };

--- a/crates/oss/unleash-edge/src/lib.rs
+++ b/crates/oss/unleash-edge/src/lib.rs
@@ -18,7 +18,6 @@ use tower::ServiceBuilder;
 use tower_http::compression::CompressionLayer;
 use tracing::warn;
 use ulid::Ulid;
-use utoipa::openapi::server::Server;
 use unleash_edge_auth::token_validator::TokenValidator;
 use unleash_edge_cli::{AuthHeaders, CliArgs, EdgeMode, HmacConfig, NetworkAddr};
 use unleash_edge_delta::cache_manager::DeltaCacheManager;
@@ -37,6 +36,7 @@ use unleash_edge_types::tokens::EdgeToken;
 use unleash_edge_types::urls::UnleashUrls;
 use unleash_edge_types::{BackgroundTask, EdgeResult, EngineCache, TokenCache};
 use url::Url;
+use utoipa::openapi::server::Server;
 use utoipa_swagger_ui::{Config, SwaggerUi};
 
 pub mod edge_builder;

--- a/crates/oss/unleash-edge/src/lib.rs
+++ b/crates/oss/unleash-edge/src/lib.rs
@@ -241,13 +241,12 @@ pub async fn configure_server(args: CliArgs) -> EdgeResult<(Router, Vec<Backgrou
     };
 
     let normalized_base_path = {
-        let base_path = args.http.base_path.trim();
-        if base_path.is_empty() || base_path == "/" {
+        let base_path = args.http.base_path.trim().trim_matches('/');
+        if base_path.is_empty() {
             String::new()
-        } else {
+            String::new()
+            format!("/{base_path}")
             format!("/{}", base_path.trim_matches('/'))
-        }
-    };
 
     let openapi_json_url = if normalized_base_path.is_empty() {
         "/docs/openapi.json".to_string()

--- a/crates/oss/unleash-edge/src/lib.rs
+++ b/crates/oss/unleash-edge/src/lib.rs
@@ -18,6 +18,7 @@ use tower::ServiceBuilder;
 use tower_http::compression::CompressionLayer;
 use tracing::warn;
 use ulid::Ulid;
+use utoipa_swagger_ui::{Config, SwaggerUi};
 use unleash_edge_auth::token_validator::TokenValidator;
 use unleash_edge_cli::{AuthHeaders, CliArgs, EdgeMode, HmacConfig, NetworkAddr};
 use unleash_edge_delta::cache_manager::DeltaCacheManager;
@@ -239,6 +240,18 @@ pub async fn configure_server(args: CliArgs) -> EdgeResult<(Router, Vec<Backgrou
     };
 
     let top_router: Router = Router::new()
+        .merge(SwaggerUi::new("/docs/openapi").url(
+            "/docs/openapi.json",
+            {
+                let mut openapi = unleash_edge_client_api::openapi();
+                openapi.merge(unleash_edge_frontend_api::openapi());
+                openapi.info.title = "Unleash Edge".to_string();
+                openapi.info.contact = None;
+                openapi.info.license = None;
+                openapi
+            },
+        )
+        .config(Config::default().use_base_layout()))
         .nest("/api", api_router)
         .nest("/edge", unleash_edge_edge_api::router())
         .nest("/internal-backstage", backstage_router)

--- a/crates/oss/unleash-edge/src/middleware/trim_multiple_and_trailing_slashes.rs
+++ b/crates/oss/unleash-edge/src/middleware/trim_multiple_and_trailing_slashes.rs
@@ -41,6 +41,10 @@ where
 }
 
 fn trim_trailing_and_double_slashes(uri: &mut Uri) {
+    if should_skip_normalization(uri.path()) {
+        return;
+    }
+
     if !uri.path().ends_with('/') && !uri.path().contains("//") {
         return;
     }
@@ -65,6 +69,16 @@ fn trim_trailing_and_double_slashes(uri: &mut Uri) {
     if let Ok(new_uri) = Uri::from_parts(parts) {
         *uri = new_uri
     }
+}
+
+fn should_skip_normalization(path: &str) -> bool {
+    // Swagger UI relies on a trailing slash route (`/docs/openapi/`) and redirects
+    // from `/docs/openapi` to `/docs/openapi/`. Normalizing this path removes the
+    // trailing slash and causes a redirect loop.
+    path == "/docs/openapi"
+        || path == "/docs/openapi/"
+        || path.contains("/docs/openapi/")
+        || path.ends_with("/docs/openapi")
 }
 
 #[cfg(test)]
@@ -186,5 +200,19 @@ mod tests {
         let mut uri = "///foo".parse::<Uri>().unwrap();
         trim_trailing_and_double_slashes(&mut uri);
         assert_eq!(uri, "/foo");
+    }
+
+    #[test]
+    fn does_not_normalize_swagger_ui_index_path() {
+        let mut uri = "/docs/openapi/".parse::<Uri>().unwrap();
+        trim_trailing_and_double_slashes(&mut uri);
+        assert_eq!(uri, "/docs/openapi/");
+    }
+
+    #[test]
+    fn does_not_normalize_swagger_ui_nested_path() {
+        let mut uri = "/docs/openapi//index.html".parse::<Uri>().unwrap();
+        trim_trailing_and_double_slashes(&mut uri);
+        assert_eq!(uri, "/docs/openapi//index.html");
     }
 }

--- a/crates/oss/unleash-edge/src/middleware/trim_multiple_and_trailing_slashes.rs
+++ b/crates/oss/unleash-edge/src/middleware/trim_multiple_and_trailing_slashes.rs
@@ -207,9 +207,9 @@ mod tests {
     }
 
     #[test]
-    fn does_not_normalize_swagger_ui_nested_path() {
+    fn normalizes_swagger_ui_nested_path() {
         let mut uri = "/docs/openapi//index.html".parse::<Uri>().unwrap();
         trim_trailing_and_double_slashes(&mut uri);
-        assert_eq!(uri, "/docs/openapi//index.html");
+        assert_eq!(uri, "/docs/openapi/index.html");
     }
 }

--- a/crates/oss/unleash-edge/src/middleware/trim_multiple_and_trailing_slashes.rs
+++ b/crates/oss/unleash-edge/src/middleware/trim_multiple_and_trailing_slashes.rs
@@ -205,11 +205,4 @@ mod tests {
         trim_trailing_and_double_slashes(&mut uri);
         assert_eq!(uri, "/docs/openapi/");
     }
-
-    #[test]
-    fn normalizes_swagger_ui_nested_path() {
-        let mut uri = "/docs/openapi//index.html".parse::<Uri>().unwrap();
-        trim_trailing_and_double_slashes(&mut uri);
-        assert_eq!(uri, "/docs/openapi/index.html");
-    }
 }

--- a/crates/oss/unleash-edge/src/middleware/trim_multiple_and_trailing_slashes.rs
+++ b/crates/oss/unleash-edge/src/middleware/trim_multiple_and_trailing_slashes.rs
@@ -73,12 +73,9 @@ fn trim_trailing_and_double_slashes(uri: &mut Uri) {
 
 fn should_skip_normalization(path: &str) -> bool {
     // Swagger UI relies on a trailing slash route (`/docs/openapi/`) and redirects
-    // from `/docs/openapi` to `/docs/openapi/`. Normalizing this path removes the
-    // trailing slash and causes a redirect loop.
-    path == "/docs/openapi"
-        || path == "/docs/openapi/"
-        || path.contains("/docs/openapi/")
-        || path.ends_with("/docs/openapi")
+    // from `/docs/openapi` to `/docs/openapi/`. Normalizing `/docs/openapi/` would
+    // remove the trailing slash and cause a redirect loop.
+    path.ends_with("/docs/openapi/")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Adds openapi docs by tapping into the existing Utoipa macros. I've chosen to cover just the api/client and api/frontend endpoints in the first pass - something is better than nothing. I've also explicitly chosen not to cover the api/proxy endpoints, those are legacy and we can quietly let them phase out rather than encouraging them to stay alive.

I've mounted these in the exact same place that Unleash mounts them: /docs/openapi/ for the swagger docs and /docs/openapi.json for the openapi definitions. Might be weird choice in paths but I think the consistency is a better choice right now