### PR TITLE
chore: core node worker enricher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5738,6 +5738,8 @@ version = "20.4.1"
 dependencies = [
  "serde",
  "serde_json",
+ "tokio",
+ "tracing",
  "unleash-types",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5741,6 +5741,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "tracing-test",
  "unleash-types",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5733,6 +5733,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "unleash-edge-context-enrichers"
+version = "20.4.1"
+dependencies = [
+ "serde",
+ "serde_json",
+ "unleash-types",
+]
+
+[[package]]
 name = "unleash-edge-delta"
 version = "20.4.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5738,6 +5738,7 @@ version = "20.4.1"
 dependencies = [
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "unleash-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ unleash-edge-auth = { path = "./crates/oss/unleash-edge-auth" }
 unleash-edge-backstage = { path = "./crates/oss/unleash-edge-backstage" }
 unleash-edge-cli = { path = "./crates/oss/unleash-edge-cli" }
 unleash-edge-client-api = { path = "./crates/oss/unleash-edge-client-api" }
+unleash-edge-context-enrichers = { path = "./crates/enterprise/unleash-edge-context-enrichers" }
 unleash-edge-delta = { path = "./crates/enterprise/unleash-edge-delta" }
 unleash-edge-edge-api = { path = "./crates/oss/unleash-edge-edge-api" }
 unleash-edge-enterprise = { path = "./crates/enterprise/unleash-edge-enterprise" }

--- a/crates/enterprise/unleash-edge-context-enrichers/Cargo.toml
+++ b/crates/enterprise/unleash-edge-context-enrichers/Cargo.toml
@@ -17,3 +17,4 @@ unleash-types = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.23.0"
+tracing-test = { workspace = true }

--- a/crates/enterprise/unleash-edge-context-enrichers/Cargo.toml
+++ b/crates/enterprise/unleash-edge-context-enrichers/Cargo.toml
@@ -11,6 +11,9 @@ license-file = "../../../LICENSE-ENTERPRISE.md"
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["io-util", "process", "sync", "time"] }
 tracing = { workspace = true }
 unleash-types = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3.23.0"

--- a/crates/enterprise/unleash-edge-context-enrichers/Cargo.toml
+++ b/crates/enterprise/unleash-edge-context-enrichers/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "unleash-edge-context-enrichers"
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+edition.workspace = true
+publish = false
+license-file = "../../../LICENSE-ENTERPRISE.md"
+
+[dependencies]
+unleash-types = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/enterprise/unleash-edge-context-enrichers/Cargo.toml
+++ b/crates/enterprise/unleash-edge-context-enrichers/Cargo.toml
@@ -9,6 +9,8 @@ publish = false
 license-file = "../../../LICENSE-ENTERPRISE.md"
 
 [dependencies]
-unleash-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+unleash-types = { workspace = true }

--- a/crates/enterprise/unleash-edge-context-enrichers/src/lib.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/lib.rs
@@ -1,3 +1,2 @@
 mod protocol;
 mod worker;
-mod worker_pool;

--- a/crates/enterprise/unleash-edge-context-enrichers/src/lib.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/lib.rs
@@ -1,0 +1,3 @@
+mod protocol;
+mod worker;
+mod worker_pool;

--- a/crates/enterprise/unleash-edge-context-enrichers/src/protocol.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/protocol.rs
@@ -10,9 +10,9 @@ pub(crate) struct EnrichmentRequest {
 }
 
 pub(crate) struct EnrichmentResponse {
-    #[expect(dead_code)]
+    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) id: i64,
-    #[expect(dead_code)]
+    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) outcome: Result<Context, String>,
 }
 

