### PR TITLE
chore: context enrichers no longer take deep clones of headers on eve…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5737,6 +5737,7 @@ dependencies = [
 name = "unleash-edge-context-enrichers"
 version = "20.5.0"
 dependencies = [
+ "http 1.5.0",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/enterprise/unleash-edge-context-enrichers/Cargo.toml
+++ b/crates/enterprise/unleash-edge-context-enrichers/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 license-file = "../../../LICENSE-ENTERPRISE.md"
 
 [dependencies]
+http = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "process", "sync", "time"] }

--- a/crates/enterprise/unleash-edge-context-enrichers/src/command.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/command.rs
@@ -1,8 +1,8 @@
-use std::{collections::HashMap, fmt::Display};
+use std::fmt::Display;
 use tokio::{sync::oneshot::Sender as OneShotSender, time::Instant};
 use unleash_types::client_features::Context;
 
-use crate::protocol::EnrichmentResponse;
+use crate::protocol::{EnrichmentResponse, SerializedEnrichmentRequest};
 
 #[derive(Debug, Clone)]
 pub enum EnricherError {
@@ -41,8 +41,7 @@ pub(crate) enum WorkerEvent {
 pub(crate) enum WorkerCommand {
     Execute {
         id: u64,
-        context: Context,
-        headers: HashMap<String, String>,
+        request: SerializedEnrichmentRequest,
         deadline: Instant,
         respond_to: OneShotSender<Result<Context, EnricherError>>,
     },

--- a/crates/enterprise/unleash-edge-context-enrichers/src/context_enricher.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/context_enricher.rs
@@ -1,8 +1,9 @@
-use std::{collections::HashMap, num::NonZeroU32, path::PathBuf, sync::Arc, time::Duration};
+use http::HeaderMap;
+use std::{num::NonZeroU32, path::PathBuf, sync::Arc, time::Duration};
 use tracing::{info, warn};
 use unleash_types::client_features::Context;
 
-use crate::{EnricherError, WorkerPool};
+use crate::{EnricherError, WorkerPool, serializable_header::SerializableHeaders};
 
 #[derive(Clone)]
 pub struct ContextEnricher {
@@ -28,7 +29,7 @@ impl ContextEnricher {
     pub async fn try_enrich(
         &self,
         context: Context,
-        headers: HashMap<String, String>,
+        headers: &HeaderMap,
         timeout: Duration,
     ) -> Context {
         let Some(worker_pool) = self.worker_pool.as_ref() else {
@@ -36,7 +37,7 @@ impl ContextEnricher {
         };
 
         match worker_pool
-            .request_enrichment(context.clone(), headers, timeout)
+            .request_enrichment(context.clone(), SerializableHeaders(headers), timeout)
             .await
         {
             Ok(enriched_context) => enriched_context,

--- a/crates/enterprise/unleash-edge-context-enrichers/src/driver.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/driver.rs
@@ -11,7 +11,7 @@ use unleash_types::client_features::Context;
 use crate::{
     child::RunningNodeChild,
     command::{EnricherError, WorkerCommand, WorkerEvent},
-    protocol::EnrichmentRequest,
+    protocol::SerializedEnrichmentRequest,
 };
 
 const PENDING_RESPONSE_EXPIRY_INTERVAL: Duration = Duration::from_millis(10);
@@ -34,7 +34,7 @@ pub(crate) async fn driver_loop(
         tokio::select! {
             command = command_rx.recv(), if pending_responses.len() < MAX_IN_FLIGHT_REQUESTS => {
                 match command {
-                    Some(WorkerCommand::Execute { id, context, headers, deadline, respond_to }) => {
+                    Some(WorkerCommand::Execute { id, request, deadline, respond_to }) => {
                         // Our queue is backed up. Badly. And trying to add a job to the queue is
                         // exceeding out timeout. Soooo... no point in sending then because we no longer care
                         if deadline <= Instant::now() {
@@ -44,9 +44,7 @@ pub(crate) async fn driver_loop(
                             continue;
                         }
 
-                        if let Err(error) =
-                            send_request(&mut child.child_input, id, context, headers).await
-                        {
+                        if let Err(error) = send_request(&mut child.child_input, &request).await {
                             let _ = respond_to.send(Err(error.clone()));
                             fail_pending_responses(&mut pending_responses, error.clone());
                             return Err(error);
@@ -141,23 +139,10 @@ fn expire_pending_responses(pending_responses: &mut HashMap<u64, PendingResponse
 
 async fn send_request(
     stdin: &mut ChildStdin,
-    id: u64,
-    context: Context,
-    headers: HashMap<String, String>,
+    request: &SerializedEnrichmentRequest,
 ) -> Result<(), EnricherError> {
-    let request = EnrichmentRequest {
-        id,
-        context,
-        headers,
-    };
-    // This isn't possible in the sense that it requires that we have a fallible serialize implementation
-    // We don't have that, there's no reason to have that and it's a bunch of work to do so for no reason.
-    let mut line = serde_json::to_vec(&request).map_err(|e| {
-        EnricherError::ProtocolError(format!("Could not serialize message to enricher: {e}"))
-    })?;
-    line.push(b'\n');
     stdin
-        .write_all(&line)
+        .write_all(request.as_bytes())
         .await
         .map_err(|e| EnricherError::IOError(format!("Could not send message to enricher: {e}")))?;
     stdin
@@ -171,6 +156,9 @@ async fn send_request(
 mod tests {
     use super::*;
     use crate::child::spawn_child;
+    use crate::protocol::EnrichmentRequest;
+    use crate::serializable_header::SerializableHeaders;
+    use http::HeaderMap;
     use std::process::Stdio;
     use tokio::{
         process::Command,
@@ -189,6 +177,16 @@ mod tests {
             .stderr(Stdio::piped())
             .kill_on_drop(true);
         command
+    }
+
+    fn serialized_request(id: u64) -> SerializedEnrichmentRequest {
+        let headers = HeaderMap::new();
+        SerializedEnrichmentRequest::try_from(EnrichmentRequest {
+            id,
+            context: Context::default(),
+            headers: SerializableHeaders(&headers),
+        })
+        .expect("request should serialize")
     }
 
     #[tokio::test]
@@ -213,8 +211,7 @@ mod tests {
         command_tx
             .send(WorkerCommand::Execute {
                 id: 0,
-                context: Context::default(),
-                headers: HashMap::new(),
+                request: serialized_request(0),
                 deadline: Instant::now() + Duration::from_secs(1),
                 respond_to,
             })
@@ -254,8 +251,7 @@ mod tests {
         command_tx
             .send(WorkerCommand::Execute {
                 id: 0,
-                context: Context::default(),
-                headers: HashMap::new(),
+                request: serialized_request(0),
                 deadline: Instant::now() + Duration::from_millis(20),
                 respond_to,
             })
@@ -299,8 +295,7 @@ mod tests {
             command_tx
                 .send(WorkerCommand::Execute {
                     id: id as u64,
-                    context: Context::default(),
-                    headers: HashMap::new(),
+                    request: serialized_request(id as u64),
                     deadline: Instant::now() + Duration::from_secs(60),
                     respond_to,
                 })
@@ -313,8 +308,7 @@ mod tests {
             Duration::from_millis(50),
             command_tx.send(WorkerCommand::Execute {
                 id: 100,
-                context: Context::default(),
-                headers: HashMap::new(),
+                request: serialized_request(100),
                 deadline: Instant::now() + Duration::from_secs(60),
                 respond_to,
             }),
@@ -344,8 +338,7 @@ mod tests {
         command_tx
             .send(WorkerCommand::Execute {
                 id: 0,
-                context: Context::default(),
-                headers: HashMap::new(),
+                request: serialized_request(0),
                 deadline: Instant::now() + Duration::from_secs(1),
                 respond_to,
             })
@@ -393,8 +386,7 @@ mod tests {
         command_tx
             .send(WorkerCommand::Execute {
                 id: 0,
-                context: Context::default(),
-                headers: HashMap::new(),
+                request: serialized_request(0),
                 deadline: Instant::now() + Duration::from_secs(1),
                 respond_to,
             })
@@ -438,8 +430,7 @@ mod tests {
         command_tx
             .send(WorkerCommand::Execute {
                 id: 0,
-                context: Context::default(),
-                headers: HashMap::new(),
+                request: serialized_request(0),
                 deadline: Instant::now() + Duration::from_secs(1),
                 respond_to,
             })
@@ -491,8 +482,7 @@ mod tests {
         command_tx
             .send(WorkerCommand::Execute {
                 id: 0,
-                context: Context::default(),
-                headers: HashMap::new(),
+                request: serialized_request(0),
                 deadline: Instant::now() + Duration::from_millis(20),
                 respond_to,
             })

--- a/crates/enterprise/unleash-edge-context-enrichers/src/lib.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/lib.rs
@@ -4,6 +4,7 @@ mod context_enricher;
 mod driver;
 mod pool;
 mod protocol;
+mod serializable_header;
 mod worker;
 
 const MAX_SCHEDULED_JOBS: usize = 32;

--- a/crates/enterprise/unleash-edge-context-enrichers/src/pool.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/pool.rs
@@ -1,6 +1,8 @@
-use crate::{MAX_SCHEDULED_JOBS, command::EnricherError, worker::NodeWorkerController};
+use crate::{
+    MAX_SCHEDULED_JOBS, command::EnricherError, serializable_header::SerializableHeaders,
+    worker::NodeWorkerController,
+};
 use std::{
-    collections::HashMap,
     num::NonZeroU32,
     path::PathBuf,
     sync::{
@@ -64,10 +66,10 @@ impl WorkerPool {
         })
     }
 
-    pub async fn request_enrichment(
+    pub(crate) async fn request_enrichment(
         &self,
         context: Context,
-        headers: HashMap<String, String>,
+        headers: SerializableHeaders<'_>,
         timeout: Duration,
     ) -> Result<Context, EnricherError> {
         let deadline = Instant::now() + timeout;
@@ -158,6 +160,7 @@ fn as_absolute_path(path: &std::path::Path) -> Result<PathBuf, EnricherError> {
 mod tests {
     use super::*;
     use crate::command::WorkerCommand;
+    use http::{HeaderMap, HeaderValue};
     use tokio::sync::mpsc::{Receiver, channel};
     use tokio::time;
 
@@ -187,6 +190,20 @@ mod tests {
             .await
             .expect("timed out waiting for worker command")
             .expect("worker command channel closed")
+    }
+
+    fn empty_headers() -> HeaderMap {
+        HeaderMap::new()
+    }
+
+    fn header_map(entries: &[(&'static str, &'static str)]) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+
+        for (name, value) in entries {
+            headers.insert(*name, HeaderValue::from_static(value));
+        }
+
+        headers
     }
 
     #[tokio::test]
@@ -232,9 +249,10 @@ mod tests {
                 inner: Arc::clone(&pool.inner),
             };
             async move {
+                let headers = header_map(&[("x-test", "true")]);
                 pool.request_enrichment(
                     Context::default(),
-                    HashMap::from([("x-test".to_string(), "true".to_string())]),
+                    SerializableHeaders(&headers),
                     Duration::from_secs(1),
                 )
                 .await
@@ -244,12 +262,14 @@ mod tests {
         match next_command(&mut command_rx).await {
             WorkerCommand::Execute {
                 id,
-                headers,
+                request,
                 respond_to,
                 ..
             } => {
                 assert_eq!(id, 0);
-                assert_eq!(headers.get("x-test").map(String::as_str), Some("true"));
+                let request =
+                    String::from_utf8(request.as_bytes().to_vec()).expect("request was not utf8");
+                assert!(request.contains(r#""x-test":"true""#));
                 let context = Context {
                     user_id: Some("pooled-user".to_string()),
                     ..Default::default()
@@ -280,11 +300,12 @@ mod tests {
     async fn request_enrichment_times_out_when_pool_capacity_is_exhausted() {
         let (worker, _command_rx) = worker_slot(0);
         let pool = pool_with_slots(vec![worker], 0);
+        let headers = empty_headers();
 
         let error = pool
             .request_enrichment(
                 Context::default(),
-                HashMap::new(),
+                SerializableHeaders(&headers),
                 Duration::from_millis(20),
             )
             .await
@@ -312,9 +333,10 @@ mod tests {
                 inner: Arc::clone(&pool.inner),
             };
             async move {
+                let headers = empty_headers();
                 pool.request_enrichment(
                     Context::default(),
-                    HashMap::new(),
+                    SerializableHeaders(&headers),
                     Duration::from_millis(50),
                 )
                 .await
@@ -366,8 +388,13 @@ mod tests {
                 inner: Arc::clone(&pool.inner),
             };
             async move {
-                pool.request_enrichment(Context::default(), HashMap::new(), Duration::from_secs(1))
-                    .await
+                let headers = empty_headers();
+                pool.request_enrichment(
+                    Context::default(),
+                    SerializableHeaders(&headers),
+                    Duration::from_secs(1),
+                )
+                .await
             }
         });
 

--- a/crates/enterprise/unleash-edge-context-enrichers/src/protocol.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/protocol.rs
@@ -1,12 +1,31 @@
 use serde::{Deserialize, Deserializer, Serialize};
-use std::collections::HashMap;
 use unleash_types::client_features::Context;
 
+use crate::serializable_header::SerializableHeaders;
+
 #[derive(Serialize)]
-pub(crate) struct EnrichmentRequest {
+pub(crate) struct EnrichmentRequest<'a> {
     pub(crate) id: u64,
     pub(crate) context: Context,
-    pub(crate) headers: HashMap<String, String>,
+    pub(crate) headers: SerializableHeaders<'a>,
+}
+
+pub(crate) struct SerializedEnrichmentRequest(Vec<u8>);
+
+impl SerializedEnrichmentRequest {
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl TryFrom<EnrichmentRequest<'_>> for SerializedEnrichmentRequest {
+    type Error = serde_json::Error;
+
+    fn try_from(request: EnrichmentRequest<'_>) -> Result<Self, Self::Error> {
+        let mut serialized = serde_json::to_vec(&request)?;
+        serialized.push(b'\n');
+        Ok(Self(serialized))
+    }
 }
 
 pub(crate) struct EnrichmentResponse {

--- a/crates/enterprise/unleash-edge-context-enrichers/src/serializable_header.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/serializable_header.rs
@@ -1,8 +1,5 @@
 use http::HeaderMap;
-use serde::{
-    Serialize, Serializer,
-    ser::SerializeMap,
-};
+use serde::{Serialize, Serializer, ser::SerializeMap};
 
 pub(crate) struct SerializableHeaders<'a>(pub(crate) &'a HeaderMap);
 

--- a/crates/enterprise/unleash-edge-context-enrichers/src/serializable_header.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/serializable_header.rs
@@ -11,10 +11,12 @@ impl Serialize for SerializableHeaders<'_> {
     where
         S: Serializer,
     {
-        let mut map = serializer.serialize_map(Some(self.0.len()))?;
+        let mut map = serializer.serialize_map(None)?;
 
         for (name, value) in self.0 {
-            let value = value.to_str().map_err(S::Error::custom)?;
+            let Ok(value) = value.to_str() else {
+                continue;
+            };
 
             map.serialize_entry(name.as_str(), value)?;
         }

--- a/crates/enterprise/unleash-edge-context-enrichers/src/serializable_header.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/serializable_header.rs
@@ -1,7 +1,7 @@
 use http::HeaderMap;
 use serde::{
     Serialize, Serializer,
-    ser::{Error as _, SerializeMap},
+    ser::SerializeMap,
 };
 
 pub(crate) struct SerializableHeaders<'a>(pub(crate) &'a HeaderMap);

--- a/crates/enterprise/unleash-edge-context-enrichers/src/serializable_header.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/serializable_header.rs
@@ -1,0 +1,24 @@
+use http::HeaderMap;
+use serde::{
+    Serialize, Serializer,
+    ser::{Error as _, SerializeMap},
+};
+
+pub(crate) struct SerializableHeaders<'a>(pub(crate) &'a HeaderMap);
+
+impl Serialize for SerializableHeaders<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(self.0.len()))?;
+
+        for (name, value) in self.0 {
+            let value = value.to_str().map_err(S::Error::custom)?;
+
+            map.serialize_entry(name.as_str(), value)?;
+        }
+
+        map.end()
+    }
+}

--- a/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     path::Path,
     sync::atomic::{AtomicU64, Ordering},
     time::Duration,
@@ -19,6 +18,8 @@ use crate::{
     child::spawn_node_child_process,
     command::{EnricherError, WorkerCommand},
     driver::driver_loop,
+    protocol::{EnrichmentRequest, SerializedEnrichmentRequest},
+    serializable_header::SerializableHeaders,
 };
 
 pub struct NodeWorkerController {
@@ -81,16 +82,24 @@ impl NodeWorkerController {
     pub async fn request_enrichment(
         &self,
         context: Context,
-        headers: HashMap<String, String>,
+        headers: SerializableHeaders<'_>,
         job_timeout: Duration,
     ) -> Result<Context, EnricherError> {
         let (respond_to, read_response) = oneshot::channel();
         let deadline = Instant::now() + job_timeout;
-
-        let command = WorkerCommand::Execute {
-            id: self.next_request_id.fetch_add(1, Ordering::SeqCst),
+        let id = self.next_request_id.fetch_add(1, Ordering::SeqCst);
+        let request = SerializedEnrichmentRequest::try_from(EnrichmentRequest {
+            id,
             context,
             headers,
+        })
+        .map_err(|e| {
+            EnricherError::ProtocolError(format!("Could not serialize message to enricher: {e}"))
+        })?;
+
+        let command = WorkerCommand::Execute {
+            id,
+            request,
             deadline,
             respond_to,
         };
@@ -125,6 +134,8 @@ impl NodeWorkerController {
 mod tests {
     use super::*;
 
+    use http::HeaderMap;
+
     #[tokio::test]
     async fn request_enrichment_times_out_when_scheduler_queue_is_full() {
         let (command_tx, _command_rx) = channel(1);
@@ -133,11 +144,12 @@ mod tests {
             .await
             .expect("failed to fill scheduler queue");
         let worker = NodeWorkerController::from_command_tx(1, command_tx);
+        let headers = HeaderMap::new();
 
         let error = worker
             .request_enrichment(
                 Context::default(),
-                HashMap::new(),
+                SerializableHeaders(&headers),
                 Duration::from_millis(20),
             )
             .await

--- a/crates/oss/unleash-edge-appstate/src/context_enricher.rs
+++ b/crates/oss/unleash-edge-appstate/src/context_enricher.rs
@@ -3,7 +3,8 @@ pub use unleash_edge_context_enrichers::ContextEnricher;
 
 #[cfg(not(feature = "enterprise"))]
 mod disabled {
-    use std::{collections::HashMap, time::Duration};
+    use axum::http::HeaderMap;
+    use std::time::Duration;
     use unleash_types::client_features::Context;
 
     #[derive(Clone, Default)]
@@ -14,12 +15,7 @@ mod disabled {
             Self
         }
 
-        pub async fn try_enrich(
-            &self,
-            context: Context,
-            _: HashMap<String, String>,
-            _: Duration,
-        ) -> Context {
+        pub async fn try_enrich(&self, context: Context, _: &HeaderMap, _: Duration) -> Context {
             context
         }
     }

--- a/crates/oss/unleash-edge-frontend-api/src/frontend.rs
+++ b/crates/oss/unleash-edge-frontend-api/src/frontend.rs
@@ -8,7 +8,6 @@ use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use ipnet::IpNet;
-use std::collections::HashMap;
 use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -266,24 +265,8 @@ pub async fn frontend_post_feature(
 async fn try_enrich(app_state: &FrontendState, context: Context, headers: &HeaderMap) -> Context {
     app_state
         .context_enricher
-        .try_enrich(
-            context,
-            headers_for_context_enricher(headers),
-            CONTEXT_ENRICHER_TIMEOUT,
-        )
+        .try_enrich(context, headers, CONTEXT_ENRICHER_TIMEOUT)
         .await
-}
-
-fn headers_for_context_enricher(headers: &HeaderMap) -> HashMap<String, String> {
-    headers
-        .iter()
-        .filter_map(|(name, value)| {
-            value
-                .to_str()
-                .ok()
-                .map(|value| (name.as_str().to_string(), value.to_string()))
-        })
-        .collect()
 }
 
 #[instrument(skip(token_cache, engine_cache, edge_token, feature_name, incoming_context))]


### PR DESCRIPTION
Adds a bit of song and dance so that Context Enrichers don't deep copy the entire header map unnecessarily - this is important for cases where Context Enrichers are not actually active. Before this, we took that perf hit on every request regardless

To make this possible, we include a thin carrier type that knows how to write itself to a JSON value. The public API to Context Enrichers accepts a borrowed HeaderMap and converts that to the internal type as soon as possible and then deals with that internally  

This doesn't address the same problem with the Context value - next piece of work