### PR TITLE
feat: expose context enrichers to public API

### DIFF
--- a/crates/enterprise/unleash-edge-enterprise-integration-tests/src/lib.rs
+++ b/crates/enterprise/unleash-edge-enterprise-integration-tests/src/lib.rs
@@ -16,7 +16,7 @@ mod tests {
     use tokio::sync::RwLock;
     use ulid::Ulid;
     use unleash_edge::edge_builder::{
-        EdgeStateArgs, PersistenceArgs, build_edge_state, resolve_license,
+        ContextEnricherConfig, EdgeStateArgs, PersistenceArgs, build_edge_state, resolve_license,
     };
     use unleash_edge_cli::OtelExporterProtocol::Grpc;
     use unleash_edge_cli::{AuthHeaders, EdgeArgs, LogFormat};
@@ -216,6 +216,7 @@ mod tests {
             prometheus_password: None,
             hostname: None,
             ec2_instance_id: None,
+            context_enricher: ContextEnricherConfig::Disabled,
         })
         .await;
 
@@ -269,6 +270,7 @@ mod tests {
             prometheus_password: None,
             hostname: None,
             ec2_instance_id: None,
+            context_enricher: ContextEnricherConfig::Disabled,
         })
         .await;
 

--- a/crates/oss/unleash-edge-cli/src/lib.rs
+++ b/crates/oss/unleash-edge-cli/src/lib.rs
@@ -7,6 +7,8 @@ use ipnet::IpNet;
 use reqwest::Client;
 use std::fmt::{Display, Formatter};
 use std::net::IpAddr;
