### PR TITLE
chore: don't clone context unnecessarily in context enricher flow

### DIFF
--- a/crates/enterprise/unleash-edge-context-enrichers/src/context_enricher.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/context_enricher.rs
@@ -28,19 +28,17 @@ impl ContextEnricher {
 
     pub async fn try_enrich(
         &self,
-        context: Context,
+        context: &Context,
         headers: &HeaderMap,
         timeout: Duration,
-    ) -> Context {
-        let Some(worker_pool) = self.worker_pool.as_ref() else {
-            return context;
-        };
+    ) -> Option<Context> {
+        let worker_pool = self.worker_pool.as_ref()?;
 
         match worker_pool
-            .request_enrichment(context.clone(), SerializableHeaders(headers), timeout)
+            .request_enrichment(context, SerializableHeaders(headers), timeout)
             .await
         {
-            Ok(enriched_context) => enriched_context,
+            Ok(enriched_context) => Some(enriched_context),
             Err(error) => {
                 match error {
                     EnricherError::Timeout(message) => {
@@ -54,7 +52,7 @@ impl ContextEnricher {
                         );
                     }
                 }
-                context
+                None
             }
         }
     }

--- a/crates/enterprise/unleash-edge-context-enrichers/src/driver.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/driver.rs
@@ -183,7 +183,7 @@ mod tests {
         let headers = HeaderMap::new();
         SerializedEnrichmentRequest::try_from(EnrichmentRequest {
             id,
-            context: Context::default(),
+            context: &Context::default(),
             headers: SerializableHeaders(&headers),
         })
         .expect("request should serialize")

--- a/crates/enterprise/unleash-edge-context-enrichers/src/pool.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/pool.rs
@@ -68,7 +68,7 @@ impl WorkerPool {
 
     pub(crate) async fn request_enrichment(
         &self,
-        context: Context,
+        context: &Context,
         headers: SerializableHeaders<'_>,
         timeout: Duration,
     ) -> Result<Context, EnricherError> {
@@ -251,7 +251,7 @@ mod tests {
             async move {
                 let headers = header_map(&[("x-test", "true")]);
                 pool.request_enrichment(
-                    Context::default(),
+                    &Context::default(),
                     SerializableHeaders(&headers),
                     Duration::from_secs(1),
                 )
@@ -304,7 +304,7 @@ mod tests {
 
         let error = pool
             .request_enrichment(
-                Context::default(),
+                &Context::default(),
                 SerializableHeaders(&headers),
                 Duration::from_millis(20),
             )
@@ -335,7 +335,7 @@ mod tests {
             async move {
                 let headers = empty_headers();
                 pool.request_enrichment(
-                    Context::default(),
+                    &Context::default(),
                     SerializableHeaders(&headers),
                     Duration::from_millis(50),
                 )
@@ -390,7 +390,7 @@ mod tests {
             async move {
                 let headers = empty_headers();
                 pool.request_enrichment(
-                    Context::default(),
+                    &Context::default(),
                     SerializableHeaders(&headers),
                     Duration::from_secs(1),
                 )

--- a/crates/enterprise/unleash-edge-context-enrichers/src/protocol.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/protocol.rs
@@ -6,7 +6,7 @@ use crate::serializable_header::SerializableHeaders;
 #[derive(Serialize)]
 pub(crate) struct EnrichmentRequest<'a> {
     pub(crate) id: u64,
-    pub(crate) context: Context,
+    pub(crate) context: &'a Context,
     pub(crate) headers: SerializableHeaders<'a>,
 }
 

--- a/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/worker.rs
@@ -81,7 +81,7 @@ impl NodeWorkerController {
 
     pub async fn request_enrichment(
         &self,
-        context: Context,
+        context: &Context,
         headers: SerializableHeaders<'_>,
         job_timeout: Duration,
     ) -> Result<Context, EnricherError> {
@@ -148,7 +148,7 @@ mod tests {
 
         let error = worker
             .request_enrichment(
-                Context::default(),
+                &Context::default(),
                 SerializableHeaders(&headers),
                 Duration::from_millis(20),
             )

--- a/crates/oss/unleash-edge-appstate/src/context_enricher.rs
+++ b/crates/oss/unleash-edge-appstate/src/context_enricher.rs
@@ -15,8 +15,13 @@ mod disabled {
             Self
         }
 
-        pub async fn try_enrich(&self, context: Context, _: &HeaderMap, _: Duration) -> Context {
-            context
+        pub async fn try_enrich(
+            &self,
+            _context: &Context,
+            _: &HeaderMap,
+            _: Duration,
+        ) -> Option<Context> {
+            None
         }
     }
 }

--- a/crates/oss/unleash-edge-frontend-api/src/frontend.rs
+++ b/crates/oss/unleash-edge-frontend-api/src/frontend.rs
@@ -46,7 +46,9 @@ pub async fn frontend_get_all_features(
     headers: HeaderMap,
     QsQueryCfg(context): QsQueryCfg<Context>,
 ) -> EdgeJsonResult<FrontendResult> {
-    let context = try_enrich(&app_state, context, &headers).await;
+    let context = try_enrich(&app_state, &context, &headers)
+        .await
+        .unwrap_or(context);
     all_features(app_state, edge_token, &context, client_ip)
 }
 
@@ -71,7 +73,9 @@ pub async fn frontend_post_all_features(
     headers: HeaderMap,
     Json(context): Json<Context>,
 ) -> EdgeJsonResult<FrontendResult> {
-    let context = try_enrich(&app_state, context, &headers).await;
+    let context = try_enrich(&app_state, &context, &headers)
+        .await
+        .unwrap_or(context);
     all_features(app_state, edge_token, &context, client_ip)
 }
 
@@ -96,7 +100,10 @@ pub async fn frontend_get_enabled_features(
     headers: HeaderMap,
     QsQueryCfg(context): QsQueryCfg<Context>,
 ) -> EdgeJsonResult<FrontendResult> {
-    let context = try_enrich(&app_state, context, &headers).await;
+    let context = try_enrich(&app_state, &context, &headers)
+        .await
+        .unwrap_or(context);
+
     enabled_features(app_state, edge_token, &context, client_ip)
 }
 
@@ -121,7 +128,9 @@ pub async fn frontend_post_enabled_features(
     headers: HeaderMap,
     Json(context): Json<Context>,
 ) -> EdgeJsonResult<FrontendResult> {
-    let context = try_enrich(&app_state, context, &headers).await;
+    let context = try_enrich(&app_state, &context, &headers)
+        .await
+        .unwrap_or(context);
     enabled_features(app_state, edge_token, &context, client_ip)
 }
 
@@ -212,7 +221,9 @@ pub async fn frontend_get_feature(
     ClientIp(client_ip): ClientIp,
     headers: HeaderMap,
 ) -> EdgeJsonResult<EvaluatedToggle> {
-    let context = try_enrich(&app_state, context, &headers).await;
+    let context = try_enrich(&app_state, &context, &headers)
+        .await
+        .unwrap_or(context);
     evaluate_feature(
         &app_state.token_cache,
         &app_state.engine_cache,
@@ -250,7 +261,9 @@ pub async fn frontend_post_feature(
     headers: HeaderMap,
     Json(context): Json<Context>,
 ) -> EdgeJsonResult<EvaluatedToggle> {
-    let context = try_enrich(&app_state, context, &headers).await;
+    let context = try_enrich(&app_state, &context, &headers)
+        .await
+        .unwrap_or(context);
     evaluate_feature(
         &app_state.token_cache,
         &app_state.engine_cache,
@@ -262,7 +275,11 @@ pub async fn frontend_post_feature(
     .map(Json)
 }
 
-async fn try_enrich(app_state: &FrontendState, context: Context, headers: &HeaderMap) -> Context {
+async fn try_enrich(
+    app_state: &FrontendState,
+    context: &Context,
+    headers: &HeaderMap,
+) -> Option<Context> {
     app_state
         .context_enricher
         .try_enrich(context, headers, CONTEXT_ENRICHER_TIMEOUT)


### PR DESCRIPTION
Stops cloning the Context during the context enricher flow unless we actually have to. Partially helpful for making the context enricher flow lighter, but also important for making sure it has no impact when its disabled'

This one's pretty boring - just standard Rust pass a borrow flow 