### PR TITLE
chore: bump yggdrasil to 0.21.5 to fix semver metadata compliance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6178,9 +6178,9 @@ dependencies = [
 
 [[package]]
 name = "unleash-yggdrasil"
-version = "0.21.4"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56172b5dc8824e8477a010cc471a344e5e3de8ec8dedf122e3cd7cb095f45a6c"
+checksum = "8df5e1811890a75dc6ad7cd9348d630353df2cdb8d38c6b2d58e4599f3d9486b"
 dependencies = [
  "ahash",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,7 @@ unleash-edge-streaming = { path = "./crates/enterprise/unleash-edge-streaming" }
 unleash-edge-tracing = { path = "./crates/enterprise/unleash-edge-tracing" }
 unleash-edge-types = { path = "./crates/oss/unleash-edge-types" }
 unleash-types = { version = "0.16.2", features = ["hashes", "openapi"] }
-unleash-yggdrasil = { version = "0.21.4" }
+unleash-yggdrasil = { version = "0.21.5" }
 url = { version = "2.5.8" }
 utoipa = { version = "5.5.0", features = ["chrono", "axum_extras"] }
 utoipauto = { version = "0.3.0-alpha.2" }


### PR DESCRIPTION
Updating Edge to support SemVer metadata the proper way with Ygg version 0.21.5