### PR TITLE
feat: expose s3 force path style argument on CLI

### DIFF
--- a/crates/oss/unleash-edge-cli/src/lib.rs
+++ b/crates/oss/unleash-edge-cli/src/lib.rs
@@ -64,6 +64,9 @@ pub struct S3Args {
     /// Bucket name to use for storing feature and token data
     #[clap(long, env)]
     pub s3_bucket_name: Option<String>,
+    /// Force path-style addressing when using S3 persistence
+    #[clap(long, env, default_value_t = false, requires = "s3_bucket_name")]
+    pub s3_force_path_style: bool,
 }
 
 #[derive(Copy, Debug, Clone, Eq, PartialEq, PartialOrd, Ord, ValueEnum)]

--- a/crates/oss/unleash-edge-persistence/src/s3.rs
+++ b/crates/oss/unleash-edge-persistence/src/s3.rs
@@ -33,9 +33,12 @@ pub mod s3_persister {
                 bucket: bucket_name.to_string(),
             }
         }
-        pub async fn new_from_env(bucket_name: &str) -> Self {
+        pub async fn new_from_env(bucket_name: &str, force_path_style: bool) -> Self {
             let shared_config = aws_config::load_from_env().await;
-            let client = s3::Client::new(&shared_config);
+            let config = s3::config::Builder::from(&shared_config)
+                .force_path_style(force_path_style)
+                .build();
+            let client = s3::Client::from_conf(config);
             Self {
                 client,
                 bucket: bucket_name.to_string(),

--- a/crates/oss/unleash-edge/src/edge_builder.rs
+++ b/crates/oss/unleash-edge/src/edge_builder.rs
@@ -126,6 +126,7 @@ async fn get_data_source(args: &PersistenceArgs) -> Option<Arc<dyn EdgePersisten
                 .s3_bucket_name
                 .clone()
                 .expect("Clap is confused, there's no bucket name"),
+            s3_args.s3_force_path_style,
         )
         .await;
         return Some(Arc::new(s3_persister));

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -203,6 +203,9 @@ Run in edge mode
 
   Default value: `2000`
 * `--s3-bucket-name <S3_BUCKET_NAME>` — Bucket name to use for storing feature and token data
+* `--s3-force-path-style` — Force path-style addressing when using S3 persistence
+
+  Default value: `false`
 * `--client-keepalive-timeout <CLIENT_KEEPALIVE_TIMEOUT>` — Sets the keep-alive timeout for connections from Edge to
   upstream
 
@@ -269,4 +272,3 @@ Perform a ready check against a running edge instance
 This document was generated automatically by
 <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
 </i></small>
-


### PR DESCRIPTION
This is annoyingly not exposed via the AWS SDK for whatever reason through env args. So this just adds a shim to ingest it explicitly