--- a/crates/enterprise/unleash-edge-context-enrichers/src/protocol.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/protocol.rs
@@ -1,0 +1,99 @@
+use serde::{Deserialize, Deserializer};
+use std::collections::HashMap;
+use unleash_types::client_features::Context;
+
+pub(crate) struct EnrichmentRequest {
+    pub(crate) id: i64,
+    pub(crate) context: Context,
+    pub(crate) headers: HashMap<String, String>,
+}
+
+pub(crate) struct EnrichmentResponse {
+    pub(crate) id: i64,
+    pub(crate) outcome: Result<Context, String>,
+}
+
+pub(crate) enum StateMessage {
+    Ready,
+    Error(String),
+    Closing,
+}
+
+#[derive(Deserialize)]
+struct ProtocolEnrichmentResponse {
+    pub(crate) id: i64,
+    pub(crate) context: Option<Context>,
+    pub(crate) error: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for EnrichmentResponse {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // yeah life sucks here - this is borked on the wire, but importantly this is not
+        // a worker telling us about an error state, this is a worker who's unable to communicate with
+        // us effectively for some reason - most likely a bug in the protocol itself. Either way, this is
+        // a different type of error from a worker reporting a protocol enrichment error
+        let protocol_response = ProtocolEnrichmentResponse::deserialize(deserializer)?;
+
+        match (protocol_response.context, protocol_response.error) {
+            (Some(context), None) => Ok(EnrichmentResponse {
+                id: protocol_response.id,
+                outcome: Ok(context),
+            }),
+            (None, Some(error)) => {
+                // errors here are happy path - user defined script is having a moment, but imporatntly, nothing is wrong with our system
+                Ok(EnrichmentResponse {
+                    id: protocol_response.id,
+                    outcome: Err(error),
+                })
+            }
+            (Some(_), Some(_)) => Err(serde::de::Error::custom(
+                "Context enricher protocol error: both context and error are set",
+            )),
+            (None, None) => Err(serde::de::Error::custom(
+                "Context enricher protocol error: response must contain either context or error",
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserializing_happy_path_enrichment_response_works() {
+        let json = r#"{"id": 1, "context": {"userId": "123"}, "error": null}"#;
+        let response: EnrichmentResponse = serde_json::from_str(json)
+            .expect("Failed to deserialize happy path enrichment response");
+
+        assert_eq!(response.id, 1);
+        assert!(response.outcome.is_ok());
+        assert_eq!(response.outcome.unwrap().user_id.as_deref(), Some("123"));
+    }
+
+    #[test]
+    fn test_deserializing_error_path_enrichment_response_works() {
+        let json = r#"{"id": 2, "context": null, "error": "Some error occurred"}"#;
+        let response: EnrichmentResponse = serde_json::from_str(json)
+            .expect("Failed to deserialize error path enrichment response");
+
+        assert_eq!(response.id, 2);
+        assert!(response.outcome.is_err());
+        assert_eq!(response.outcome.unwrap_err(), "Some error occurred");
+    }
+
+    #[test]
+    fn broken_protocol_message_errors() {
+        let json = r#"{"id": 3, "context": {"userId": "123"}, "error": "Some error occurred"}"#;
+        let both_fields_set_response: Result<EnrichmentResponse, _> = serde_json::from_str(json);
+
+        let json = r#"{"id": 4, "context": null, "error": null}"#;
+        let neither_field_set_response: Result<EnrichmentResponse, _> = serde_json::from_str(json);
+
+        assert!(both_fields_set_response.is_err());
+        assert!(neither_field_set_response.is_err());
+    }
+}

--- a/crates/enterprise/unleash-edge-context-enrichers/src/protocol.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/protocol.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
 use unleash_types::client_features::Context;
 
+#[expect(dead_code)]
 pub(crate) struct EnrichmentRequest {
     pub(crate) id: i64,
     pub(crate) context: Context,
@@ -9,14 +10,16 @@ pub(crate) struct EnrichmentRequest {
 }
 
 pub(crate) struct EnrichmentResponse {
+    #[expect(dead_code)]
     pub(crate) id: i64,
+    #[expect(dead_code)]
     pub(crate) outcome: Result<Context, String>,
 }
 
-pub(crate) enum StateMessage {
-    Ready,
-    Error(String),
-    Closing,
+#[derive(Deserialize)]
+pub(crate) struct ReadyMessage {
+    #[serde(rename = "messageType")]
+    pub _message_type: String,
 }
 
 #[derive(Deserialize)]

--- a/crates/enterprise/unleash-edge-context-enrichers/src/protocol.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/protocol.rs
@@ -99,4 +99,19 @@ mod tests {
         assert!(both_fields_set_response.is_err());
         assert!(neither_field_set_response.is_err());
     }
+
+    #[test]
+    fn malformed_enrichment_response_errors() {
+        let response: Result<EnrichmentResponse, _> = serde_json::from_str("not-json");
+
+        assert!(response.is_err());
+    }
+
+    #[test]
+    fn ready_message_deserializes() {
+        let ready: ReadyMessage = serde_json::from_str(r#"{"messageType":"ready"}"#)
+            .expect("Failed to deserialize ready message");
+
+        assert_eq!(ready._message_type, "ready");
+    }
 }

--- a/crates/enterprise/unleash-edge-context-enrichers/src/protocol.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/protocol.rs
@@ -46,7 +46,7 @@ impl<'de> Deserialize<'de> for EnrichmentResponse {
                 outcome: Ok(context),
             }),
             (None, Some(error)) => {
-                // errors here are happy path - user defined script is having a moment, but imporatntly, nothing is wrong with our system
+                // errors here are happy path - user defined script is having a moment, but importantly, nothing is wrong with our system
                 Ok(EnrichmentResponse {
                     id: protocol_response.id,
                     outcome: Err(error),

--- a/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
@@ -243,16 +243,6 @@ mod tests {
     use tokio::io::AsyncWriteExt;
 
     fn node_is_available() -> bool {
-        // very stupid hack - right now CI doesn't have a Node runtime
-        // available and I don't want to add it. So we'll skip these on CI
-        // but I'm a banana who forgets things so I'm putting a time-bomb on this
-        // if this check is still here Aug 26 we fail so someone (me) needs to fix it
-
-        assert!(
-            std::time::SystemTime::now()
-                < std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1787695200)
-        );
-
         StdCommand::new(resolve_node_path())
             .arg("--version")
             .output()

--- a/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
@@ -268,6 +268,7 @@ mod tests {
         command
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn worker_sends_and_reads_happy_path_messages_to_child() {
         let command = fake_child_command(

--- a/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
@@ -214,3 +214,149 @@ fn resolve_node_path() -> PathBuf {
         .find(|path| path.is_file())
         .unwrap_or(node)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        fs,
+        io::{BufRead, BufReader as StdBufReader, Read, Write},
+        path::Path,
+        process::{Child as StdChild, Command as StdCommand},
+    };
+    use tempfile::{NamedTempFile, TempPath};
+
+    fn node_is_available() -> bool {
+        StdCommand::new(resolve_node_path())
+            .arg("--version")
+            .output()
+            .is_ok_and(|output| output.status.success())
+    }
+
+    fn write_temp_enricher(source: &str) -> TempPath {
+        let file = NamedTempFile::with_suffix(".cjs").expect("failed to create temp enricher file");
+        let path = file.into_temp_path();
+        fs::write(&path, source).expect("failed to write temp enricher script");
+        path
+    }
+
+    fn spawn_worker_script(enricher_script: &Path) -> StdChild {
+        StdCommand::new(resolve_node_path())
+            .arg("--eval")
+            .arg(WORKER_SCRIPT)
+            .arg("--")
+            .arg("--enricher-script")
+            .arg(enricher_script)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("failed to spawn worker script")
+    }
+
+    fn stop_child(mut child: StdChild) {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn worker_script_reports_ready_and_returns_enriched_context() {
+        if !node_is_available() {
+            return;
+        }
+
+        let enricher_script = write_temp_enricher(
+            r#"
+            module.exports = async (context) => ({
+                ...context,
+                userId: "enriched-user",
+            });
+            "#,
+        );
+        let mut child = spawn_worker_script(&enricher_script);
+        let mut stdin = child.stdin.take().expect("worker stdin is not piped");
+        let stdout = child.stdout.take().expect("worker stdout is not piped");
+        let mut stdout = StdBufReader::new(stdout);
+
+        let mut ready = String::new();
+        stdout
+            .read_line(&mut ready)
+            .expect("failed to read worker ready message");
+        let ready: ReadyMessage =
+            serde_json::from_str(&ready).expect("worker ready message was not JSON");
+        assert_eq!(ready._message_type, "ready");
+
+        writeln!(
+            stdin,
+            r#"{{"id":7,"context":{{"userId":"original-user"}}}}"#
+        )
+        .expect("failed to write enrichment request");
+        stdin.flush().expect("failed to flush enrichment request");
+
+        let mut response = String::new();
+        stdout
+            .read_line(&mut response)
+            .expect("failed to read enrichment response");
+        let response: EnrichmentResponse =
+            serde_json::from_str(&response).expect("worker response was not valid JSON");
+
+        assert_eq!(response.id, 7);
+        assert_eq!(
+            response.outcome.unwrap().user_id.as_deref(),
+            Some("enriched-user")
+        );
+
+        stop_child(child);
+    }
+
+    #[test]
+    fn worker_script_redirects_console_output_and_returns_script_errors() {
+        if !node_is_available() {
+            return;
+        }
+
+        let enricher_script = write_temp_enricher(
+            r#"
+            module.exports = async () => {
+                console.log("hello from enricher", { ok: true });
+                throw new Error("script blew up");
+            };
+            "#,
+        );
+        let mut child = spawn_worker_script(&enricher_script);
+        let mut stdin = child.stdin.take().expect("worker stdin is not piped");
+        let stdout = child.stdout.take().expect("worker stdout is not piped");
+        let mut stdout = StdBufReader::new(stdout);
+
+        let mut ready = String::new();
+        stdout
+            .read_line(&mut ready)
+            .expect("failed to read worker ready message");
+
+        writeln!(stdin, r#"{{"id":8,"context":{{}}}}"#)
+            .expect("failed to write enrichment request");
+        stdin.flush().expect("failed to flush enrichment request");
+
+        let mut response = String::new();
+        stdout
+            .read_line(&mut response)
+            .expect("failed to read enrichment response");
+        let response: EnrichmentResponse =
+            serde_json::from_str(&response).expect("worker response was not valid JSON");
+
+        assert_eq!(response.id, 8);
+        assert_eq!(response.outcome.unwrap_err(), "script blew up");
+
+        let mut stderr_pipe = child.stderr.take().expect("worker stderr is not piped");
+
+        let _ = child.kill();
+        let _ = child.wait();
+
+        let mut stderr = String::new();
+        stderr_pipe
+            .read_to_string(&mut stderr)
+            .expect("failed to read worker stderr");
+
+        assert!(stderr.contains("[console.log] hello from enricher {\"ok\":true}"));
+    }
+}

--- a/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
@@ -131,7 +131,7 @@ async fn wait_for_ready(lines: &mut Lines<BufReader<ChildStdout>>) -> Result<(),
     )
     .await
     .map_err(|_| EnricherError::StartupFailure("worker readiness timed out".into()))?
-    .map_err(|_| EnricherError::StartupFailure("worker readiness read failed".into()))?;
+    .map_err(|e| EnricherError::StartupFailure(format!("worker readiness read failed: {e}")))?;
 
     let line = line.ok_or(EnricherError::StartupFailure(
         "worker failed to report readiness state".into(),

--- a/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
@@ -1,4 +1,8 @@
-use std::{path::PathBuf, process::Stdio, time::Duration};
+use std::{
+    path::{Path, PathBuf},
+    process::Stdio,
+    time::Duration,
+};
 use tokio::{
     io::{AsyncBufReadExt, BufReader, Lines},
     process::{Child, ChildStderr, ChildStdin, ChildStdout, Command},
@@ -27,14 +31,14 @@ pub enum EnricherError {
     IOError(String),
 }
 
-#[expect(dead_code)]
+#[cfg_attr(not(test), expect(dead_code))]
 enum WorkerEvent {
     Response(EnrichmentResponse),
     BrokenPipe(String),
     ProtocolError(String),
 }
 
-#[expect(dead_code)]
+#[cfg_attr(not(test), expect(dead_code))]
 struct RunningNodeChild {
     child: Child,
     child_input: ChildStdin,
@@ -49,26 +53,42 @@ pub struct NodeWorkerController {
 
 impl NodeWorkerController {
     #[expect(dead_code)]
-    pub async fn start(worker_id: u32) -> Result<Self, EnricherError> {
-        let child = spawn_node_child_process(worker_id).await?;
+    pub async fn start(worker_id: u32, enricher_script: &Path) -> Result<Self, EnricherError> {
+        let child = spawn_node_child_process(worker_id, enricher_script).await?;
 
         Ok(NodeWorkerController { worker_id, child })
     }
 }
 
-async fn spawn_node_child_process(worker_id: u32) -> Result<RunningNodeChild, EnricherError> {
-    let mut command = Command::new(resolve_node_path());
-    let (event_tx, event_rx) = tokio::sync::mpsc::channel(MAX_IN_FLIGHT_MESSAGES);
+async fn spawn_node_child_process(
+    worker_id: u32,
+    enricher_script: &Path,
+) -> Result<RunningNodeChild, EnricherError> {
+    spawn_configured_child(worker_id, node_worker_command(enricher_script)).await
+}
 
+fn node_worker_command(enricher_script: &Path) -> Command {
+    let mut command = Command::new(resolve_node_path());
     command
         .arg(format!("--max-old-space-size={}", CHILD_MEMORY_CEILING_MB))
         .arg("--eval")
         .arg(WORKER_SCRIPT)
+        .arg("--")
+        .arg("--enricher-script")
+        .arg(enricher_script)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .env_clear()
         .kill_on_drop(true);
+    command
+}
+
+async fn spawn_configured_child(
+    worker_id: u32,
+    mut command: Command,
+) -> Result<RunningNodeChild, EnricherError> {
+    let (event_tx, event_rx) = tokio::sync::mpsc::channel(MAX_IN_FLIGHT_MESSAGES);
 
     let mut child = command.spawn().map_err(|e| {
         EnricherError::StartupFailure(format!("Failed to spawn child process: {}", e))
@@ -218,13 +238,9 @@ fn resolve_node_path() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{
-        fs,
-        io::{BufRead, BufReader as StdBufReader, Read, Write},
-        path::Path,
-        process::{Child as StdChild, Command as StdCommand},
-    };
+    use std::{fs, process::Command as StdCommand};
     use tempfile::{NamedTempFile, TempPath};
+    use tokio::io::AsyncWriteExt;
 
     fn node_is_available() -> bool {
         // very stupid hack - right now CI doesn't have a Node runtime
@@ -250,27 +266,86 @@ mod tests {
         path
     }
 
-    fn spawn_worker_script(enricher_script: &Path) -> StdChild {
-        StdCommand::new(resolve_node_path())
-            .arg("--eval")
-            .arg(WORKER_SCRIPT)
-            .arg("--")
-            .arg("--enricher-script")
-            .arg(enricher_script)
+    fn fake_child_command(script: &str) -> Command {
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg(script)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .spawn()
-            .expect("failed to spawn worker script")
+            .kill_on_drop(true);
+        command
     }
 
-    fn stop_child(mut child: StdChild) {
-        let _ = child.kill();
-        let _ = child.wait();
+    #[tokio::test]
+    async fn worker_sends_and_reads_happy_path_messages_to_child() {
+        let command = fake_child_command(
+            r#"printf '%s\n' '{"messageType":"ready"}'
+               while IFS= read -r _line; do
+                   printf '%s\n' '{"id":42,"context":{"userId":"fake-user"}}'
+               done"#,
+        );
+
+        let mut child = spawn_configured_child(1, command)
+            .await
+            .expect("failed to spawn fake child");
+
+        child
+            .child_input
+            .write_all(br#"{"id":42,"context":{}}"#)
+            .await
+            .expect("failed to write fake request");
+        child
+            .child_input
+            .write_all(b"\n")
+            .await
+            .expect("failed to terminate fake request");
+
+        let event = time::timeout(Duration::from_secs(1), child.child_output.recv())
+            .await
+            .expect("timed out waiting for fake child event")
+            .expect("fake child event stream closed");
+
+        match event {
+            WorkerEvent::Response(response) => {
+                assert_eq!(response.id, 42);
+                assert_eq!(
+                    response.outcome.unwrap().user_id.as_deref(),
+                    Some("fake-user")
+                );
+            }
+            WorkerEvent::BrokenPipe(error) | WorkerEvent::ProtocolError(error) => {
+                panic!("unexpected fake child event: {error}");
+            }
+        }
     }
 
-    #[test]
-    fn worker_script_reports_ready_and_returns_enriched_context() {
+    #[tokio::test]
+    async fn protocol_errors_from_child_are_received_in_parent() {
+        let command = fake_child_command(
+            r#"printf '%s\n' '{"messageType":"ready"}'
+               printf '%s\n' 'not-json'"#,
+        );
+
+        let mut child = spawn_configured_child(1, command)
+            .await
+            .expect("failed to spawn fake child");
+
+        let event = time::timeout(Duration::from_secs(1), child.child_output.recv())
+            .await
+            .expect("timed out waiting for fake child event")
+            .expect("fake child event stream closed");
+
+        match event {
+            WorkerEvent::ProtocolError(line) => assert_eq!(line, "not-json"),
+            WorkerEvent::Response(_) => panic!("unexpected enrichment response"),
+            WorkerEvent::BrokenPipe(error) => panic!("unexpected broken pipe: {error}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn worker_happy_path_messages_work_end_to_end() {
         if !node_is_available() {
             return;
         }
@@ -279,94 +354,102 @@ mod tests {
             r#"
             module.exports = async (context) => ({
                 ...context,
-                userId: "enriched-user",
+                userId: "real-worker-user",
             });
             "#,
         );
-        let mut child = spawn_worker_script(&enricher_script);
-        let mut stdin = child.stdin.take().expect("worker stdin is not piped");
-        let stdout = child.stdout.take().expect("worker stdout is not piped");
-        let mut stdout = StdBufReader::new(stdout);
+        let mut child = spawn_node_child_process(1, &enricher_script)
+            .await
+            .expect("failed to spawn node child process");
 
-        let mut ready = String::new();
-        stdout
-            .read_line(&mut ready)
-            .expect("failed to read worker ready message");
-        let ready: ReadyMessage =
-            serde_json::from_str(&ready).expect("worker ready message was not JSON");
-        assert_eq!(ready._message_type, "ready");
+        child
+            .child_input
+            .write_all(br#"{"id":9,"context":{"userId":"original-user"}}"#)
+            .await
+            .expect("failed to write enrichment request");
+        child
+            .child_input
+            .write_all(b"\n")
+            .await
+            .expect("failed to terminate enrichment request");
 
-        writeln!(
-            stdin,
-            r#"{{"id":7,"context":{{"userId":"original-user"}}}}"#
-        )
-        .expect("failed to write enrichment request");
-        stdin.flush().expect("failed to flush enrichment request");
+        let event = time::timeout(Duration::from_secs(1), child.child_output.recv())
+            .await
+            .expect("timed out waiting for worker event")
+            .expect("worker event stream closed");
 
-        let mut response = String::new();
-        stdout
-            .read_line(&mut response)
-            .expect("failed to read enrichment response");
-        let response: EnrichmentResponse =
-            serde_json::from_str(&response).expect("worker response was not valid JSON");
-
-        assert_eq!(response.id, 7);
-        assert_eq!(
-            response.outcome.unwrap().user_id.as_deref(),
-            Some("enriched-user")
-        );
-
-        stop_child(child);
-    }
-
-    #[test]
-    fn worker_script_redirects_console_output_and_returns_script_errors() {
-        if !node_is_available() {
-            return;
+        match event {
+            WorkerEvent::Response(response) => {
+                assert_eq!(response.id, 9);
+                assert_eq!(
+                    response.outcome.unwrap().user_id.as_deref(),
+                    Some("real-worker-user")
+                );
+            }
+            WorkerEvent::BrokenPipe(error) | WorkerEvent::ProtocolError(error) => {
+                panic!("unexpected worker event: {error}");
+            }
         }
 
-        let enricher_script = write_temp_enricher(
-            r#"
-            module.exports = async () => {
-                console.log("hello from enricher", { ok: true });
-                throw new Error("script blew up");
-            };
-            "#,
-        );
-        let mut child = spawn_worker_script(&enricher_script);
-        let mut stdin = child.stdin.take().expect("worker stdin is not piped");
-        let stdout = child.stdout.take().expect("worker stdout is not piped");
-        let mut stdout = StdBufReader::new(stdout);
+        let _ = child.child.start_kill();
+    }
 
-        let mut ready = String::new();
-        stdout
-            .read_line(&mut ready)
-            .expect("failed to read worker ready message");
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn worker_traps_console_messages_and_pipes_them_to_logs() {
+        let mut child = spawn_configured_child(
+            1,
+            fake_child_command(
+                r#"printf '%s\n' '{"messageType":"ready"}'
+                   printf '%s\n' '[console.log] hello from enricher {"ok":true}' >&2
+                   while IFS= read -r _line; do
+                       printf '%s\n' '{"id":8,"error":"script blew up"}'
+                   done"#,
+            ),
+        )
+        .await
+        .expect("failed to spawn fake child");
 
-        writeln!(stdin, r#"{{"id":8,"context":{{}}}}"#)
-            .expect("failed to write enrichment request");
-        stdin.flush().expect("failed to flush enrichment request");
+        child
+            .child_input
+            .write_all(br#"{"id":8,"context":{}}"#)
+            .await
+            .expect("failed to write fake request");
+        child
+            .child_input
+            .write_all(b"\n")
+            .await
+            .expect("failed to terminate fake request");
 
-        let mut response = String::new();
-        stdout
-            .read_line(&mut response)
-            .expect("failed to read enrichment response");
-        let response: EnrichmentResponse =
-            serde_json::from_str(&response).expect("worker response was not valid JSON");
+        let event = time::timeout(Duration::from_secs(1), child.child_output.recv())
+            .await
+            .expect("timed out waiting for fake child event")
+            .expect("fake child event stream closed");
 
-        assert_eq!(response.id, 8);
-        assert_eq!(response.outcome.unwrap_err(), "script blew up");
+        match event {
+            WorkerEvent::Response(response) => {
+                assert_eq!(response.id, 8);
+                assert_eq!(response.outcome.unwrap_err(), "script blew up");
+            }
+            WorkerEvent::BrokenPipe(error) | WorkerEvent::ProtocolError(error) => {
+                panic!("unexpected fake child event: {error}");
+            }
+        }
 
-        let mut stderr_pipe = child.stderr.take().expect("worker stderr is not piped");
+        time::timeout(Duration::from_secs(1), async {
+            loop {
+                if logs_contain("[node-worker 1 pid=")
+                    && logs_contain("[console.log] hello from enricher {\"ok\":true}")
+                {
+                    break;
+                }
 
-        let _ = child.kill();
-        let _ = child.wait();
+                time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .expect("timed out waiting for drained stderr log");
 
-        let mut stderr = String::new();
-        stderr_pipe
-            .read_to_string(&mut stderr)
-            .expect("failed to read worker stderr");
-
-        assert!(stderr.contains("[console.log] hello from enricher {\"ok\":true}"));
+        let _ = child.child.start_kill();
     }
 }

--- a/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
@@ -168,7 +168,7 @@ async fn read_child_messages(
                         event_tx.send(WorkerEvent::ProtocolError(line)).await
                     };
 
-                // this happens if the child manages to flush one last message to it's std out but the Rust side receiver
+                // this happens if the child manages to flush one last message to its stdout but the Rust side receiver
                 // has already been dropped. This should basically not happen if everything else is working right
                 // but it's also not harmful if it does
                 if message_result.is_err() {

--- a/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
@@ -227,6 +227,16 @@ mod tests {
     use tempfile::{NamedTempFile, TempPath};
 
     fn node_is_available() -> bool {
+        // very stupid hack - right now CI doesn't have a Node runtime
+        // available and I don't want to add it. So we'll skip these on CI
+        // but I'm a banana who forgets things so I'm putting a time-bomb on this
+        // if this check is still here Aug 26 we fail so someone (me) needs to fix it
+
+        assert!(
+            std::time::SystemTime::now()
+                < std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1787695200)
+        );
+
         StdCommand::new(resolve_node_path())
             .arg("--version")
             .output()

--- a/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
@@ -1,0 +1,210 @@
+use std::{path::PathBuf, process::Stdio, time::Duration};
+use tokio::{
+    io::{AsyncBufReadExt, BufReader, Lines},
+    process::{Child, ChildStderr, ChildStdin, ChildStdout, Command},
+    sync::mpsc::{Receiver, Sender},
+    time,
+};
+use tracing::{debug, error, info};
+
+use crate::protocol::{EnrichmentResponse, ReadyMessage};
+
+const CHILD_MEMORY_CEILING_MB: u64 = 128;
+const CHILD_READY_TIMEOUT_IN_SECONDS: u64 = 2;
+const MAX_IN_FLIGHT_MESSAGES: usize = 32;
+// This is the message handling script that executes the messenger protocol on the Node side
+// This is absolutely critical for the whole thing to hang together, so relying on a filepath to read this
+// feels super fragile. Luckily, we don't have to do that - we can just bake the whole thing
+// in the Edge binary itself and then feed it to the Node process on startup
+const WORKER_SCRIPT: &str = include_str!("../worker_script.js");
+
+#[derive(Debug)]
+#[expect(dead_code)]
+pub enum EnricherError {
+    StartupFailure(String),
+    UnexpectedShutdown(String),
+    ProtocolError(String),
+    IOError(String),
+}
+
+#[expect(dead_code)]
+enum WorkerEvent {
+    Response(EnrichmentResponse),
+    BrokenPipe(String),
+    ProtocolError(String),
+}
+
+#[expect(dead_code)]
+struct RunningNodeChild {
+    child: Child,
+    child_input: ChildStdin,
+    child_output: Receiver<WorkerEvent>,
+}
+
+#[expect(dead_code)]
+pub struct NodeWorkerController {
+    worker_id: u32,
+    child: RunningNodeChild,
+}
+
+impl NodeWorkerController {
+    #[expect(dead_code)]
+    pub async fn start(worker_id: u32) -> Result<Self, EnricherError> {
+        let child = spawn_node_child_process(worker_id).await?;
+
+        Ok(NodeWorkerController { worker_id, child })
+    }
+}
+
+async fn spawn_node_child_process(worker_id: u32) -> Result<RunningNodeChild, EnricherError> {
+    let mut command = Command::new(resolve_node_path());
+    let (event_tx, event_rx) = tokio::sync::mpsc::channel(MAX_IN_FLIGHT_MESSAGES);
+
+    command
+        .arg(format!("--max-old-space-size={}", CHILD_MEMORY_CEILING_MB))
+        .arg("--eval")
+        .arg(WORKER_SCRIPT)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env_clear()
+        .kill_on_drop(true);
+
+    let mut child = command.spawn().map_err(|e| {
+        EnricherError::StartupFailure(format!("Failed to spawn child process: {}", e))
+    })?;
+    let child_pid = child
+        .id()
+        // tokio docs say this doesn't happen unless the process immediately terminates. We very much
+        // do not expect that to happen because the Node process should be running an infinite
+        // receiver loop so this is Bad™ and someone needs to know about it
+        .ok_or_else(|| EnricherError::StartupFailure("Failed to get child PID".to_string()))?;
+
+    let std_in = child
+        .stdin
+        .take()
+        .ok_or_else(|| EnricherError::StartupFailure("Failed to open child stdin".to_string()))?;
+
+    let std_out = child
+        .stdout
+        .take()
+        .ok_or_else(|| EnricherError::StartupFailure("Failed to open child stdout".to_string()))?;
+
+    drain_error_stream(worker_id, child_pid, child.stderr.take());
+
+    let mut lines = BufReader::new(std_out).lines();
+    wait_for_ready(&mut lines).await?;
+
+    tokio::spawn(read_child_messages(worker_id, child_pid, lines, event_tx));
+
+    Ok(RunningNodeChild {
+        child,
+        child_input: std_in,
+        child_output: event_rx,
+    })
+}
+
+async fn wait_for_ready(lines: &mut Lines<BufReader<ChildStdout>>) -> Result<(), EnricherError> {
+    let line = time::timeout(
+        Duration::from_secs(CHILD_READY_TIMEOUT_IN_SECONDS),
+        lines.next_line(),
+    )
+    .await
+    .map_err(|_| EnricherError::StartupFailure("worker readiness timed out".into()))?
+    .map_err(|_| EnricherError::StartupFailure("worker readiness read failed".into()))?;
+
+    let line = line.ok_or(EnricherError::StartupFailure(
+        "worker failed to report readiness state".into(),
+    ))?;
+
+    serde_json::from_str::<ReadyMessage>(&line).map_err(|_| {
+        EnricherError::StartupFailure("worker readiness failed: unparsable reponse".into())
+    })?;
+
+    // Message is just marker so we don't really care about it, only that it was received
+    // so we chuck it in the bin and let the caller know we're good to go
+    Ok(())
+}
+
+async fn read_child_messages(
+    worker_id: u32,
+    child_pid: u32,
+    mut child_std_out: Lines<BufReader<ChildStdout>>,
+    event_tx: Sender<WorkerEvent>,
+) {
+    loop {
+        match child_std_out.next_line().await {
+            Ok(Some(line)) => {
+                let message_result =
+                    if let Ok(event) = serde_json::from_str::<EnrichmentResponse>(&line) {
+                        event_tx.send(WorkerEvent::Response(event)).await
+                    } else {
+                        event_tx.send(WorkerEvent::ProtocolError(line)).await
+                    };
+
+                // this happens if the child manages to flush one last message to it's std out but the Rust side receiver
+                // has already been dropped. This should basically not happen if everything else is working right
+                // but it's also not harmful if it does
+                if message_result.is_err() {
+                    debug!(
+                        "[node-worker {worker_id} pid={child_pid}] event receiver closed; stopping stdout reader"
+                    );
+                    break;
+                }
+            }
+            Err(error) => {
+                let _ = event_tx
+                    .send(WorkerEvent::BrokenPipe(format!(
+                        "child stdout read failed: {error}"
+                    )))
+                    .await;
+                break;
+            }
+            Ok(None) => break,
+        }
+    }
+}
+
+// The intent is to pipe user script's std out and std err to the process std err. That way when someone leaves a bunch
+// of console logs in the script, it doesn't break our IPC protocol. So this is just a polite way of making sure
+// that stream doesn't fill its own buffers and block while still giving the user a way to see what their script is doing.
+// We also really don't care about this from our system's perspective so it gets a lazy background task to just OMNOMNOMNOM the stream
+fn drain_error_stream(worker_id: u32, child_pid: u32, stderr: Option<ChildStderr>) {
+    let Some(stderr) = stderr else {
+        return;
+    };
+    tokio::spawn(async move {
+        let mut lines = BufReader::new(stderr).lines();
+        loop {
+            match lines.next_line().await {
+                Ok(Some(line)) => {
+                    info!("[node-worker {worker_id} pid={child_pid}] {line}");
+                }
+                Err(error) => {
+                    error!(
+                        "[node-worker {worker_id} pid={child_pid}] stopped draining stderr after read failure: {error}"
+                    );
+                    break;
+                }
+                Ok(None) => break,
+            }
+        }
+    });
+}
+
+// spawn_node_child_process is wiping the environment so we need to resolve the path to node ourselves
+// because now only the parent is able to see the configured env vars. Bit of a hack. Three paths to deal with this
+// 1) Throw all this in the bin and compose a JS runtime from parts - more work, out of scope for an MVP
+// 2) Don't wipe the environment before spawning the child, which gives the child more scope to do bad things
+// 3) Leave it alone - probably fine for an MVP middle ground
+fn resolve_node_path() -> PathBuf {
+    let node = PathBuf::from("node");
+    let Some(path) = std::env::var_os("PATH") else {
+        return node;
+    };
+
+    std::env::split_paths(&path)
+        .map(|path| path.join("node"))
+        .find(|path| path.is_file())
+        .unwrap_or(node)
+}

--- a/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
@@ -387,6 +387,75 @@ mod tests {
 
     #[tokio::test]
     #[tracing_test::traced_test]
+    async fn worker_redirects_process_stdout_write_without_corrupting_protocol() {
+        if !node_is_available() {
+            return;
+        }
+
+        let enricher_script = write_temp_enricher(
+            r#"
+            process.stdout.write("top-level stdout");
+            module.exports = async (context) => {
+                process.stdout.write("request stdout");
+                return {
+                    ...context,
+                    userId: "stdout-safe-user",
+                };
+            };
+            "#,
+        );
+        let mut child = spawn_node_child_process(1, &enricher_script)
+            .await
+            .expect("failed to spawn node child process");
+
+        child
+            .child_input
+            .write_all(br#"{"id":10,"context":{"userId":"original-user"}}"#)
+            .await
+            .expect("failed to write enrichment request");
+        child
+            .child_input
+            .write_all(b"\n")
+            .await
+            .expect("failed to terminate enrichment request");
+
+        let event = time::timeout(Duration::from_secs(1), child.child_output.recv())
+            .await
+            .expect("timed out waiting for worker event")
+            .expect("worker event stream closed");
+
+        match event {
+            WorkerEvent::Response(response) => {
+                assert_eq!(response.id, 10);
+                assert_eq!(
+                    response.outcome.unwrap().user_id.as_deref(),
+                    Some("stdout-safe-user")
+                );
+            }
+            WorkerEvent::BrokenPipe(error) | WorkerEvent::ProtocolError(error) => {
+                panic!("unexpected worker event: {error}");
+            }
+        }
+
+        time::timeout(Duration::from_secs(1), async {
+            loop {
+                if logs_contain("[process.stdout.write] top-level stdout")
+                    && logs_contain("[process.stdout.write] request stdout")
+                {
+                    break;
+                }
+
+                time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .expect("timed out waiting for redirected stdout logs");
+
+        let _ = child.child.start_kill();
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
     async fn worker_traps_console_messages_and_pipes_them_to_logs() {
         let mut child = spawn_configured_child(
             1,

--- a/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
@@ -117,10 +117,16 @@ async fn wait_for_ready(lines: &mut Lines<BufReader<ChildStdout>>) -> Result<(),
         "worker failed to report readiness state".into(),
     ))?;
 
-    serde_json::from_str::<ReadyMessage>(&line).map_err(|_| {
-        EnricherError::StartupFailure("worker readiness failed: unparsable reponse".into())
+    let ready = serde_json::from_str::<ReadyMessage>(&line).map_err(|_| {
+        EnricherError::StartupFailure("worker readiness failed: unparsable response".into())
     })?;
 
+    if ready._message_type != "ready" {
+        return Err(EnricherError::StartupFailure(format!(
+            "worker readiness failed: unexpected messageType '{}'",
+            ready._message_type
+        )));
+    }
     // Message is just marker so we don't really care about it, only that it was received
     // so we chuck it in the bin and let the caller know we're good to go
     Ok(())

--- a/crates/enterprise/unleash-edge-context-enrichers/worker_script.js
+++ b/crates/enterprise/unleash-edge-context-enrichers/worker_script.js
@@ -89,6 +89,9 @@ function main() {
     try {
         captureConsole();
         const enricherScript = loadEnricherScript(process.argv);
+        if (typeof enricherScript !== "function") {
+            throw new Error("enricher script must export a function");
+        }
         setupMessageHandler(enricherScript);
         send({ messageType: "ready" });
 

--- a/crates/enterprise/unleash-edge-context-enrichers/worker_script.js
+++ b/crates/enterprise/unleash-edge-context-enrichers/worker_script.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const readline = require("readline");
+const protocolWrite = process.stdout.write.bind(process.stdout);
 
 function formatConsolePart(part) {
     if (typeof part === "string") {
@@ -23,7 +24,7 @@ function toStdErr(method, parts) {
 }
 
 function send(message) {
-    process.stdout.write(`${JSON.stringify(message)}\n`);
+    protocolWrite(`${JSON.stringify(message)}\n`);
 }
 
 // We use stdout for communication with the parent process, so anything that touches that will
@@ -35,6 +36,14 @@ function captureConsole() {
     console.warn = (...parts) => toStdErr("warn", parts);
     console.error = (...parts) => toStdErr("error", parts);
     console.debug = (...parts) => toStdErr("debug", parts);
+}
+
+function captureProcessStdout() {
+    process.stdout.write = (...parts) => {
+        const message = parts.map(formatConsolePart).join(" ");
+        process.stderr.write(`[process.stdout.write] ${message}\n`);
+        return true;
+    };
 }
 
 async function handle(message, enrich) {
@@ -87,6 +96,7 @@ function setupMessageHandler(enricherScript) {
 function main() {
     try {
         captureConsole();
+        captureProcessStdout();
         const enricherScript = loadEnricherScript(process.argv);
         if (typeof enricherScript !== "function") {
             throw new Error("enricher script must export a function");

--- a/crates/enterprise/unleash-edge-context-enrichers/worker_script.js
+++ b/crates/enterprise/unleash-edge-context-enrichers/worker_script.js
@@ -1,0 +1,104 @@
+const path = require("path");
+const readline = require("readline");
+
+function formatConsolePart(part) {
+    if (typeof part === "string") {
+        return part;
+    }
+
+    if (part instanceof Error) {
+        return part.stack || part.message;
+    }
+
+    try {
+        return JSON.stringify(part);
+    } catch (_error) {
+        return String(part);
+    }
+}
+
+function toStdErr(method, parts) {
+    const message = parts.map(formatConsolePart).join(" ");
+    process.stderr.write(`[console.${method}] ${message}\n`);
+}
+
+function send(message) {
+    process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+// We use stdout for communication with the parent process, so anything that touches that will
+// break the protocol. Easy enough to just capture console output and redirect it to stderr instead.
+// The Rust worker runner expects us to do this and pipes it all out to logs
+function captureConsole() {
+    console.log = (...parts) => toStdErr("log", parts);
+    console.info = (...parts) => toStdErr("info", parts);
+    console.warn = (...parts) => toStdErr("warn", parts);
+    console.error = (...parts) => toStdErr("error", parts);
+    console.debug = (...parts) => toStdErr("debug", parts);
+}
+
+async function handle(message, enrich) {
+    try {
+        const result = await enrich(message.context);
+        send({ id: message.id, result });
+    } catch (error) {
+        send({
+            id: message.id,
+            error: error instanceof Error ? error.message : String(error),
+        });
+    }
+}
+
+function loadEnricherScript(args) {
+    const index = args.indexOf("--enricher-script");
+    if (index === -1 || args.length <= index + 1) {
+        throw new Error("enricher script path not provided");
+    }
+
+    const enricherScriptPath = args[index + 1];
+    const resolvedScriptPath = path.resolve(enricherScriptPath);
+    return require(resolvedScriptPath);
+}
+
+function setupMessageHandler(enricherScript) {
+    const input = readline.createInterface({
+        input: process.stdin,
+        crlfDelay: Infinity,
+    });
+
+    input.on("line", (line) => {
+        if (line.trim() === "") {
+            return;
+        }
+
+        try {
+            const message = JSON.parse(line);
+            // awaiting here would block our message handler and prevent inputs from the parent process being read.
+            // When the task to process the message is complete, we'll write it back over stdout so it can be fire and forget
+            void handle(message, enricherScript);
+        } catch (error) {
+            console.error(
+                `invalid JSON request: ${error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+    });
+}
+
+function main() {
+    try {
+        captureConsole();
+        const enricherScript = loadEnricherScript(process.argv);
+        setupMessageHandler(enricherScript);
+        send({ messageType: "ready" });
+
+    } catch (error) {
+        console.error(
+            `failed to setup reader: ${error instanceof Error ? error.message : String(error)
+            }`,
+        );
+        process.exit(1);
+    }
+}
+
+main();

--- a/crates/enterprise/unleash-edge-context-enrichers/worker_script.js
+++ b/crates/enterprise/unleash-edge-context-enrichers/worker_script.js
@@ -78,8 +78,7 @@ function setupMessageHandler(enricherScript) {
             void handle(message, enricherScript);
         } catch (error) {
             console.error(
-                `invalid JSON request: ${error instanceof Error ? error.message : String(error)
-                }`,
+                `invalid JSON request: ${error instanceof Error ? error.message : String(error)}`,
             );
         }
     });

--- a/crates/enterprise/unleash-edge-context-enrichers/worker_script.js
+++ b/crates/enterprise/unleash-edge-context-enrichers/worker_script.js
@@ -40,7 +40,7 @@ function captureConsole() {
 async function handle(message, enrich) {
     try {
         const result = await enrich(message.context);
-        send({ id: message.id, result });
+        send({ id: message.id, context: result });
     } catch (error) {
         send({
             id: message.id,


### PR DESCRIPTION
Implements the core of the Context Enricher system - a small Node worker child process managed by a Rust module. 

This works by spawning a Node process and immediately invoking a JS script inside that worker. The JS script ingests messages in a loop over std in, processes then asynchronously and writes back responses over stdout. The Rust worker manages this whole process, piping in requests over std in and reading the responses back at a later time over std out. Because this work is inherently asynchronous, the protocol works over message ids - e.g. Rust sends job 7, later expecting a response with that same id

This is as small as I can make this without losing the context for what I'm trying to do, all of this code is currently unused so I've marked the relevant unused places with expect(dead_code) for now to get the compiler off my case, when the code is used those expects will fail the lint and CI so we don't forget them