### PR TITLE
Decrease error logging for first run a bit

### DIFF
--- a/crates/oss/unleash-edge-persistence/src/s3.rs
+++ b/crates/oss/unleash-edge-persistence/src/s3.rs
@@ -372,5 +372,20 @@ mod tests {
             let loaded_event_ids = persister.load_last_event_ids().await.unwrap();
             assert_eq!(loaded_event_ids, event_ids);
         }
+
+        #[tokio::test]
+        async fn test_s3_persister_load_last_event_ids_returns_friendly_error_on_first_run() {
+            let (_localstack, persister) = setup_s3_persister().await;
+
+            let result = persister.load_last_event_ids().await;
+
+            let Err(EdgeError::PersistenceError(msg)) = result else {
+                panic!("expected PersistenceError, got {:?}", result);
+            };
+            assert!(
+                msg.contains("expected on first run"),
+                "unexpected error message: {msg}"
+            );
+        }
     }
 }

--- a/crates/oss/unleash-edge-persistence/src/s3.rs
+++ b/crates/oss/unleash-edge-persistence/src/s3.rs
@@ -94,7 +94,11 @@ pub mod s3_persister {
                 .send()
                 .await
                 .map_err(|err| {
-                    if err.as_service_error().map(|e| e.is_no_such_key()).unwrap_or(false) {
+                    if err
+                        .as_service_error()
+                        .map(|e| e.is_no_such_key())
+                        .unwrap_or(false)
+                    {
                         return EdgeError::PersistenceError("No features found".to_string());
                     }
                     EdgeError::PersistenceError(format!("Failed to load features: {err:?}"))
@@ -248,7 +252,8 @@ mod tests {
         use unleash_types::client_features::ClientFeature;
         use unleash_types::client_features::ClientFeatures;
 
-        async fn setup_s3_persister_with_missing_bucket() -> (ContainerAsync<LocalStack>, S3Persister) {
+        async fn setup_s3_persister_with_missing_bucket()
+        -> (ContainerAsync<LocalStack>, S3Persister) {
             let localstack = LocalStack::default()
                 .with_env_var("SERVICES", "s3")
                 .start()

--- a/crates/oss/unleash-edge-persistence/src/s3.rs
+++ b/crates/oss/unleash-edge-persistence/src/s3.rs
@@ -94,7 +94,7 @@ pub mod s3_persister {
                 .send()
                 .await
                 .map_err(|err| {
-                    if err.to_string().contains("NoSuchKey") {
+                    if err.as_service_error().map(|e| e.is_no_such_key()).unwrap_or(false) {
                         return EdgeError::PersistenceError("No features found".to_string());
                     }
                     EdgeError::PersistenceError(format!("Failed to load features: {err:?}"))
@@ -208,7 +208,7 @@ pub mod s3_persister {
                 .send()
                 .await
                 .map_err(|e| {
-                    if e.to_string().contains("NoSuchKey") {
+                    if e.as_service_error().map(|e| e.is_no_such_key()).unwrap_or(false) {
                         return EdgeError::PersistenceError(
                             "No last event ids found in S3. This is expected on first run. \
                              If this persists, check that Edge has write permissions to your S3 bucket."
@@ -247,6 +247,32 @@ mod tests {
         use unleash_edge_types::tokens::EdgeToken;
         use unleash_types::client_features::ClientFeature;
         use unleash_types::client_features::ClientFeatures;
+
+        async fn setup_s3_persister_with_missing_bucket() -> (ContainerAsync<LocalStack>, S3Persister) {
+            let localstack = LocalStack::default()
+                .with_env_var("SERVICES", "s3")
+                .start()
+                .await
+                .expect("Failed to start localstack");
+
+            let local_stack_ip = localstack.get_host().await.expect("Could not get host");
+            let local_stack_port = localstack
+                .get_host_port_ipv4(4566)
+                .await
+                .expect("Could not get port");
+
+            let config = s3::config::Config::builder()
+                .region(Region::new("us-east-1"))
+                .endpoint_url(format!("http://{}:{}", local_stack_ip, local_stack_port))
+                .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
+                .force_path_style(true)
+                .build();
+
+            (
+                localstack,
+                S3Persister::new_with_config("nonexistent-bucket", config),
+            )
+        }
 
         async fn setup_s3_persister() -> (ContainerAsync<LocalStack>, S3Persister) {
             let localstack = LocalStack::default()
@@ -371,6 +397,44 @@ mod tests {
                 .unwrap();
             let loaded_event_ids = persister.load_last_event_ids().await.unwrap();
             assert_eq!(loaded_event_ids, event_ids);
+        }
+
+        #[tokio::test]
+        async fn test_s3_persister_load_features_returns_empty_map_on_other_s3_error() {
+            let (_localstack, persister) = setup_s3_persister_with_missing_bucket().await;
+
+            let result = persister.load_features().await;
+
+            assert_eq!(result.unwrap(), HashMap::default());
+        }
+
+        #[tokio::test]
+        async fn test_s3_persister_load_last_event_ids_returns_persistence_error_on_other_s3_error()
+        {
+            let (_localstack, persister) = setup_s3_persister_with_missing_bucket().await;
+
+            let result = persister.load_last_event_ids().await;
+
+            let Err(EdgeError::PersistenceError(msg)) = result else {
+                panic!("expected PersistenceError, got {:?}", result);
+            };
+            assert!(
+                !msg.contains("expected on first run"),
+                "unexpected friendly message for non-NoSuchKey error: {msg}"
+            );
+            assert!(
+                msg.contains("Failed to load last event ids"),
+                "unexpected error message: {msg}"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_s3_persister_load_features_returns_empty_map_when_no_key_exists() {
+            let (_localstack, persister) = setup_s3_persister().await;
+
+            let result = persister.load_features().await;
+
+            assert_eq!(result.unwrap(), HashMap::default());
         }
 
         #[tokio::test]

--- a/crates/oss/unleash-edge-persistence/src/s3.rs
+++ b/crates/oss/unleash-edge-persistence/src/s3.rs
@@ -208,6 +208,13 @@ pub mod s3_persister {
                 .send()
                 .await
                 .map_err(|e| {
+                    if e.to_string().contains("NoSuchKey") {
+                        return EdgeError::PersistenceError(
+                            "No last event ids found in S3. This is expected on first run. \
+                             If this persists, check that Edge has write permissions to your S3 bucket."
+                                .to_string(),
+                        );
+                    }
                     EdgeError::PersistenceError(format!("Failed to load last event ids: {e:?}"))
                 })?;
             let data = response.body.collect().await.map_err(|e| {


### PR DESCRIPTION


It seems that logging this error was confusing for customers - nothing is really wrong on the first run. 

I added error in https://github.com/Unleash/unleash-edge/pull/1672/changes#diff-9ae328e49f01398e440d9ca76601c00c41644c241f2aab403ef3802d9da07785L217

I think it still makes sense to log weird issues, but missing key already is handled differently in `load_features` so it probably should here too. 

But, the other option is to just go back to the previous message. 

