### PR TITLE
feat: add SDK flavor to Edge's frontend client metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6153,9 +6153,9 @@ dependencies = [
 
 [[package]]
 name = "unleash-types"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75aa5b25bab4826d8d9ec316332f0fa07326cf969d56589a2992ba04aa39793d"
+checksum = "ecf1d95c8d28530377cb1d80e006cb8144f859fc36962268bef88b2526666bfc"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ unleash-edge-request-logger = { path = "./crates/oss/unleash-edge-request-logger
 unleash-edge-streaming = { path = "./crates/enterprise/unleash-edge-streaming" }
 unleash-edge-tracing = { path = "./crates/enterprise/unleash-edge-tracing" }
 unleash-edge-types = { path = "./crates/oss/unleash-edge-types" }
-unleash-types = { version = "0.16.1", features = ["hashes", "openapi"] }
+unleash-types = { version = "0.16.2", features = ["hashes", "openapi"] }
 unleash-yggdrasil = { version = "0.21.4" }
 url = { version = "2.5.8" }
 utoipa = { version = "5.5.0", features = ["chrono", "axum_extras"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,6 @@ RUN dpkg --add-architecture arm64 \
     protobuf-compiler \
     g++-aarch64-linux-gnu \
     libc6-dev-arm64-cross \
-    libzip-dev:arm64 \
     ca-certificates \
     && rustup target add aarch64-unknown-linux-gnu \
     && rustup toolchain install stable-aarch64-unknown-linux-gnu --force-non-host \

--- a/crates/oss/unleash-edge-client-api/src/metrics.rs
+++ b/crates/oss/unleash-edge-client-api/src/metrics.rs
@@ -211,6 +211,8 @@ mod tests {
                 sdk_version: None,
                 sdk_type: None,
                 yggdrasil_version: None,
+                sdk_flavor: None,
+                sdk_flavor_version: None,
             },
         };
 
@@ -320,6 +322,8 @@ mod tests {
                 sdk_version: Some("1.0".into()),
                 sdk_type: Some(Backend),
                 yggdrasil_version: None,
+                sdk_flavor: None,
+                sdk_flavor_version: None,
             },
         };
         let r = server
@@ -374,6 +378,8 @@ mod tests {
                             sdk_version: None,
                             sdk_type: None,
                             yggdrasil_version: None,
+                            sdk_flavor: None,
+                            sdk_flavor_version: None,
                         },
                     }],
                     metrics: vec![ClientMetricsEnv {
@@ -390,6 +396,8 @@ mod tests {
                             sdk_version: None,
                             sdk_type: None,
                             yggdrasil_version: None,
+                            sdk_flavor: None,
+                            sdk_flavor_version: None,
                         },
                     }],
                     impact_metrics: Some(vec![ImpactMetric::Counter {

--- a/crates/oss/unleash-edge-feature-refresh/src/lib.rs
+++ b/crates/oss/unleash-edge-feature-refresh/src/lib.rs
@@ -197,6 +197,8 @@ fn client_application_from_token_and_name(
             sdk_version: Some(format!("unleash-edge:{}", build::PKG_VERSION)),
             sdk_type: Some(SdkType::Backend),
             yggdrasil_version: None,
+            sdk_flavor: None,
+            sdk_flavor_version: None,
         },
     }
 }

--- a/crates/oss/unleash-edge-metrics/src/client_impact_metrics.rs
+++ b/crates/oss/unleash-edge-metrics/src/client_impact_metrics.rs
@@ -271,7 +271,7 @@ mod test {
                 sdk_type: None,
                 yggdrasil_version: None,
                 sdk_flavor: None,
-                sdk_flavor_version: None,    
+                sdk_flavor_version: None,
             },
         }
     }

--- a/crates/oss/unleash-edge-metrics/src/client_impact_metrics.rs
+++ b/crates/oss/unleash-edge-metrics/src/client_impact_metrics.rs
@@ -270,6 +270,8 @@ mod test {
                 sdk_version: None,
                 sdk_type: None,
                 yggdrasil_version: None,
+                sdk_flavor: None,
+                sdk_flavor_version: None,    
             },
         }
     }

--- a/crates/oss/unleash-edge-metrics/src/client_metrics.rs
+++ b/crates/oss/unleash-edge-metrics/src/client_metrics.rs
@@ -379,6 +379,8 @@ mod test {
                 sdk_version: None,
                 sdk_type: None,
                 yggdrasil_version: None,
+                sdk_flavor: None,
+                sdk_flavor_version: None,
             },
         };
 
