### PR TITLE
chore: different redacted format for v2 tokens

### DIFF
--- a/crates/oss/unleash-edge-types/src/tokens.rs
+++ b/crates/oss/unleash-edge-types/src/tokens.rs
@@ -340,7 +340,8 @@ pub struct RequestTokensArg {
 
 #[cfg(test)]
 mod tests {
-    use crate::{EdgeTokens, TokenValidationStatus};
+    use super::*;
+    use crate::EdgeTokens;
     use serde_json::json;
 
     #[test]
@@ -362,5 +363,28 @@ mod tests {
             edge_tokens.tokens.first().unwrap().status,
             TokenValidationStatus::Validated
         );
+    }
+
+    #[test]
+    fn anonymize_token_strips_legacy_token_secret() {
+        let token = crate::EdgeToken {
+            token: "*:development.abcdefghijklmnopqrstuvwxyz123456".to_string(),
+            ..Default::default()
+        };
+        let anonymized = anonymize_token(&token);
+        assert_eq!(
+            anonymized.token,
+            "*:development.abcdef****123456".to_string()
+        );
+    }
+
+    #[test]
+    fn anonymize_token_strips_new_token_secret() {
+        let token = crate::EdgeToken {
+            token: "*:development.v2_selector_abcdefghijklmnopqrstuvwxyz123456".to_string(),
+            ..Default::default()
+        };
+        let anonymized = anonymize_token(&token);
+        assert_eq!(anonymized.token, "*:development.v2_selector".to_string());
     }
 }

--- a/crates/oss/unleash-edge-types/src/tokens.rs
+++ b/crates/oss/unleash-edge-types/src/tokens.rs
@@ -309,33 +309,26 @@ fn filter_unique_tokens(tokens: &[TokenRefresh]) -> Vec<TokenRefresh> {
 }
 
 pub fn anonymize_token(edge_token: &EdgeToken) -> EdgeToken {
-    let mut iterator = edge_token.token.split('.');
-    let project_and_environment = iterator.next();
-    let maybe_hash = iterator.next();
-    match (project_and_environment, maybe_hash) {
-        (Some(p_and_e), Some(hash)) => {
-            let safe_secret = redact_secret(hash);
-            EdgeToken {
-                token: format!("{}.{}", p_and_e, safe_secret),
-                ..edge_token.clone()
-            }
-        }
-        _ => edge_token.clone(),
-    }
-}
+    let parts: Vec<&str> = edge_token.token.split([':', '.', '_']).collect();
 
-fn redact_secret(hash: &str) -> String {
-    if hash.starts_with("v2_") && hash.contains('_') {
-        let parts: Vec<&str> = hash.split('_').collect();
-        if parts.len() == 3 {
-            return format!("{}_{}_****", parts[1], &parts[2]);
+    let secret = match parts.as_slice() {
+        [environment, projects, hash] => {
+            format!(
+                "{environment}:{projects}.{}****{}",
+                &hash[..6],
+                &hash[hash.len() - 6..]
+            )
         }
+        [environment, projects, version, selector, _secret] => {
+            format!("{environment}:{projects}.{version}_{selector}")
+        }
+        _ => edge_token.token.to_string(),
+    };
+
+    EdgeToken {
+        token: secret,
+        ..edge_token.clone()
     }
-    format!(
-        "{}****{}",
-        &hash[..6].to_string(),
-        &hash[hash.len() - 6..].to_string()
-    )
 }
 
 pub struct RequestTokensArg {

--- a/crates/oss/unleash-edge-types/src/tokens.rs
+++ b/crates/oss/unleash-edge-types/src/tokens.rs
@@ -314,16 +314,23 @@ pub fn anonymize_token(edge_token: &EdgeToken) -> EdgeToken {
     let maybe_hash = iterator.next();
     match (project_and_environment, maybe_hash) {
         (Some(p_and_e), Some(hash)) => {
-            let safe_hash = clean_hash(hash);
+            let safe_secret = redact_secret(hash);
             EdgeToken {
-                token: format!("{}.{}", p_and_e, safe_hash),
+                token: format!("{}.{}", p_and_e, safe_secret),
                 ..edge_token.clone()
             }
         }
         _ => edge_token.clone(),
     }
 }
-fn clean_hash(hash: &str) -> String {
+
+fn redact_secret(hash: &str) -> String {
+    if hash.starts_with("v2_") && hash.contains('_') {
+        let parts: Vec<&str> = hash.split('_').collect();
+        if parts.len() == 3 {
+            return format!("{}_{}_****", parts[1], &parts[2]);
+        }
+    }
     format!(
         "{}****{}",
         &hash[..6].to_string(),


### PR DESCRIPTION
The old scheme for redacting tokens trims out first 6 characters of the secret. For v2 tokens that means we're left with 3 characters of the selector - that's typically not enough to identify the token in a meaningful way. This gives v2 tokens a new redaction format so they include their whole selector - that's effectively their id property so it's ideal for safe identification 