### PR TITLE
chore: update histogram for a little more granularity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5748,6 +5748,7 @@ name = "unleash-edge-context-enrichers"
 version = "20.5.0"
 dependencies = [
  "http 1.5.0",
+ "prometheus",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/enterprise/unleash-edge-context-enrichers/Cargo.toml
+++ b/crates/enterprise/unleash-edge-context-enrichers/Cargo.toml
@@ -10,6 +10,7 @@ license-file = "../../../LICENSE-ENTERPRISE.md"
 
 [dependencies]
 http = { workspace = true }
+prometheus = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "process", "sync", "time"] }

--- a/crates/enterprise/unleash-edge-context-enrichers/src/context_enricher.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/context_enricher.rs
@@ -1,9 +1,18 @@
 use http::HeaderMap;
-use std::{num::NonZeroU32, path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    num::NonZeroU32,
+    path::PathBuf,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 use tracing::{info, warn};
 use unleash_types::client_features::Context;
 
-use crate::{EnricherError, WorkerPool, serializable_header::SerializableHeaders};
+use crate::{
+    EnricherError, WorkerPool,
+    metrics::{record_enrichment, record_error, record_timeout},
+    serializable_header::SerializableHeaders,
+};
 
 #[derive(Clone)]
 pub struct ContextEnricher {
@@ -33,20 +42,26 @@ impl ContextEnricher {
         timeout: Duration,
     ) -> Option<Context> {
         let worker_pool = self.worker_pool.as_ref()?;
+        let start = Instant::now();
 
         match worker_pool
             .request_enrichment(context, SerializableHeaders(headers), timeout)
             .await
         {
-            Ok(enriched_context) => Some(enriched_context),
+            Ok(enriched_context) => {
+                record_enrichment(start.elapsed());
+                Some(enriched_context)
+            }
             Err(error) => {
                 match error {
                     EnricherError::Timeout(message) => {
+                        record_timeout(start.elapsed());
                         info!(
                             "Context enrichment timed out, falling back to original context: {message}"
                         );
                     }
                     _ => {
+                        record_error(start.elapsed());
                         warn!(
                             "Failed to enrich frontend context, falling back to original context: {error}"
                         );

--- a/crates/enterprise/unleash-edge-context-enrichers/src/lib.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/lib.rs
@@ -2,6 +2,7 @@ mod child;
 mod command;
 mod context_enricher;
 mod driver;
+mod metrics;
 mod pool;
 mod protocol;
 mod serializable_header;

--- a/crates/enterprise/unleash-edge-context-enrichers/src/metrics.rs
+++ b/crates/enterprise/unleash-edge-context-enrichers/src/metrics.rs
@@ -1,0 +1,55 @@
+use std::sync::LazyLock;
+use std::time::Duration;
+
+use prometheus::{Histogram, IntCounter, register_histogram, register_int_counter};
+
+pub(crate) static CONTEXT_ENRICHER_REQUESTS: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "context_enricher_requests_total",
+        "Total number of context enrichment requests"
+    )
+    .unwrap()
+});
+
+pub(crate) static CONTEXT_ENRICHER_ERRORS: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "context_enricher_errors_total",
+        "Total number of failed context enrichment requests"
+    )
+    .unwrap()
+});
+
+pub(crate) static CONTEXT_ENRICHER_TIMEOUTS: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "context_enricher_timeouts_total",
+        "Total number of context enrichment requests that timed out"
+    )
+    .unwrap()
+});
+
+pub(crate) static CONTEXT_ENRICHER_DURATION_MILLISECONDS: LazyLock<Histogram> =
+    LazyLock::new(|| {
+        register_histogram!(
+            "context_enricher_duration_milliseconds",
+            "Context enrichment request duration in milliseconds",
+            vec![0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 75.0, 100.0,]
+        )
+        .unwrap()
+    });
+
+pub(crate) fn record_enrichment(duration: Duration) {
+    CONTEXT_ENRICHER_REQUESTS.inc();
+    CONTEXT_ENRICHER_DURATION_MILLISECONDS.observe(duration.as_secs_f64() * 1000.0);
+}
+
+pub(crate) fn record_timeout(duration: Duration) {
+    CONTEXT_ENRICHER_REQUESTS.inc();
+    CONTEXT_ENRICHER_TIMEOUTS.inc();
+    CONTEXT_ENRICHER_DURATION_MILLISECONDS.observe(duration.as_secs_f64() * 1000.0);
+}
+
+pub(crate) fn record_error(duration: Duration) {
+    CONTEXT_ENRICHER_REQUESTS.inc();
+    CONTEXT_ENRICHER_ERRORS.inc();
+    CONTEXT_ENRICHER_DURATION_MILLISECONDS.observe(duration.as_secs_f64() * 1000.0);
+}


### PR DESCRIPTION
Just some prom metrics for context enrichers. The idea here is that we gather the request time, errors, timeouts and total number of requests so we can show that back to the user later - "why is Edge running slow?" -> "this one's on you, buddy"