+#[cfg(feature = "enterprise")]
+use std::num::NonZeroU32;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
@@ -265,8 +267,22 @@ pub struct EdgeArgs {
     #[clap(long, env, hide = true)]
     pub ec2_instance_id: Option<String>,
 
+    #[cfg(feature = "enterprise")]
+    #[clap(flatten)]
+    pub context_enricher: ContextEnricherArgs,
+
     #[clap(flatten)]
     pub hmac_config: HmacConfig,
+}
+
+#[cfg(feature = "enterprise")]
+#[derive(Args, Debug, Clone, Default)]
+pub struct ContextEnricherArgs {
+    #[clap(long, env, hide = true)]
+    pub context_enricher_script: Option<PathBuf>,
+
+    #[clap(long, env, hide = true, requires = "context_enricher_script")]
+    pub context_enricher_workers: Option<NonZeroU32>,
 }
 
 pub fn string_to_header_tuple(s: &str) -> Result<(String, String), String> {
@@ -789,7 +805,7 @@ impl HttpServerArgs {
 mod tests {
     use super::{CliArgs, EdgeMode, NetworkAddr};
     use axum::http;
-    use clap::Parser;
+    use clap::{CommandFactory, Parser};
     use ipnet::IpNet;
     use std::net::IpAddr;
     use std::str::FromStr;
@@ -1316,6 +1332,66 @@ mod tests {
         ];
         let args = CliArgs::try_parse_from(args);
         assert!(args.is_ok());
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    pub fn can_parse_hidden_context_enricher_args() {
+        let args = vec![
+            "unleash-edge",
+            "edge",
+            "-u",
+            "http://localhost:4242",
+            "--context-enricher-script",
+            "/tmp/enricher.js",
+            "--context-enricher-workers",
+            "2",
+        ];
+        let args = CliArgs::parse_from(args);
+        match args.mode {
+            EdgeMode::Edge(args) => {
+                assert_eq!(
+                    args.context_enricher.context_enricher_script.as_deref(),
+                    Some(std::path::Path::new("/tmp/enricher.js"))
+                );
+                assert_eq!(
+                    args.context_enricher
+                        .context_enricher_workers
+                        .map(|count| count.get()),
+                    Some(2)
+                );
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    pub fn context_enricher_args_are_hidden_from_help() {
+        let mut command = CliArgs::command();
+        let help = command
+            .find_subcommand_mut("edge")
+            .expect("edge subcommand should exist")
+            .render_long_help()
+            .to_string();
+
+        assert!(!help.contains("context-enricher-script"));
+        assert!(!help.contains("context-enricher-workers"));
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    pub fn context_enricher_workers_requires_context_enricher_script() {
+        let args = vec![
+            "unleash-edge",
+            "edge",
+            "-u",
+            "http://localhost:4242",
+            "--context-enricher-workers",
+            "2",
+        ];
+
+        assert!(CliArgs::try_parse_from(args).is_err());
     }
 
     #[test]

--- a/crates/oss/unleash-edge-types/src/errors.rs
+++ b/crates/oss/unleash-edge-types/src/errors.rs
@@ -92,6 +92,7 @@ pub enum EdgeError {
     ClientFeaturesFetchError(FeatureError),
     ClientFeaturesParseError(String),
     ClientHydrationFailed(String),
+    ContextEnricherError(String),
     ClientRegisterError,
     ContextParseError,
     EdgeMetricsError(String),
@@ -211,6 +212,9 @@ impl Display for EdgeError {
                     "Client hydration failed. Somehow we said [{message}] when it did"
                 )
             }
+            EdgeError::ContextEnricherError(message) => {
+                write!(f, "Failed to start context enricher: {message}")
+            }
             EdgeError::ClientCacheError => {
                 write!(f, "Fetching client features from cache failed")
             }
@@ -269,6 +273,7 @@ impl IntoResponse for EdgeError {
             EdgeError::ClientFeaturesFetchError(_) => Response::builder().status(self.status_code()).body(Body::empty()),
             EdgeError::ClientFeaturesParseError(_) => Response::builder().status(self.status_code()).body(Body::empty()),
             EdgeError::ClientHydrationFailed(_) => Response::builder().status(self.status_code()).body(Body::empty()),
+            EdgeError::ContextEnricherError(_) => Response::builder().status(self.status_code()).body(Body::empty()),
             EdgeError::ClientRegisterError => Response::builder().status(self.status_code()).body(Body::empty()),
             EdgeError::ContextParseError => Response::builder().status(self.status_code()).body(Body::empty()),
             EdgeError::EdgeMetricsError(_) => Response::builder().status(self.status_code()).body(Body::empty()),
@@ -348,6 +353,7 @@ impl EdgeError {
             EdgeError::HeartbeatError(_, status_code) => *status_code,
             EdgeError::ReadyCheckError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             EdgeError::ClientHydrationFailed(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            EdgeError::ContextEnricherError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             EdgeError::ClientCacheError => StatusCode::INTERNAL_SERVER_ERROR,
             EdgeError::NotReady => StatusCode::SERVICE_UNAVAILABLE,
             EdgeError::InvalidToken => StatusCode::FORBIDDEN,

--- a/crates/oss/unleash-edge/src/edge_builder.rs
+++ b/crates/oss/unleash-edge/src/edge_builder.rs
@@ -5,6 +5,8 @@ use http::StatusCode;
 use ipnet::IpNet;
 #[cfg(feature = "enterprise")]
 use std::collections::{HashMap, HashSet};
+#[cfg(feature = "enterprise")]
+use std::num::NonZeroU32;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -422,6 +424,39 @@ pub struct EdgeStateArgs {
     pub prometheus_password: Option<String>,
     pub hostname: Option<String>,
     pub ec2_instance_id: Option<String>,
+    pub context_enricher: ContextEnricherConfig,
+}
+
+#[derive(Debug, Clone, Default)]
+pub enum ContextEnricherConfig {
+    #[default]
+    Disabled,
+    #[cfg(feature = "enterprise")]
+    Enabled {
+        script_path: PathBuf,
+        worker_count: NonZeroU32,
+    },
+}
+
+impl From<&EdgeArgs> for ContextEnricherConfig {
+    fn from(edge_args: &EdgeArgs) -> Self {
+        #[cfg(feature = "enterprise")]
+        {
+            if let Some(script_path) = edge_args.context_enricher.context_enricher_script.clone() {
+                return Self::Enabled {
+                    script_path,
+                    worker_count: edge_args
+                        .context_enricher
+                        .context_enricher_workers
+                        .unwrap_or_else(|| NonZeroU32::new(1).unwrap()),
+                };
+            }
+        }
+
+        #[cfg(not(feature = "enterprise"))]
+        let _ = edge_args;
+        Self::Disabled
+    }
 }
 
 impl From<&EdgeStateArgs> for TracingOpts {
@@ -519,6 +554,7 @@ pub async fn build_edge_state(
         args.http_client,
     )?);
     let metrics_cache = Arc::new(MetricsCache::default());
+    let context_enricher = build_context_enricher(args.context_enricher).await?;
 
     let background_tasks = create_edge_mode_background_tasks(BackgroundTaskArgs {
         app_name: args.client_meta_information.app_name.clone(),
@@ -578,7 +614,7 @@ pub async fn build_edge_state(
         allow_list: args.http_allow_list.unwrap_or_default(),
         trust_proxy: args.trust_proxy,
         proxy_trusted_servers: args.proxy_trusted_servers,
-        context_enricher: ContextEnricher::disabled(),
+        context_enricher,
         auth_headers: args.auth_headers.clone(),
         connect_via: ConnectVia {
             app_name: args.client_meta_information.app_name.clone(),
@@ -588,6 +624,21 @@ pub async fn build_edge_state(
     };
 
     Ok((app_state, background_tasks, shutdown_tasks))
+}
+
+async fn build_context_enricher(
+    config: ContextEnricherConfig,
+) -> Result<ContextEnricher, EdgeError> {
+    match config {
+        ContextEnricherConfig::Disabled => Ok(ContextEnricher::disabled()),
+        #[cfg(feature = "enterprise")]
+        ContextEnricherConfig::Enabled {
+            script_path,
+            worker_count,
+        } => ContextEnricher::start(worker_count, script_path)
+            .await
+            .map_err(|error| EdgeError::ContextEnricherError(error.to_string())),
+    }
 }
 
 pub(crate) struct ShutdownTaskArgs {
@@ -602,6 +653,7 @@ pub(crate) struct ShutdownTaskArgs {
     edge_instance_data: Arc<EdgeInstanceData>,
     instances_observed_for_app_context: Arc<RwLock<Vec<EdgeInstanceData>>>,
 }
+
 fn create_shutdown_tasks(
     ShutdownTaskArgs {
         persistence,
@@ -1075,6 +1127,7 @@ mod enterprise_tests {
             hmac_config: HmacConfig::default(),
             hostname: None,
             ec2_instance_id: None,
+            context_enricher: Default::default(),
         };
         let client_meta_information = ClientMetaInformation {
             app_name: "test_app".to_string(),

--- a/crates/oss/unleash-edge/src/lib.rs
+++ b/crates/oss/unleash-edge/src/lib.rs
@@ -197,6 +197,7 @@ pub async fn configure_server(args: CliArgs) -> EdgeResult<(Router, Vec<Backgrou
                 prometheus_password: edge_args.prometheus_password.clone(),
                 hostname: edge_args.hostname.clone(),
                 ec2_instance_id: edge_args.ec2_instance_id.clone(),
+                context_enricher: edge_args.into(),
             })
             .await?
         }


### PR DESCRIPTION
Allows context enrichers to be configured at startup so they're technically usable at this point. However I've turned off their visibility from the help text so the only way anyone knows they're here is reading the source. Standard flow for dark releases in Edge really

There's a little more cfg feature gating than I would like here, however, this allows us to make sure downstream code never has to think about the differences between enterprise + context enrichers, enterprise - context enrichers and oss. And it's also impossible to get wrong because the invalid state simply doesn't exist at compile time (thank you rustc, I do appreciate you) 