@@ -419,6 +421,8 @@ mod test {
                 sdk_version: None,
                 sdk_type: None,
                 yggdrasil_version: None,
+                sdk_flavor: None,
+                sdk_flavor_version: None,
             },
         };
 
@@ -452,6 +456,8 @@ mod test {
                 sdk_version: None,
                 sdk_type: None,
                 yggdrasil_version: None,
+                sdk_flavor: None,
+                sdk_flavor_version: None,
             },
         };
 
@@ -492,6 +498,8 @@ mod test {
                 sdk_version: None,
                 sdk_type: None,
                 yggdrasil_version: None,
+                sdk_flavor: None,
+                sdk_flavor_version: None,
             },
         };
 
@@ -519,6 +527,8 @@ mod test {
                 sdk_version: None,
                 sdk_type: None,
                 yggdrasil_version: None,
+                sdk_flavor: None,
+                sdk_flavor_version: None,
             },
         };
 
@@ -556,6 +566,8 @@ mod test {
                 sdk_version: None,
                 sdk_type: None,
                 yggdrasil_version: None,
+                sdk_flavor: None,
+                sdk_flavor_version: None,
             },
         };
 
@@ -590,6 +602,8 @@ mod test {
                 sdk_version: None,
                 sdk_type: None,
                 yggdrasil_version: None,
+                sdk_flavor: None,
+                sdk_flavor_version: None,
             },
         };
         let connected_via_test_instance = client_application.connect_via("test", "instance");
@@ -636,6 +650,8 @@ mod test {
                 sdk_version: None,
                 sdk_type: None,
                 yggdrasil_version: None,
+                sdk_flavor: None,
+                sdk_flavor_version: None,
             },
         };
 
@@ -684,6 +700,8 @@ mod test {
                         sdk_version: None,
                         sdk_type: None,
                         yggdrasil_version: None,
+                        sdk_flavor: None,
+                        sdk_flavor_version: None,
                     },
                 },
                 ClientMetricsEnv {
@@ -700,6 +718,8 @@ mod test {
                         sdk_version: None,
                         sdk_type: None,
                         yggdrasil_version: None,
+                        sdk_flavor: None,
+                        sdk_flavor_version: None,
                     },
                 },
             ],
@@ -732,6 +752,8 @@ mod test {
                     sdk_version: None,
                     sdk_type: None,
                     yggdrasil_version: None,
+                    sdk_flavor: None,
+                    sdk_flavor_version: None,
                 },
             },
             ClientMetricsEnv {
@@ -748,6 +770,8 @@ mod test {
                     sdk_version: None,
                     sdk_type: None,
                     yggdrasil_version: None,
+                    sdk_flavor: None,
+                    sdk_flavor_version: None,
                 },
             },
         ];

--- a/crates/oss/unleash-edge-metrics/src/metric_batching.rs
+++ b/crates/oss/unleash-edge-metrics/src/metric_batching.rs
@@ -184,7 +184,7 @@ mod tests {
                 sdk_type: Some(Backend),
                 yggdrasil_version: None,
                 sdk_flavor: None,
-                sdk_flavor_version: None,    
+                sdk_flavor_version: None,
             },
         }
     }
@@ -210,7 +210,7 @@ mod tests {
                 sdk_type: None,
                 yggdrasil_version: None,
                 sdk_flavor: None,
-                sdk_flavor_version: None,    
+                sdk_flavor_version: None,
             },
         }
     }

--- a/crates/oss/unleash-edge-metrics/src/metric_batching.rs
+++ b/crates/oss/unleash-edge-metrics/src/metric_batching.rs
@@ -183,6 +183,8 @@ mod tests {
                 sdk_version: Some("some-test-sdk".into()),
                 sdk_type: Some(Backend),
                 yggdrasil_version: None,
+                sdk_flavor: None,
+                sdk_flavor_version: None,    
             },
         }
     }
@@ -207,6 +209,8 @@ mod tests {
                 sdk_version: None,
                 sdk_type: None,
                 yggdrasil_version: None,
+                sdk_flavor: None,
+                sdk_flavor_version: None,    
             },
         }
     }


### PR DESCRIPTION
## About the changes

[Now](https://github.com/Unleash/unleash-types-rs/pull/155) that "unleash-types" carry`sdkFlavor`, `sdkFlavorVersion` on `MetricsMetadata`.

We bump to v0.16.2 of "unleash-types" lib to point to latest schema changes.

Backend SDKs are already fine - they send flavor in their registration.


Note: 

1. no flavour -> the fields are simply absent (`skip_serializing_if` on the type), so old clients and old Unleash behave exactly as before (fully backwards-compatible)
2. fix commit: omit :arm64 nothing installs this package anymore - to fix build workflow
